### PR TITLE
feat: スコア計算ページに共有ブローチ選択機能を追加

### DIFF
--- a/docs/broach_spec.md
+++ b/docs/broach_spec.md
@@ -1,0 +1,143 @@
+# ブローチ仕様書
+
+## 1. 概要
+
+ブローチはカードに装着することでステータスを強化するアイテム。URカードには最大2つのブローチスロットがある。ブローチには「固定ブローチ」と「共有ブローチ」の2種類が存在する。
+
+## 2. ブローチの種類
+
+### 固定ブローチ
+
+カードに紐付いたブローチ。つけ外しはできない。
+
+- データソース: Google Spreadsheet (GID: `1087762308`)
+- フェッチャー: `src/lib/data/fetchFixedBroachsJson.ts`
+- `card_id` でカードと紐付く
+
+### 共有ブローチ
+
+任意のURカードに自由に装着できるブローチ。
+
+- データソース: `src/lib/data/sharedBroachs.ts` にハードコード
+- カードとの紐付きはなく、ユーザーが任意に選択する
+
+## 3. スロットルール
+
+| カードレアリティ | スロット数 | 備考 |
+|----------------|----------|------|
+| UR | 2 | 固定ブローチ + 共有ブローチの組み合わせ |
+| UR以外 | 0 | ブローチ装着不可 |
+
+### 装着パターン
+
+| 固定ブローチ | 共有ブローチ | 合計 |
+|------------|-----------|------|
+| あり | 最大1つ | 2 |
+| なし | 最大2つ | 2 |
+
+- 固定ブローチが存在するカードは、共有ブローチを **1つだけ** セットできる
+- 固定ブローチが存在しないURカードは、共有ブローチを **2つまで** セットできる
+
+## 4. 固定ブローチのデータ構造
+
+```typescript
+interface FixedBroach {
+  id: number | null;          // ブローチID
+  card_id: number | null;     // 紐付くカードID
+  card_name: string | null;   // カード名
+  shout: number | null;       // Shout加算値
+  beat: number | null;        // Beat加算値
+  melody: number | null;      // Melody加算値
+  attribute: string | null;   // 属性条件
+  idol: string | null;        // アイドル条件
+  group: string | null;       // グループ条件
+  auto: number | null;        // オート
+  song: string | null;        // 楽曲条件
+  score: number | null;       // スコア加算値（種類9用）
+  limit: number | null;       // デッキ内発動上限
+  broach_type: number | null; // ブローチの種類（1〜9）
+  condition: string | null;   // 条件テキスト
+}
+```
+
+## 5. 共有ブローチのデータ構造
+
+```typescript
+interface SharedBroach {
+  id: number;
+  name: string;      // 表示名（例: "ALL750", "Shout700"）
+  shout: number;     // Shout加算値
+  beat: number;      // Beat加算値
+  melody: number;    // Melody加算値
+}
+```
+
+### 共有ブローチ一覧
+
+| 名前 | Shout | Beat | Melody |
+|------|-------|------|--------|
+| ALL750 | 750 | 750 | 750 |
+| ALL700 | 700 | 700 | 700 |
+| ALL500 | 500 | 500 | 500 |
+| ALL300 | 300 | 300 | 300 |
+| ALL200 | 200 | 200 | 200 |
+| Shout700 | 700 | 0 | 0 |
+| Shout400 | 400 | 0 | 0 |
+| Beat700 | 0 | 700 | 0 |
+| Beat400 | 0 | 400 | 0 |
+| Melody700 | 0 | 0 | 700 |
+| Melody400 | 0 | 0 | 400 |
+
+## 6. ブローチ種類（broach_type）
+
+固定ブローチには発動条件が異なる複数の種類がある。
+
+| broach_type | 名称 | 発動条件 |
+|-------------|------|---------|
+| 1 | 属性UP | 無条件で発動 |
+| 4 | グループ | デッキ6枚全員が指定グループと同一 |
+| 5 | アイドル属性カウント | デッキ内に同アイドル・同属性のカードが `limit` 枚以上 |
+| 6 | 属性UP（上限付き） | 無条件だがデッキ内の発動数に上限あり |
+| 7 | 全属性 | デッキ内にShout・Beat・Melody全属性が存在 |
+| 8 | オート専用 | 現在のスコア計算では常に無効 |
+| 9 | スコアUP | 指定楽曲をプレイ中のみ発動（ステータスではなくスコアに直接加算） |
+
+### デッキ内発動上限
+
+種類6・7のブローチにはデッキ全体での発動上限（`limit` フィールド）がある。同種のブローチが複数カードに存在する場合、上限を超えた分は無効になる。
+
+## 7. スコア計算への影響
+
+ブローチは2つの経路でスコアに影響する。
+
+### ステータス加算（種類1〜8）
+
+カードの属性値に加算され、チーム属性値の計算に反映される。フレンド枠（スロット5）のカードには適用されない。
+
+```
+broachShoutTotal = Σ スロット0-4の有効ブローチShout値
+broachBeatTotal  = Σ スロット0-4の有効ブローチBeat値
+broachMelodyTotal = Σ スロット0-4の有効ブローチMelody値
+
+teamShout  = floor((rawShout  + broachShoutTotal)  × (100 + shoutRate)  / 100)
+teamBeat   = floor((rawBeat   + broachBeatTotal)   × (100 + beatRate)   / 100)
+teamMelody = floor((rawMelody + broachMelodyTotal) × (100 + melodyRate) / 100)
+```
+
+### スコア直接加算（種類9）
+
+最終スコアに直接加算される。バッジ倍率適用後に加算。
+
+```
+最終スコア = floor(floor(ノーツスコア合計) × バッジ倍率) + broachScoreBonus
+```
+
+## 8. 実装ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `src/lib/data/fetchFixedBroachsJson.ts` | 固定ブローチデータのフェッチ |
+| `src/lib/data/sharedBroachs.ts` | 共有ブローチのマスターデータ |
+| `src/lib/score/broachResolver.ts` | ブローチの条件判定・発動上限処理 |
+| `src/lib/score/engine.ts` | ブローチ値のチーム属性値・スコアへの反映 |
+| `src/lib/score/types.ts` | `DeckCard.broach*`、`ComputedTeam.broach*` 型定義 |

