### PR TITLE
fix: groupnameがnullのカードでグループ指定ブローチが発動しない問題を修正

### DIFF
--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -1,4 +1,5 @@
 import { SPREADSHEET_ID, fetchSheetAsJson } from './gviz.ts';
+import { CHARACTER_GROUPS } from '../constants';
 
 /** APスキル1レベル分のパラメータ */
 export interface ApSkillLevel {
@@ -93,6 +94,15 @@ export async function fetchCardsJson(): Promise<Card[]> {
     // スコアアップ系は発動条件を括弧付きで表示（例: スコアアップ（タイマー）、スコアアップ（コンポ））
     if (row.ap_skill_type === 'スコアアップ' && row.ap_skill_req) {
       row.ap_skill_type = `スコアアップ（${row.ap_skill_req}）`;
+    }
+    // groupname が null の場合、キャラクター名からグループを解決
+    if (!row.groupname && row.name) {
+      for (const group of CHARACTER_GROUPS) {
+        if ((group.members as readonly string[]).includes(row.name as string)) {
+          row.groupname = group.name;
+          break;
+        }
+      }
     }
     return row as unknown as Card;
   });

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -193,7 +193,7 @@ const otherSkills = [
               <span class="text-blue-500">Beat: {b.beat ?? '-'}</span>
               <span class="text-green-500">Melody: {b.melody ?? '-'}</span>
             </div>
-            {b.broach_type && <p class="text-xs text-gray-500 mt-1">種類: {b.broach_type}</p>}
+            {b.condition && <p class="text-xs text-gray-500 mt-1">条件: {b.condition}{b.group ? `（${b.group}）` : ''}</p>}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- スプレッドシートのカードデータで `groupname` 列が null のカード（714件/2668件）について、`CHARACTER_GROUPS` 定数からキャラクター名でグループ名を補完するロジックを `fetchCardsJson.ts` に追加
- カード3414（10th Anniversary 四葉環）等で、全員同一グループのデッキ構成時にグループ指定ブローチ（`broach_type=4`）が「条件未達」になるバグを修正
- カード詳細ページのグループ表示（`groupname` が null で非表示だった）も同時に修正

## Root Cause
`hasNoOtherGroup()` が `card.groupname !== "IDOLiSH7"` を比較する際、`null !== "IDOLiSH7"` → `true` となり、カード自身が「他グループ」と誤判定されていた。

## Test plan
- [x] ビルド成功確認（2818ページ）
- [x] カード3414をセンターに全員IDOLiSH7 URで構成 → ブローチラベルが紫色（条件達成）表示
- [x] カード詳細テーブルで B+4500 が正しく加算
- [x] カード詳細ページ `/cards/3414/` でグループ「IDOLiSH7」が表示
- [x] Playwright E2Eテスト: 修正前後で同一結果（31 passed / 11 failed, 既存の失敗のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)