### PR TITLE
feat: スコア計算画面にセンタースキル加算値を表示

### DIFF
--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -52,7 +52,7 @@ function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5
 }
 
 /** センタースキルの増加率を解析する */
-function parseCenterSkillRate(ctSkill: string | null): number {
+export function parseCenterSkillRate(ctSkill: string | null): number {
   if (!ctSkill) return 0;
   for (const [keyword, rate] of Object.entries(CENTER_SKILL_RATES)) {
     if (ctSkill.includes(keyword)) return rate;

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -332,7 +332,7 @@ const base = import.meta.env.BASE_URL;
     import type { Song } from '../../lib/data/fetchSongsJson';
     import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
     import type { ComputedTeam, SimulationResult, ScoreOptions } from '../../lib/score/types';
-    import { computeTeam, calcMinScore, calcMaxScore, runSimulation, flattenNotes } from '../../lib/score/engine';
+    import { computeTeam, calcMinScore, calcMaxScore, runSimulation, flattenNotes, parseCenterSkillRate } from '../../lib/score/engine';
     import { resolveDeckBroachs, type ResolvedBroach } from '../../lib/score/broachResolver';
     import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER } from '../../lib/score/constants';
     import { EVENT_BONUS_TIERS, EVENT_BONUS_MULTIPLIER, BONUS_LABEL, BONUS_CLASS, ALL_SELECT_CLASSES } from '../../lib/data/eventBonusTiers';
@@ -749,6 +749,35 @@ const base = import.meta.env.BASE_URL;
       }).join('');
 
       $('card-detail-body').innerHTML = rows;
+      // センタースキルによる加算値を計算
+      const centerCard = deck[0];
+      const friendCard = deck[5];
+      const centerRate = centerCard ? parseCenterSkillRate(centerCard.ct_skill) : 0;
+      const friendRate = friendCard ? parseCenterSkillRate(friendCard.ct_skill) : 0;
+      const centerAttr = centerCard ? normalizeAttr(centerCard.attribute) : null;
+      const friendAttr = friendCard ? normalizeAttr(friendCard.attribute) : null;
+
+      let shoutRate = 0, beatRate = 0, melodyRate = 0;
+      if (centerAttr === 'Shout') shoutRate += centerRate;
+      if (centerAttr === 'Beat') beatRate += centerRate;
+      if (centerAttr === 'Melody') melodyRate += centerRate;
+      if (friendAttr === 'Shout') shoutRate += friendRate;
+      if (friendAttr === 'Beat') beatRate += friendRate;
+      if (friendAttr === 'Melody') melodyRate += friendRate;
+
+      const baseShout = totalShout + totalBS;
+      const baseBeat = totalBeat + totalBB;
+      const baseMelody = totalMelody + totalBM;
+      const csShout = Math.floor(baseShout * (100 + shoutRate) / 100) - baseShout;
+      const csBeat = Math.floor(baseBeat * (100 + beatRate) / 100) - baseBeat;
+      const csMelody = Math.floor(baseMelody * (100 + melodyRate) / 100) - baseMelody;
+
+      const hasCenter = shoutRate > 0 || beatRate > 0 || melodyRate > 0;
+      const centerSkillLabels: string[] = [];
+      if (centerCard && centerRate > 0) centerSkillLabels.push(`自分+${centerRate}%`);
+      if (friendCard && friendRate > 0) centerSkillLabels.push(`フレンド+${friendRate}%`);
+      const centerSkillLabel = centerSkillLabels.join(' / ');
+
       $('card-detail-foot').innerHTML = `<tr class="border-t-2 border-gray-300 font-bold text-xs">
         <td colspan="4" class="py-1 px-1 text-right text-gray-700">合計</td>
         <td class="py-1 px-1 text-right text-red-500">${totalShout.toLocaleString()}</td>
@@ -758,7 +787,14 @@ const base = import.meta.env.BASE_URL;
         <td class="py-1 px-1 text-right">${totalBB || '-'}</td>
         <td class="py-1 px-1 text-right">${totalBM || '-'}</td>
         <td colspan="4"></td>
-      </tr>`;
+      </tr>${hasCenter ? `<tr class="font-bold text-xs text-purple-600">
+        <td colspan="4" class="py-1 px-1 text-right">センタースキル (${centerSkillLabel})</td>
+        <td class="py-1 px-1 text-right">${csShout > 0 ? `+${csShout.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${csBeat > 0 ? `+${csBeat.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${csMelody > 0 ? `+${csMelody.toLocaleString()}` : '-'}</td>
+        <td colspan="3"></td>
+        <td colspan="4"></td>
+      </tr>` : ''}`;
     }
 
     // --- カード選択モーダル ---


### PR DESCRIPTION
## Summary
- スコア計算画面のカード詳細テーブルの合計行の下に、センタースキルによる属性値の加算分を表示する行を追加
- 自分のセンター・フレンドそれぞれのセンタースキル増加率と対象属性に基づいて加算値を計算
- `computeTeam` と同一の計算式 `floor(base * (100 + rate%) / 100) - base` を使用

## Test plan
- [ ] カード詳細テーブルの合計行の下にセンタースキル加算行が表示されることを確認
- [ ] センタースキルを持つカードをセンター/フレンドに配置した場合のみ行が表示されること
- [ ] 加算値が `computeTeam` の計算結果と一致すること
- [ ] センタースキルが無い場合（ct_skill が null）は行が非表示であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)