--- a/src/lib/data/sharedBroachs.ts
+++ b/src/lib/data/sharedBroachs.ts
@@ -1,0 +1,21 @@
+export interface SharedBroach {
+  id: number;
+  name: string;
+  shout: number;
+  beat: number;
+  melody: number;
+}
+
+export const SHARED_BROACHS: SharedBroach[] = [
+  { id: 1, name: 'ALL750', shout: 750, beat: 750, melody: 750 },
+  { id: 2, name: 'ALL700', shout: 700, beat: 700, melody: 700 },
+  { id: 3, name: 'ALL500', shout: 500, beat: 500, melody: 500 },
+  { id: 4, name: 'ALL300', shout: 300, beat: 300, melody: 300 },
+  { id: 5, name: 'ALL200', shout: 200, beat: 200, melody: 200 },
+  { id: 6, name: 'Shout700', shout: 700, beat: 0, melody: 0 },
+  { id: 7, name: 'Shout400', shout: 400, beat: 0, melody: 0 },
+  { id: 8, name: 'Beat700', shout: 0, beat: 700, melody: 0 },
+  { id: 9, name: 'Beat400', shout: 0, beat: 400, melody: 0 },
+  { id: 10, name: 'Melody700', shout: 0, beat: 0, melody: 700 },
+  { id: 11, name: 'Melody400', shout: 0, beat: 0, melody: 400 },
+];

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -16,6 +16,7 @@ import type { EventBonusTier } from './constants';
 import { XorShift128Plus } from './rng';
 import { flattenNotes } from './noteFlattener';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
