### PR TITLE
fix: 判定縮小スキルのボーナス適用からnotes_20を除外

### DIFF
--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -256,7 +256,7 @@ export function calcMaxScore(team: ComputedTeam, notes: FlatNote[], options?: Sc
 
     const base = team[note.attribute] * NOTE_RATE[note.type] * LIGHT_MULTIPLIER[note.group];
     const assistedBase = base * assistMult;
-    const shrinkExtra = shrinkActive ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
+    const shrinkExtra = (shrinkActive && note.group !== 'notes_20') ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
     total += assistedBase + shrinkExtra + scoreUpSum;
   }
 
@@ -341,12 +341,12 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
 
     const base = team[note.attribute] * NOTE_RATE[note.type] * LIGHT_MULTIPLIER[note.group];
     const assistedBase = base * assistMult;
-    const shrinkExtra = shrinkActive ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
+    const shrinkExtra = (shrinkActive && note.group !== 'notes_20') ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
     const noteScore = assistedBase + shrinkExtra + scoreUpSum;
     totalScore += noteScore;
 
-    // 判定縮小スキルのスコア寄与を発動中のカードに按分
-    if (shrinkActive) {
+    // 判定縮小スキルのスコア寄与を発動中のカードに按分（notes_20は対象外）
+    if (shrinkActive && note.group !== 'notes_20') {
       const extra = base * (SHRINK_MULTIPLIER - 1.0);
       let activeShrinkCount = 0;
       for (let c = 0; c < cardCount; c++) {

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -81,6 +81,7 @@ const base = import.meta.env.BASE_URL;
             <input type="checkbox" id="opt-shrink-full" class="rounded" />
             <span>判定縮小フル発動</span>
           </label>
+          <p class="text-xs text-gray-400 ml-6">※最初の20ノーツは縮小の計算対象外です</p>
         </div>
         <div class="mt-3 pt-3 border-t space-y-2 text-sm">
           <label class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 判定縮小スコアアップスキル（SHRINK_MULTIPLIER ×1.6）のボーナス適用対象から `notes_20` グループのノートを除外
- `calcMaxScore`（最高スコア計算）と `runOnce`（MCシミュレーション）の3箇所を修正
- スキル発動カウンター（ノート数カウント）には `notes_20` を引き続き含める（発動タイミングには影響なし）

## Test plan
- [x] `npm run build` でビルドエラーなし
- [x] スコア計算ページで「判定縮小フル発動」チェック時にシミュレーション正常完了を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)