### PR TITLE
fix: スコア計算デッキの同一カード重複選択・共有ブローチ改善

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -756,13 +756,7 @@ const base = import.meta.env.BASE_URL;
       const ownedOnly = ($('modal-owned-only') as HTMLInputElement).checked;
       const counts = loadCounts();
 
-      // デッキに既に入っているカードIDを除外
-      const usedIds = new Set(deck.filter(c => c !== null).map(c => c!.ID));
-      // 現在編集中のスロットのカードは除外しない
-      if (deck[activeModalSlot]) usedIds.delete(deck[activeModalSlot]!.ID);
-
       let filtered = allCards.filter(card => {
-        if (usedIds.has(card.ID!)) return false;
         if (ownedOnly && !(counts[String(card.ID)] >= 1)) return false;
         if (text) {
           const name = (card.cardname || '').toLowerCase();


### PR DESCRIPTION
## Summary
- スコア計算画面のデッキ編成で同一カードを複数スロットに選択できるよう制限を解除
- 共有ブローチの同一スロット内での重複選択を許可
- 共有ブローチにShout500・Melody500を追加

## Test plan
- [ ] スコア計算画面で同じカードを複数スロットに配置できることを確認
- [ ] カード選択モーダルのフィルタ（名前検索・レアリティ・属性・所持のみ）が正常に動作すること
- [ ] 共有ブローチで同じブローチを複数選択できることを確認
- [ ] スコア計算結果が正しく算出されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)