### PR TITLE
feat: 曲一覧に選択チェックボックスを追加しスコア計算の曲選択と連携

### DIFF
--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -45,6 +45,8 @@ const base = import.meta.env.BASE_URL;
           <option value="notes-asc">ノーツ数（少ない順）</option>
           <option value="stars-desc">難易度（高い順）</option>
           <option value="stars-asc">難易度（低い順）</option>
+          <option value="duration-desc">秒数（長い順）</option>
+          <option value="duration-asc">秒数（短い順）</option>
         </select>
       </div>
     </div>
@@ -221,6 +223,12 @@ const base = import.meta.env.BASE_URL;
           break;
         case 'stars-asc':
           filtered.sort((a, b) => (a.stars || 0) - (b.stars || 0));
+          break;
+        case 'duration-desc':
+          filtered.sort((a, b) => (b.duration || 0) - (a.duration || 0));
+          break;
+        case 'duration-asc':
+          filtered.sort((a, b) => (a.duration || 0) - (b.duration || 0));
           break;
       }
 


### PR DESCRIPTION
## Summary
- 曲一覧ページのテーブル左端に曲選択チェックボックスを追加（デスクトップ/モバイル対応）
- ヘッダーの全選択/解除チェックボックス、選択数の表示、秒数ソートオプションも追加
- スコア計算ページの曲セレクトで、曲一覧で選択した曲が「選択中の曲（N曲・秒数順）」として先頭に表示される
- 選択状態は `localStorage`（`i7_selected_songs`）で永続化し、ページ間で共有

## Test plan
- [ ] 曲一覧ページでチェックボックスが各行の左端に表示される
- [ ] チェックボックスのクリックで曲詳細ページに遷移しない
- [ ] 全選択チェックボックスで表示中の曲を一括選択/解除できる
- [ ] 選択数が「N曲を選択中」として表示される
- [ ] モバイル表示でもチェックボックスが正しく表示される
- [ ] スコア計算ページの曲セレクトで選択曲が秒数順で先頭に表示される
- [ ] ブラウザリロード後も選択状態が維持される
- [ ] 秒数ソート（長い順/短い順）が正しく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)