### PR TITLE
feat: ラビットノート機能を追加

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,6 +45,7 @@ const base = import.meta.env.BASE_URL;
           <li><a href={`${base}songs/`} class="hover:text-indigo-200 transition-colors">楽曲一覧</a></li>
           <li><a href={`${base}mycard/`} class="hover:text-indigo-200 transition-colors">所持カード</a></li>
           <li><a href={`${base}score-calc/`} class="hover:text-indigo-200 transition-colors">スコア計算</a></li>
+          <li><a href={`${base}rabbit-note/`} class="hover:text-indigo-200 transition-colors">ラビットノート</a></li>
           <li><a href={`${base}decks/`} class="hover:text-indigo-200 transition-colors">保存デッキ</a></li>
         </ul>
       </nav>
@@ -54,6 +55,7 @@ const base = import.meta.env.BASE_URL;
         <li><a href={`${base}songs/`} class="block py-1 hover:text-indigo-200">楽曲一覧</a></li>
         <li><a href={`${base}mycard/`} class="block py-1 hover:text-indigo-200">所持カード</a></li>
         <li><a href={`${base}score-calc/`} class="block py-1 hover:text-indigo-200">スコア計算</a></li>
+        <li><a href={`${base}rabbit-note/`} class="block py-1 hover:text-indigo-200">ラビットノート</a></li>
         <li><a href={`${base}decks/`} class="block py-1 hover:text-indigo-200">保存デッキ</a></li>
       </ul>
     </header>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,8 +2,16 @@ export const CHARACTERS = [
   '和泉一織', '二階堂大和', '和泉三月', '四葉環',
   '逢坂壮五', '六弥ナギ', '七瀬陸',
   '八乙女楽', '九条天', '十龍之介',
+  '百', '千',
   '亥清悠', '狗丸トウマ', '棗巳波',
   '御堂虎於'
+] as const;
+
+export const CHARACTER_GROUPS = [
+  { name: 'IDOLiSH7', members: ['和泉一織', '二階堂大和', '和泉三月', '四葉環', '逢坂壮五', '六弥ナギ', '七瀬陸'] },
+  { name: 'TRIGGER', members: ['八乙女楽', '九条天', '十龍之介'] },
+  { name: 'Re:vale', members: ['百', '千'] },
+  { name: 'ŹOOĻ', members: ['亥清悠', '狗丸トウマ', '棗巳波', '御堂虎於'] },
 ] as const;
 
 export const RARITIES = ['UR', 'SSR', 'SR', 'R', 'N'] as const;

--- a/src/lib/data/rabbitNote.ts
+++ b/src/lib/data/rabbitNote.ts
@@ -1,0 +1,18 @@
+export interface RabbitNoteEntry {
+  shout: number;
+  beat: number;
+  melody: number;
+}
+
+/** キャラクター名 → { shout, beat, melody } */
+export type RabbitNoteMap = Record<string, RabbitNoteEntry>;
+
+const STORAGE_KEY = 'i7_rabbit_notes';
+
+export function loadRabbitNotes(): RabbitNoteMap {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+}
+
+export function saveRabbitNotes(notes: RabbitNoteMap): void {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(notes)); } catch {}
+}

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -18,6 +18,7 @@ import { XorShift128Plus } from './rng';
 import { flattenNotes } from './noteFlattener';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
 import { SHARED_BROACHS } from '../data/sharedBroachs';
