### PR TITLE
feat: 楽曲詳細ページに楽曲カバー画像を表示

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -46,5 +46,6 @@ export const RARITY_BADGE_CLASSES: Record<string, string> = {
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 export const CARD_IMAGE_BASE_URL = `${BASE}/assets/cards`;
 export const CARD_THUMB_BASE_URL = `${BASE}/assets/th_cards`;
+export const SONG_IMAGE_BASE_URL = `${BASE}/assets/songs`;
 
 export const PAGE_SIZE = 100;

--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
+import { SONG_IMAGE_BASE_URL } from '../../lib/constants';
 import { attrDonutSvg } from '../../lib/donutChart';
 
 export async function getStaticPaths() {
@@ -61,21 +62,30 @@ const infoRows = [
 
   <!-- 基本情報 -->
   <div class="bg-white rounded-lg shadow p-6 mb-6">
-    <h1 class="text-2xl font-bold mb-1">{song.song_name}</h1>
-    <p class="text-gray-500 mb-4">{song.artist} / {song.category}</p>
-    {song.stars && (
-      <p class="text-amber-400 text-lg mb-4">{'★'.repeat(song.stars)}{'☆'.repeat(Math.max(0, 5 - song.stars))}</p>
-    )}
-    <table class="w-full text-sm">
-      <tbody class="divide-y divide-gray-100">
-        {infoRows.map(row => (
-          <tr>
-            <td class="py-2 pr-4 font-medium text-gray-500 w-1/3">{row.label}</td>
-            <td class="py-2">{row.value}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="md:col-span-1">
+        <img src={`${SONG_IMAGE_BASE_URL}/${song.id}.png`} alt={song.song_name || ''}
+             class="w-full rounded-lg shadow-md bg-gray-200"
+             onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 200%22><rect width=%22200%22 height=%22200%22 fill=%22%23e5e7eb%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 fill=%22%239ca3af%22 font-size=%2216%22>No Image</text></svg>'" />
+      </div>
+      <div class="md:col-span-2">
+        <h1 class="text-2xl font-bold mb-1">{song.song_name}</h1>
+        <p class="text-gray-500 mb-4">{song.artist} / {song.category}</p>
+        {song.stars && (
+          <p class="text-amber-400 text-lg mb-4">{'★'.repeat(song.stars)}{'☆'.repeat(Math.max(0, 5 - song.stars))}</p>
+        )}
+        <table class="w-full text-sm">
+          <tbody class="divide-y divide-gray-100">
+            {infoRows.map(row => (
+              <tr>
+                <td class="py-2 pr-4 font-medium text-gray-500 w-1/3">{row.label}</td>
+                <td class="py-2">{row.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 
   <!-- 属性比率 -->


### PR DESCRIPTION
## Summary
- 楽曲詳細ページにWikiから取得済みの楽曲カバー画像を表示
- カード詳細と同様のグリッドレイアウト（左: 画像、右: 基本情報）
- `SONG_IMAGE_BASE_URL` 定数を追加、画像未取得時のフォールバック SVG にも対応

## Test plan
- [ ] `/songs/1/` (4-ROAR) で画像が表示されることを確認
- [ ] `/songs/3/` (輪舞) で日本語マッチ曲の画像が表示されることを確認
- [ ] モバイル幅で画像が上、情報が下に並ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)