### PR TITLE
feat: スコアアップスキルに発動条件を括弧表示

### DIFF
--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -90,9 +90,9 @@ export async function fetchCardsJson(): Promise<Card[]> {
     if (typeof raw === 'string' && raw in SKILL_TYPE_NORMALIZE) {
       row.ap_skill_type = SKILL_TYPE_NORMALIZE[raw];
     }
-    // スコアアップ＋タイマーを区別して表示
-    if (row.ap_skill_type === 'スコアアップ' && row.ap_skill_req === 'タイマー') {
-      row.ap_skill_type = 'スコアアップ（タイマー）';
+    // スコアアップ系は発動条件を括弧付きで表示（例: スコアアップ（タイマー）、スコアアップ（コンポ））
+    if (row.ap_skill_type === 'スコアアップ' && row.ap_skill_req) {
+      row.ap_skill_type = `スコアアップ（${row.ap_skill_req}）`;
     }
     return row as unknown as Card;
   });


### PR DESCRIPTION
## Summary
- カード一覧のスキル列で、スコアアップタイプのスキルに発動条件（コンボ、Perfect、タイマー等）を括弧付きで表示
- 既存のタイマー専用の特別処理を一般化し、`ap_skill_req` を持つすべてのスコアアップスキルに対応

## Test plan
- [ ] カード一覧でスコアアップ（コンボ）、スコアアップ（Perfect）等が正しく表示される
- [ ] スキルタイプフィルターで各発動条件が個別に選択できる
- [ ] スコア計算エンジンが正常に動作する（タイマー判定含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)