+import type { RabbitNoteMap } from '../data/rabbitNote';
 
 /** カードからスキル情報を解析する */
 function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5 = 5): CardSkill | null {
@@ -69,6 +70,7 @@ export function computeTeam(
   selectedBroachIds?: (number | null)[],
   sharedBroachSelections?: number[][],
   skillLevels?: (1 | 2 | 3 | 4 | 5)[],
+  rabbitNotes?: RabbitNoteMap,
 ): ComputedTeam {
   const cards: DeckCard[] = [];
 
@@ -95,9 +97,11 @@ export function computeTeam(
     const baseBeat = trained ? (card.beat_max || 0) : (card.beat_min || 0);
     const baseMelody = trained ? (card.melody_max || 0) : (card.melody_min || 0);
 
-    const s = Math.round(baseShout * bonusMult);
-    const b = Math.round(baseBeat * bonusMult);
-    const m = Math.round(baseMelody * bonusMult);
+    // ラビットノート加算（イベントボーナス倍率適用前）
+    const rn = rabbitNotes?.[card.name || ''];
+    const s = Math.round((baseShout + (rn?.shout || 0)) * bonusMult);
+    const b = Math.round((baseBeat + (rn?.beat || 0)) * bonusMult);
+    const m = Math.round((baseMelody + (rn?.melody || 0)) * bonusMult);
     rawShout += s;
     rawBeat += b;
     rawMelody += m;

--- a/src/pages/rabbit-note/index.astro
+++ b/src/pages/rabbit-note/index.astro
@@ -1,0 +1,108 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="ラビットノート">
+  <h1 class="text-2xl font-bold mb-4">ラビットノート</h1>
+  <p class="text-sm text-gray-600 mb-6">各キャラクターのラビットノート値を入力してください。スコア計算時に各カードの素点に加算されます。</p>
+
+  <div id="rabbit-note-form"></div>
+
+  <div class="mt-6 flex gap-3">
+    <button id="btn-save" class="px-5 py-2.5 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 font-bold shadow-lg">保存</button>
+    <button id="btn-clear" class="px-5 py-2.5 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 shadow-lg">全てクリア</button>
+    <span id="save-feedback" class="self-center text-sm text-green-600 font-medium opacity-0 transition-opacity duration-300"></span>
+  </div>
+
+  <script>
+    import { CHARACTER_GROUPS } from '../../lib/constants';
+    import { loadRabbitNotes, saveRabbitNotes, type RabbitNoteMap } from '../../lib/data/rabbitNote';
+
+    const ATTRS = [
+      { key: 'shout', label: 'Shout', color: 'text-red-600', border: 'focus:border-red-400' },
+      { key: 'beat', label: 'Beat', color: 'text-green-600', border: 'focus:border-green-400' },
+      { key: 'melody', label: 'Melody', color: 'text-blue-600', border: 'focus:border-blue-400' },
+    ] as const;
+
+    const GROUP_COLORS: Record<string, string> = {
+      'IDOLiSH7': 'border-l-indigo-500',
+      'TRIGGER': 'border-l-amber-500',
+      'Re:vale': 'border-l-pink-500',
+      'ŹOOĻ': 'border-l-emerald-500',
+    };
+
+    function render() {
+      const saved = loadRabbitNotes();
+      const container = document.getElementById('rabbit-note-form')!;
+      container.innerHTML = '';
+
+      for (const group of CHARACTER_GROUPS) {
+        const section = document.createElement('section');
+        section.className = `bg-white rounded-lg shadow mb-4 border-l-4 ${GROUP_COLORS[group.name] || ''}`;
+
+        let html = `<h2 class="text-lg font-bold px-4 pt-4 pb-2">${group.name}</h2>`;
+        html += '<div class="px-4 pb-4 space-y-3">';
+
+        for (const member of group.members) {
+          const entry = saved[member] || { shout: 0, beat: 0, melody: 0 };
+          html += `<div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">`;
+          html += `<span class="font-medium text-sm w-28 shrink-0">${member}</span>`;
+          html += `<div class="flex gap-2 flex-1">`;
+          for (const attr of ATTRS) {
+            const val = entry[attr.key] || 0;
+            html += `<div class="flex items-center gap-1 flex-1">`;
+            html += `<label class="text-xs font-bold ${attr.color} w-7 shrink-0">${attr.label.charAt(0)}</label>`;
+            html += `<input type="number" min="0" max="99999" value="${val || ''}"
+              data-char="${member}" data-attr="${attr.key}"
+              class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm text-right ${attr.border} focus:outline-none focus:ring-1" placeholder="0">`;
+            html += `</div>`;
+          }
+          html += `</div></div>`;
+        }
+
+        html += '</div>';
+        section.innerHTML = html;
+        container.appendChild(section);
+      }
+    }
+
+    function collectValues(): RabbitNoteMap {
+      const map: RabbitNoteMap = {};
+      const inputs = document.querySelectorAll<HTMLInputElement>('#rabbit-note-form input[data-char]');
+      for (const input of inputs) {
+        const char = input.dataset.char!;
+        const attr = input.dataset.attr as 'shout' | 'beat' | 'melody';
+        const val = parseInt(input.value, 10) || 0;
+        if (!map[char]) map[char] = { shout: 0, beat: 0, melody: 0 };
+        map[char][attr] = val;
+      }
+      // 全て0のエントリは除外
+      const cleaned: RabbitNoteMap = {};
+      for (const [k, v] of Object.entries(map)) {
+        if (v.shout || v.beat || v.melody) cleaned[k] = v;
+      }
+      return cleaned;
+    }
+
+    function showFeedback(msg: string) {
+      const el = document.getElementById('save-feedback')!;
+      el.textContent = msg;
+      el.style.opacity = '1';
+      setTimeout(() => { el.style.opacity = '0'; }, 2000);
+    }
+
+    document.getElementById('btn-save')!.addEventListener('click', () => {
+      saveRabbitNotes(collectValues());
+      showFeedback('保存しました');
+    });
+
+    document.getElementById('btn-clear')!.addEventListener('click', () => {
+      if (!confirm('全てのラビットノート値をクリアしますか？')) return;
+      saveRabbitNotes({});
+      render();
+      showFeedback('クリアしました');
+    });
+
+    render();
+  </script>
+</BaseLayout>

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -339,6 +339,7 @@ const base = import.meta.env.BASE_URL;
     import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTRIBUTE_MAP } from '../../lib/constants';
     import { SHARED_BROACHS } from '../../lib/data/sharedBroachs';
     import { loadCounts } from '../../lib/cardListRenderer';
+    import { loadRabbitNotes } from '../../lib/data/rabbitNote';
 
     const thumbUrl = (window as any).__CARD_THUMB_BASE_URL__ || '';
 
@@ -826,7 +827,7 @@ const base = import.meta.env.BASE_URL;
         return;
       }
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels, loadRabbitNotes());
       const notes = flattenNotes(selectedSong, 42);
 
       // スコア内訳表示
