### PR TITLE
feat: スコア計算ページにスキルレベル選択機能を追加

### DIFF
--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -1,4 +1,5 @@
 import type { Card } from '../data/fetchCardsJson';
+import { getApSkillLevel } from '../data/fetchCardsJson';
 import type { FixedBroach } from '../data/fetchFixedBroachsJson';
 import type { Song } from '../data/fetchSongsJson';
 import {
@@ -18,14 +19,15 @@ import { flattenNotes } from './noteFlattener';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
 import { SHARED_BROACHS } from '../data/sharedBroachs';
 
-/** カードからLv5のスキル情報を解析する */
-function parseSkill(card: Card, slotIndex: number): CardSkill | null {
+/** カードからスキル情報を解析する */
+function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5 = 5): CardSkill | null {
   const type = card.ap_skill_type;
   if (!type || type === 'MISS→Good') return null;
 
-  const count = card.ap_skill_5_count;
-  const per = card.ap_skill_5_per;
-  const value = card.ap_skill_5_value;
+  const sl = getApSkillLevel(card, skillLevel);
+  const count = sl.count;
+  const per = sl.per;
+  const value = sl.value;
 
   if (count == null || per == null) return null;
 
@@ -66,6 +68,7 @@ export function computeTeam(
   trainedFlags?: boolean[],
   selectedBroachIds?: (number | null)[],
   sharedBroachSelections?: number[][],
+  skillLevels?: (1 | 2 | 3 | 4 | 5)[],
 ): ComputedTeam {
   const cards: DeckCard[] = [];
 
@@ -139,7 +142,7 @@ export function computeTeam(
       shout_max: s,
       beat_max: b,
       melody_max: m,
-      skill: parseSkill(card, i),
+      skill: parseSkill(card, i, skillLevels?.[i] ?? 5),
       broachShout: bShout,
       broachBeat: bBeat,
       broachMelody: bMelody,

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -318,7 +318,7 @@ const base = import.meta.env.BASE_URL;
   </script>
 
   <script>
-    import type { Card } from '../../lib/data/fetchCardsJson';
+    import { getApSkillLevel, type Card } from '../../lib/data/fetchCardsJson';
     import type { Song } from '../../lib/data/fetchSongsJson';
     import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
     import type { ComputedTeam, SimulationResult, ScoreOptions } from '../../lib/score/types';
@@ -346,6 +346,7 @@ const base = import.meta.env.BASE_URL;
     let deckBonusTiers: EventBonusTier[] = ['none', 'none', 'none', 'none', 'none', 'none'];
     let deckTrained: boolean[] = [true, true, true, true, true, true];
     let deckSharedBroachs: number[][] = [[], [], [], [], [], []];
+    let deckSkillLevels: (1 | 2 | 3 | 4 | 5)[] = [5, 5, 5, 5, 5, 5];
     let activeModalSlot = -1;
     let simulationResult: SimulationResult | null = null;
 
@@ -471,6 +472,7 @@ const base = import.meta.env.BASE_URL;
 
         const currentTier = deckBonusTiers[i];
         const trainedChecked = deckTrained[i];
+        const currentSkillLv = deckSkillLevels[i];
 
         // 固定ブローチ表示（読み取り専用）
         const cardBroachs = (i < 5 && card.rarity === 'UR')
@@ -539,6 +541,9 @@ const base = import.meta.env.BASE_URL;
             <option value="bronze"${currentTier === 'bronze' ? ' selected' : ''}>銅特効</option>
             <option value="silver"${currentTier === 'silver' ? ' selected' : ''}>銀特効</option>
             <option value="gold"${currentTier === 'gold' ? ' selected' : ''}>金特効</option>
+          </select>
+          <select class="skill-level-select mt-1 w-full text-[9px] border border-gray-300 rounded px-0.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-400" data-skill-slot="${i}">
+            ${[1, 2, 3, 4, 5].map(lv => `<option value="${lv}"${currentSkillLv === lv ? ' selected' : ''}>スキルLv${lv}</option>`).join('')}
           </select>${broachLabelHtml}${sharedBroachHtml}`;
       }
 
@@ -566,6 +571,19 @@ const base = import.meta.env.BASE_URL;
           const chk = e.target as HTMLInputElement;
           const slot = Number(chk.dataset.trainedSlot);
           deckTrained[slot] = chk.checked;
+          renderCardDetailTable();
+          recalculate();
+          saveState();
+        });
+      });
+
+      // スキルレベルセレクターのイベント登録
+      document.querySelectorAll('.skill-level-select').forEach(el => {
+        el.addEventListener('click', (e) => e.stopPropagation());
+        el.addEventListener('change', (e) => {
+          const sel = e.target as HTMLSelectElement;
+          const slot = Number(sel.dataset.skillSlot);
+          deckSkillLevels[slot] = Number(sel.value) as 1 | 2 | 3 | 4 | 5;
           renderCardDetailTable();
           recalculate();
           saveState();
@@ -652,9 +670,10 @@ const base = import.meta.env.BASE_URL;
         const hasInactive = slotBroachs.some(rb => !rb.active);
         const broachClass = hasInactive ? 'text-gray-300' : '';
         const skillType = card.ap_skill_type || '-';
-        const count = card.ap_skill_5_count ?? '-';
-        const per = card.ap_skill_5_per != null ? `${card.ap_skill_5_per}%` : '-';
-        const value = card.ap_skill_5_value != null ? card.ap_skill_5_value.toLocaleString() : '-';
+        const sl = getApSkillLevel(card, deckSkillLevels[i]);
+        const count = sl.count ?? '-';
+        const per = sl.per != null ? `${sl.per}%` : '-';
+        const value = sl.value != null ? sl.value.toLocaleString() : '-';
         const tier = deckBonusTiers[i];
         const bonusLabel = BONUS_LABEL[tier];
         const bonusClass = BONUS_CLASS[tier];
@@ -800,7 +819,7 @@ const base = import.meta.env.BASE_URL;
         return;
       }
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels);
       const notes = flattenNotes(selectedSong, 42);
 
       // スコア内訳表示
@@ -896,7 +915,7 @@ const base = import.meta.env.BASE_URL;
       btn.textContent = '計算中...';
       $('progress-container').classList.remove('hidden');
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels);
       const notes = flattenNotes(selectedSong, 42);
 
       // スキルオプションの適用
@@ -997,6 +1016,7 @@ const base = import.meta.env.BASE_URL;
         bonusTiers: deckBonusTiers,
         trained: deckTrained,
         sharedBroachs: deckSharedBroachs,
+        skillLevels: deckSkillLevels,
       };
       try { localStorage.setItem('i7_score_calc_state', JSON.stringify(state)); } catch {}
     }
@@ -1027,6 +1047,12 @@ const base = import.meta.env.BASE_URL;
         if (Array.isArray(state.sharedBroachs)) {
           for (let i = 0; i < 6; i++) {
             deckSharedBroachs[i] = Array.isArray(state.sharedBroachs[i]) ? state.sharedBroachs[i] : [];
+          }
+        }
+        if (Array.isArray(state.skillLevels)) {
+          for (let i = 0; i < 6; i++) {
+            const lv = state.skillLevels[i];
+            deckSkillLevels[i] = (lv >= 1 && lv <= 5) ? lv : 5;
           }
         }
         if (Array.isArray(state.deckIds)) {


### PR DESCRIPTION
## Summary
- スコア計算画面の各デッキスロットにスキルレベル（Lv1〜Lv5）のドロップダウンを追加
- 選択したレベルに応じてカード詳細テーブルの値とスコア計算結果が動的に反映される
- スキルレベルの選択状態はLocalStorageに保存・復元される

## 変更内容
- `engine.ts`: `parseSkill()`にスキルレベル引数を追加、既存の`getApSkillLevel()`ヘルパーを活用
- `index.astro`: スキルレベルセレクターUI・状態管理・データフロー追加

## スクリーンショット
### デフォルト（Lv5）
![default](https://github.com/user-attachments/assets/score-calc-skill-level-default.png)

### メンバー1をLv1に変更後
![changed](https://github.com/user-attachments/assets/score-calc-skill-level-changed.png)

## Test plan
- [ ] カードを選択後、スキルレベルセレクター（Lv1〜Lv5）が表示される
- [ ] スキルレベル変更でカード詳細テーブルのカウント・確率・スコアアップ値が変わる
- [ ] スキルレベル変更でスコア計算結果（期待最高値・MC結果）が変わる
- [ ] ページリロード後にスキルレベルの選択が復元される
- [ ] デフォルトはLv5で、既存の動作と後方互換性がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)