### PR TITLE
feat: フレンドカードにブローチ選択機能を追加

### DIFF
--- a/src/lib/score/broachResolver.ts
+++ b/src/lib/score/broachResolver.ts
@@ -94,7 +94,7 @@ function checkBroachCondition(
 /**
  * デッキ全体のブローチを条件判定して返す。
  * デッキ内発動上限（種類6/7）も処理する。
- * @returns key = slotIndex (0-4), value = ResolvedBroach[]
+ * @returns key = slotIndex (0-5), value = ResolvedBroach[]
  */
 export function resolveDeckBroachs(
   deck: (Card | null)[],
@@ -116,7 +116,7 @@ export function resolveDeckBroachs(
   }
   const pending: PendingBroach[] = [];
 
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 6; i++) {
     const card = deck[i];
     if (!card || card.rarity !== 'UR') continue;
 

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -102,35 +102,33 @@ export function computeTeam(
     rawBeat += b;
     rawMelody += m;
 
-    // ブローチ加算（スロット0-4のみ、条件判定済み）
+    // ブローチ加算（条件判定済み）
     let bShout = 0, bBeat = 0, bMelody = 0;
-    if (i < 5) {
-      const slotBroachs = resolvedBroachs.get(i) ?? [];
-      for (const rb of slotBroachs) {
-        if (!rb.active) continue;
-        // 種類9（スコアUP）はステータスではなくスコア直接加算なのでここではスキップ
-        if (rb.broach.broach_type === 9) continue;
-        bShout += rb.broach.shout || 0;
-        bBeat += rb.broach.beat || 0;
-        bMelody += rb.broach.melody || 0;
-      }
-      // 共有ブローチ加算
-      if (sharedBroachSelections?.[i]) {
-        for (const sbId of sharedBroachSelections[i]) {
-          if (!sbId) continue;
-          const sb = SHARED_BROACHS.find(s => s.id === sbId);
-          if (sb) {
-            bShout += sb.shout;
-            bBeat += sb.beat;
-            bMelody += sb.melody;
-          }
+    const slotBroachs = resolvedBroachs.get(i) ?? [];
+    for (const rb of slotBroachs) {
+      if (!rb.active) continue;
+      // 種類9（スコアUP）はステータスではなくスコア直接加算なのでここではスキップ
+      if (rb.broach.broach_type === 9) continue;
+      bShout += rb.broach.shout || 0;
+      bBeat += rb.broach.beat || 0;
+      bMelody += rb.broach.melody || 0;
+    }
+    // 共有ブローチ加算
+    if (sharedBroachSelections?.[i]) {
+      for (const sbId of sharedBroachSelections[i]) {
+        if (!sbId) continue;
+        const sb = SHARED_BROACHS.find(s => s.id === sbId);
+        if (sb) {
+          bShout += sb.shout;
+          bBeat += sb.beat;
+          bMelody += sb.melody;
         }
       }
-
-      broachShoutTotal += bShout;
-      broachBeatTotal += bBeat;
-      broachMelodyTotal += bMelody;
     }
+
+    broachShoutTotal += bShout;
+    broachBeatTotal += bBeat;
+    broachMelodyTotal += bMelody;
 
     cards.push({
       cardId: card.ID || 0,

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -372,7 +372,7 @@ const base = import.meta.env.BASE_URL;
     // --- 共有ブローチバリデーション ---
     function validateSharedBroachs(slotIndex: number) {
       const card = deck[slotIndex];
-      if (!card || card.rarity !== 'UR' || slotIndex >= 5) {
+      if (!card || card.rarity !== 'UR') {
         deckSharedBroachs[slotIndex] = [];
         return;
       }
@@ -482,7 +482,7 @@ const base = import.meta.env.BASE_URL;
         const currentSkillLv = deckSkillLevels[i];
 
         // 固定ブローチ表示（読み取り専用）
-        const cardBroachs = (i < 5 && card.rarity === 'UR')
+        const cardBroachs = card.rarity === 'UR'
           ? allBroachs.filter(br => br.card_id === card.cardID)
           : [];
         let broachLabelHtml = '';
@@ -501,9 +501,9 @@ const base = import.meta.env.BASE_URL;
           }).join('');
         }
 
-        // 共有ブローチセレクター（URカード、スロット0-4のみ）
+        // 共有ブローチセレクター（URカード）
         let sharedBroachHtml = '';
-        if (i < 5 && card.rarity === 'UR') {
+        if (card.rarity === 'UR') {
           const hasFixed = cardBroachs.length > 0;
           const maxShared = hasFixed ? 1 : 2;
           for (let s = 0; s < maxShared; s++) {


### PR DESCRIPTION
## Summary
- フレンドスロット（スロット5）で固定ブローチの表示と共有ブローチの選択ができるようにした
- 他のメンバースロットと同じ挙動（固定ブローチありなら共有1枠、なしなら共有2枠）
- ブローチリゾルバー・スコア計算エンジンもスロット5を含むよう修正

## Test plan
- [ ] フレンドにURカードを設定し、固定ブローチラベルが表示されることを確認
- [ ] フレンドのURカードで共有ブローチのドロップダウンが表示・選択できることを確認
- [ ] 固定ブローチありの場合は共有ブローチ1枠、なしの場合は2枠であることを確認
- [ ] ブローチ選択がスコア計算結果に反映されることを確認
- [ ] メンバー1-4のブローチ選択が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)