@@ -922,7 +923,7 @@ const base = import.meta.env.BASE_URL;
       btn.textContent = '計算中...';
       $('progress-container').classList.remove('hidden');
 
-      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels);
+      const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels, loadRabbitNotes());
       const notes = flattenNotes(selectedSong, 42);
 
       // スキルオプションの適用


### PR DESCRIPTION
## Summary
- ラビットノート入力ページ（`/rabbit-note/`）を新規作成。16キャラクター×3属性（Shout/Beat/Melody）の値をグループ別に入力・保存できる
- スコア計算時に、デッキ内カードのキャラクターに一致するラビットノート値を素点に加算（イベントボーナス倍率適用前）
- CHARACTERSに百・千（Re:vale）を追加し14→16名に拡張

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `src/lib/constants.ts` | CHARACTERS に百・千追加、CHARACTER_GROUPS 定数追加 |
| `src/lib/data/rabbitNote.ts` | 新規: RabbitNoteMap 型 + localStorage ヘルパー |
| `src/lib/score/engine.ts` | `computeTeam()` に rabbitNotes パラメータ追加 |
| `src/pages/score-calc/index.astro` | recalculate/runMC で rabbitNotes を渡すよう変更 |
| `src/pages/rabbit-note/index.astro` | 新規: ラビットノート入力ページ |
| `src/layouts/BaseLayout.astro` | ヘッダーナビにリンク追加 |

## Test plan
- [ ] ラビットノートページが正常に表示される（16キャラクター×3属性）
- [ ] 値を入力して保存→ページリロード後も値が復元される
- [ ] 全てクリアで値がリセットされる
- [ ] スコア計算ページでラビットノート値が素点に反映される
- [ ] ラビットノート未設定時は従来通りの計算結果になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)