### PR TITLE
feat: スコア計算画面から「スコアUPフル発動」「判定縮小フル発動」を削除

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -74,17 +74,6 @@ const base = import.meta.env.BASE_URL;
         <h2 class="text-sm font-bold text-gray-700 mb-3">スキルオプション</h2>
         <div class="space-y-2 text-sm">
           <label class="flex items-center gap-2">
-            <input type="checkbox" id="opt-scoreup-full" class="rounded" />
-            <span>スコアアップフル発動</span>
-          </label>
-          <label class="flex items-center gap-2">
-            <input type="checkbox" id="opt-shrink-full" class="rounded" />
-            <span>判定縮小フル発動</span>
-          </label>
-          <p class="text-xs text-gray-400 ml-6">※最初の20ノーツは縮小の計算対象外です</p>
-        </div>
-        <div class="mt-3 pt-3 border-t space-y-2 text-sm">
-          <label class="flex items-center gap-2">
             <input type="checkbox" id="opt-scoreup-assist" class="rounded" />
             <span>SCOREUPアシスト（属性値×1.2）</span>
           </label>
@@ -1017,23 +1006,6 @@ const base = import.meta.env.BASE_URL;
       const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels, loadRabbitNotes());
       const notes = flattenNotes(selectedSong, 42);
 
-      // スキルオプションの適用
-      const forceScoreUp = ($('opt-scoreup-full') as HTMLInputElement).checked;
-      const forceShrink = ($('opt-shrink-full') as HTMLInputElement).checked;
-
-      // フル発動の場合はper=100にオーバーライド
-      if (forceScoreUp || forceShrink) {
-        for (const dc of team.cards) {
-          if (!dc.skill) continue;
-          if (forceScoreUp && (dc.skill.skillType === 'scoreUp' || dc.skill.skillType === 'timerScoreUp')) {
-            dc.skill.per = 100;
-          }
-          if (forceShrink && dc.skill.isShrink) {
-            dc.skill.per = 100;
-          }
-        }
-      }
-
       const iterations = Number(($('mc-iterations-select') as HTMLSelectElement).value) || MC_ITERATIONS;
 
       // スコアオプション
@@ -1335,8 +1307,6 @@ const base = import.meta.env.BASE_URL;
       $('btn-calculate').addEventListener('click', runMC);
 
       // スキルオプション変更時に再計算
-      $('opt-scoreup-full').addEventListener('change', recalculate);
-      $('opt-shrink-full').addEventListener('change', recalculate);
       $('opt-scoreup-assist').addEventListener('change', recalculate);
       $('opt-scoreup-badge').addEventListener('change', recalculate);
 


### PR DESCRIPTION
## Summary
- スコア計算画面のスキルオプションから「スコアアップフル発動」と「判定縮小フル発動」の2つのチェックボックスを削除
- 関連するエンジンロジック（スキル発動率100%オーバーライド処理）とイベントリスナーも削除

## Test plan
- [ ] スコア計算画面でスキルオプションに「SCOREUPアシスト」「SCOREUPバッジ」のみ表示されることを確認
- [ ] スコア計算が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)