### PR TITLE
fix: スコア計算画面の「期待最低値/最高値」を「理論最低値/最高値」に変更

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -109,11 +109,11 @@ const base = import.meta.env.BASE_URL;
         </table>
         <div class="mt-4 border-t pt-3">
           <div class="flex justify-between text-sm">
-            <span class="text-gray-500">期待最低値（スキル全不発）</span>
+            <span class="text-gray-500">理論最低値（スキル全不発）</span>
             <span id="score-min" class="font-medium"></span>
           </div>
           <div class="flex justify-between text-sm mt-1">
-            <span class="text-gray-500">期待最高値（スキル全発動）</span>
+            <span class="text-gray-500">理論最高値（スキル全発動）</span>
             <span id="score-max" class="font-medium"></span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- スコア計算結果の「期待最低値（スキル全不発）」→「理論最低値（スキル全不発）」に変更
- スコア計算結果の「期待最高値（スキル全発動）」→「理論最高値（スキル全発動）」に変更

## Test plan
- [ ] スコア計算画面でラベルが「理論最低値」「理論最高値」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)