### PR TITLE
fix: GViz APIフェッチにリトライと空データ検証を追加

### DIFF
--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -75,11 +75,16 @@ const SKILL_TYPE_NORMALIZE: Record<string, string> = {
   '判定領域を': '判定縮小スコアアップ',
 };
 
+const MIN_EXPECTED_CARDS = 100;
+
 /**
  * カードデータをGoogle Spreadsheetから取得してクリーンなJSON配列で返す
  */
 export async function fetchCardsJson(): Promise<Card[]> {
   const rows = await fetchSheetAsJson(SPREADSHEET_ID, CARDS_GID);
+  if (rows.length < MIN_EXPECTED_CARDS) {
+    throw new Error(`カードデータが不足しています: ${rows.length}件 (最低${MIN_EXPECTED_CARDS}件を期待)`);
+  }
   return rows.map((row) => {
     const raw = row.ap_skill_type;
     if (typeof raw === 'string' && raw in SKILL_TYPE_NORMALIZE) {

--- a/src/lib/data/gviz.ts
+++ b/src/lib/data/gviz.ts
@@ -56,15 +56,35 @@ export function parseGvizResponse(text: string): GVizResponse {
 
 /**
  * GViz JSON 経由で生のテーブルデータを取得する（カラムマッピングは呼び出し側で行う）
+ * フェッチ失敗時はリトライし、空データの場合はエラーをスローする。
  */
-export async function fetchSheetRaw(spreadsheetId: string, gid: number): Promise<GVizTable> {
+export async function fetchSheetRaw(spreadsheetId: string, gid: number, maxRetries = 2): Promise<GVizTable> {
   const url = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/gviz/tq?tqx=out:json&gid=${gid}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`スプレッドシートの取得に失敗: ${response.status} ${response.statusText}`);
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      await new Promise(r => setTimeout(r, 1000 * attempt));
+    }
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`スプレッドシートの取得に失敗: ${response.status} ${response.statusText}`);
+      }
+      const text = await response.text();
+      const table = parseGvizResponse(text).table;
+      if (table.rows.length === 0) {
+        throw new Error(`スプレッドシートのデータが空です (gid=${gid})`);
+      }
+      return table;
+    } catch (e) {
+      lastError = e as Error;
+      if (attempt < maxRetries) {
+        console.warn(`[gviz] フェッチ試行 ${attempt + 1}/${maxRetries + 1} 失敗 (gid=${gid}): ${lastError.message}`);
+      }
+    }
   }
-  const text = await response.text();
-  return parseGvizResponse(text).table;
+  throw lastError!;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Google Sheets GViz APIが一時的に空/不完全なレスポンスを返した場合に、カード一覧ページが壊れる（1件のundefinedカードのみ表示される）問題を修正
- `fetchSheetRaw()` にリトライ機構（最大2回、指数バックオフ）と空データ検証を追加
- `fetchCardsJson()` に最低件数検証（100件未満でビルドエラー）を追加し、不完全データでのデプロイを防止

## Test plan
- [ ] `npm run build` で2800+ページが正常にビルドされること
- [ ] カード一覧ページ (`/cards/`) で2668件のカードが正常に表示されること
- [ ] GViz APIが一時的に失敗した場合、リトライ後にビルドが成功すること
- [ ] GViz APIが継続的に失敗した場合、ビルドがエラーで停止すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)