+import { SHARED_BROACHS } from '../data/sharedBroachs';
 
 /** カードからLv5のスキル情報を解析する */
 function parseSkill(card: Card, slotIndex: number): CardSkill | null {
@@ -64,6 +65,7 @@ export function computeTeam(
   bonusTiers?: EventBonusTier[],
   trainedFlags?: boolean[],
   selectedBroachIds?: (number | null)[],
+  sharedBroachSelections?: number[][],
 ): ComputedTeam {
   const cards: DeckCard[] = [];
 
@@ -109,6 +111,19 @@ export function computeTeam(
         bBeat += rb.broach.beat || 0;
         bMelody += rb.broach.melody || 0;
       }
+      // 共有ブローチ加算
+      if (sharedBroachSelections?.[i]) {
+        for (const sbId of sharedBroachSelections[i]) {
+          if (!sbId) continue;
+          const sb = SHARED_BROACHS.find(s => s.id === sbId);
+          if (sb) {
+            bShout += sb.shout;
+            bBeat += sb.beat;
+            bMelody += sb.melody;
+          }
+        }
+      }
+
       broachShoutTotal += bShout;
       broachBeatTotal += bBeat;
       broachMelodyTotal += bMelody;

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -329,6 +329,7 @@ const base = import.meta.env.BASE_URL;
     import { renderHistogramSvg } from '../../lib/score/histogram';
     import { attrDonutSvg } from '../../lib/donutChart';
     import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTRIBUTE_MAP } from '../../lib/constants';
+    import { SHARED_BROACHS } from '../../lib/data/sharedBroachs';
     import { loadCounts } from '../../lib/cardListRenderer';
 
     const thumbUrl = (window as any).__CARD_THUMB_BASE_URL__ || '';
@@ -344,6 +345,7 @@ const base = import.meta.env.BASE_URL;
     let deck: (Card | null)[] = [null, null, null, null, null, null];
     let deckBonusTiers: EventBonusTier[] = ['none', 'none', 'none', 'none', 'none', 'none'];
     let deckTrained: boolean[] = [true, true, true, true, true, true];
+    let deckSharedBroachs: number[][] = [[], [], [], [], [], []];
     let activeModalSlot = -1;
     let simulationResult: SimulationResult | null = null;
 
@@ -357,6 +359,18 @@ const base = import.meta.env.BASE_URL;
       const num = Number(attr);
       if (!isNaN(num) && ATTRIBUTE_MAP[num]) return ATTRIBUTE_MAP[num];
       return attr as string || 'Shout';
+    }
+
+    // --- 共有ブローチバリデーション ---
+    function validateSharedBroachs(slotIndex: number) {
+      const card = deck[slotIndex];
+      if (!card || card.rarity !== 'UR' || slotIndex >= 5) {
+        deckSharedBroachs[slotIndex] = [];
+        return;
+      }
+      const hasFixed = allBroachs.some(br => br.card_id === card.cardID);
+      const maxShared = hasFixed ? 1 : 2;
+      deckSharedBroachs[slotIndex] = deckSharedBroachs[slotIndex].slice(0, maxShared);
     }
 
     // --- 楽曲選択 ---
@@ -478,6 +492,33 @@ const base = import.meta.env.BASE_URL;
           }).join('');
         }
 
