### PR TITLE
fix: 楽曲詳細画面のノート内訳の倍率を修正

### DIFF
--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -28,10 +28,10 @@ const ratioChartHtml = attrDonutSvg(sr, br, mr, { sizeClass: 'w-full h-full', st
 // ノート内訳データ（ライト倍率付き）
 const NOTE_GROUPS = [
   { key: 'notes_20', label: 'Notes 2.0', mult: 1.0 },
-  { key: 'light_2', label: 'Light 2', mult: 1.1 },
-  { key: 'light_3', label: 'Light 3', mult: 1.2 },
-  { key: 'light_4', label: 'Light 4', mult: 1.3 },
-  { key: 'light_5', label: 'Light 5', mult: 1.4 },
+  { key: 'light_2', label: 'Light 2', mult: 1.0 },
+  { key: 'light_3', label: 'Light 3', mult: 1.1 },
+  { key: 'light_4', label: 'Light 4', mult: 1.2 },
+  { key: 'light_5', label: 'Light 5', mult: 1.3 },
   { key: 'light_6', label: 'Light 6', mult: 1.5 },
   { key: 'chorus_light_5', label: 'Chorus Light 5', mult: 2.6 },
   { key: 'chorus_light_6', label: 'Chorus Light 6', mult: 3.0 },


### PR DESCRIPTION
## Summary
- 楽曲詳細画面のノート内訳テーブルで light_2〜light_5 の倍率が1段階ずつずれていたのを修正
- `src/lib/score/constants.ts` の `LIGHT_MULTIPLIER` と一致させた

| グループ | 修正前（誤） | 修正後（正） |
|---|---|---|
| Light 2 | ×1.1 | ×1.0 |
| Light 3 | ×1.2 | ×1.1 |
| Light 4 | ×1.3 | ×1.2 |
| Light 5 | ×1.4 | ×1.3 |

## Test plan
- [ ] 楽曲詳細画面のノート内訳の倍率が constants.ts と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)