+        // 共有ブローチセレクター（URカード、スロット0-4のみ）
+        let sharedBroachHtml = '';
+        if (i < 5 && card.rarity === 'UR') {
+          const hasFixed = cardBroachs.length > 0;
+          const maxShared = hasFixed ? 1 : 2;
+          for (let s = 0; s < maxShared; s++) {
+            const currentVal = deckSharedBroachs[i]?.[s] ?? 0;
+            // 同一スロット内の重複防止: もう一方のスロットで選択中のIDを除外
+            const otherIdx = s === 0 ? 1 : 0;
+            const otherId = maxShared > 1 ? (deckSharedBroachs[i]?.[otherIdx] ?? 0) : 0;
+            const options = SHARED_BROACHS.filter(sb => sb.id !== otherId || sb.id === currentVal).map(sb => {
+              const sel = sb.id === currentVal ? ' selected' : '';
+              const stats: string[] = [];
+              if (sb.shout) stats.push(`S+${sb.shout}`);
+              if (sb.beat) stats.push(`B+${sb.beat}`);
+              if (sb.melody) stats.push(`M+${sb.melody}`);
+              return `<option value="${sb.id}"${sel}>${sb.name} (${stats.join('/')})</option>`;
+            }).join('');
+            sharedBroachHtml += `
+              <select class="shared-broach-select mt-1 w-full text-[8px] border border-purple-300 rounded px-0.5 py-0.5 bg-purple-50 text-purple-700 focus:outline-none focus:ring-1 focus:ring-purple-400"
+                      data-broach-slot="${i}" data-broach-idx="${s}">
+                <option value="0">共有ブローチ${maxShared > 1 ? (s + 1) : ''}を選択</option>
+                ${options}
+              </select>`;
+          }
+        }
+
         container.className = 'slot-content border-2 border-solid rounded-lg p-1.5 flex flex-col items-center cursor-pointer min-h-[120px] transition-colors';
         container.style.borderColor = attrColor;
         container.innerHTML = `
@@ -498,7 +539,7 @@ const base = import.meta.env.BASE_URL;
             <option value="bronze"${currentTier === 'bronze' ? ' selected' : ''}>銅特効</option>
             <option value="silver"${currentTier === 'silver' ? ' selected' : ''}>銀特効</option>
             <option value="gold"${currentTier === 'gold' ? ' selected' : ''}>金特効</option>
-          </select>${broachLabelHtml}`;
+          </select>${broachLabelHtml}${sharedBroachHtml}`;
       }
 
       // 特効セレクターのイベント登録
@@ -526,6 +567,23 @@ const base = import.meta.env.BASE_URL;
           const slot = Number(chk.dataset.trainedSlot);
           deckTrained[slot] = chk.checked;
           renderCardDetailTable();
+          recalculate();
+          saveState();
+        });
+      });
+
+      // 共有ブローチセレクターのイベント登録
+      document.querySelectorAll('.shared-broach-select').forEach(el => {
+        el.addEventListener('click', (e) => e.stopPropagation());
+        el.addEventListener('change', (e) => {
+          const sel = e.target as HTMLSelectElement;
+          const slot = Number(sel.dataset.broachSlot);
+          const idx = Number(sel.dataset.broachIdx);
+          const val = Number(sel.value);
+          if (!deckSharedBroachs[slot]) deckSharedBroachs[slot] = [];
+          while (deckSharedBroachs[slot].length <= idx) deckSharedBroachs[slot].push(0);
+          deckSharedBroachs[slot][idx] = val;
+          renderDeckSlots();
           recalculate();
           saveState();
         });
@@ -580,9 +638,17 @@ const base = import.meta.env.BASE_URL;
         const attr = normalizeAttr(card.attribute);
         const slotBroachs = resolvedMap.get(i) ?? [];
         const activeBroachs = slotBroachs.filter(rb => rb.active && rb.broach.broach_type !== 9);
-        const bS = activeBroachs.reduce((s, rb) => s + (rb.broach.shout || 0), 0);
-        const bB = activeBroachs.reduce((s, rb) => s + (rb.broach.beat || 0), 0);
-        const bM = activeBroachs.reduce((s, rb) => s + (rb.broach.melody || 0), 0);
+        let bS = activeBroachs.reduce((s, rb) => s + (rb.broach.shout || 0), 0);
+        let bB = activeBroachs.reduce((s, rb) => s + (rb.broach.beat || 0), 0);
+        let bM = activeBroachs.reduce((s, rb) => s + (rb.broach.melody || 0), 0);
+        // 共有ブローチのステータスも加算
+        if (i < 5 && card.rarity === 'UR') {
+          for (const sbId of (deckSharedBroachs[i] || [])) {
+            if (!sbId) continue;
+            const sb = SHARED_BROACHS.find(s => s.id === sbId);
+            if (sb) { bS += sb.shout; bB += sb.beat; bM += sb.melody; }
+          }
+        }
         const hasInactive = slotBroachs.some(rb => !rb.active);
         const broachClass = hasInactive ? 'text-gray-300' : '';
         const skillType = card.ap_skill_type || '-';
@@ -710,6 +776,7 @@ const base = import.meta.env.BASE_URL;
           const card = allCards.find(c => c.ID === cardId);
           if (card && activeModalSlot >= 0) {
             deck[activeModalSlot] = card;
+            validateSharedBroachs(activeModalSlot);
             closeCardPicker();
             renderDeckSlots();
             recalculate();
@@ -733,7 +800,7 @@ const base = import.meta.env.BASE_URL;
         return;
       }
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs);
       const notes = flattenNotes(selectedSong, 42);
 
       // スコア内訳表示
@@ -829,7 +896,7 @@ const base = import.meta.env.BASE_URL;
       btn.textContent = '計算中...';
       $('progress-container').classList.remove('hidden');
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs);
       const notes = flattenNotes(selectedSong, 42);
 
       // スキルオプションの適用
@@ -929,6 +996,7 @@ const base = import.meta.env.BASE_URL;
         deckIds: deck.map(c => c?.ID ?? null),
         bonusTiers: deckBonusTiers,
         trained: deckTrained,
+        sharedBroachs: deckSharedBroachs,
       };
       try { localStorage.setItem('i7_score_calc_state', JSON.stringify(state)); } catch {}
     }
@@ -956,12 +1024,21 @@ const base = import.meta.env.BASE_URL;
             deckTrained[i] = state.trained[i] !== false;
           }
         }
+        if (Array.isArray(state.sharedBroachs)) {
+          for (let i = 0; i < 6; i++) {
+            deckSharedBroachs[i] = Array.isArray(state.sharedBroachs[i]) ? state.sharedBroachs[i] : [];
+          }
+        }
         if (Array.isArray(state.deckIds)) {
           for (let i = 0; i < 6; i++) {
             const id = state.deckIds[i];
             if (id != null) {
               deck[i] = allCards.find(c => c.ID === id) || null;
             }
+          }
+          // デッキ復元後に共有ブローチのバリデーション
+          for (let i = 0; i < 6; i++) {
+            validateSharedBroachs(i);
           }
           renderDeckSlots();
           recalculate();
@@ -990,6 +1067,7 @@ const base = import.meta.env.BASE_URL;
           deck[activeModalSlot] = null;
           deckBonusTiers[activeModalSlot] = 'none';
           deckTrained[activeModalSlot] = true;
+          deckSharedBroachs[activeModalSlot] = [];
           closeCardPicker();
           renderDeckSlots();
           recalculate();


### PR DESCRIPTION
## Summary
- URカードのデッキスロットに共有ブローチを選択できるドロップダウンを追加
- 固定ブローチありのカードは共有1つ、なしのカードは共有2つまで装着可能
- 選択した共有ブローチのステータスがスコア計算・カード詳細テーブルに即時反映
- ブローチ仕様書(`docs/broach_spec.md`)を新規追加

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `docs/broach_spec.md` | ブローチ仕様書（新規） |
| `src/lib/data/sharedBroachs.ts` | 共有ブローチマスターデータ（新規） |
| `src/lib/score/engine.ts` | `computeTeam`に`sharedBroachSelections`パラメータ追加 |
| `src/pages/score-calc/index.astro` | UI描画・状態管理・イベント・保存復元 |

## スクリーンショット

### 固定ブローチありURカード（共有ブローチ1つ選択可能）+ 固定ブローチなしURカード（共有ブローチ2つ選択可能）
![score-calc-broach-complete](https://github.com/user-attachments/assets/score-calc-broach-complete.png)

## Test plan
- [ ] URカード（固定ブローチあり）選択 → 固定ブローチ表示 + 共有ブローチ1つ選択可能
- [ ] URカード（固定ブローチなし）選択 → 共有ブローチ2つ選択可能
- [ ] SSR/SR/Rカード → ブローチUI非表示
- [ ] フレンドスロット → ブローチUI非表示
- [ ] 共有ブローチ選択後にスコア内訳「ブローチ加算」に反映されること
- [ ] カード詳細テーブルのブローチS/B/M列に固定+共有の合算値が表示されること
- [ ] 同一スロット内で同じブローチを重複選択できないこと
- [ ] ページリロード後に選択が復元されること
- [ ] カード入替/クリア時に共有ブローチが適切にリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)