### PR TITLE
feat: スコア計算画面のカード詳細下に縮小の注釈を追加

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -249,6 +249,7 @@ const base = import.meta.env.BASE_URL;
           </table>
         </div>
         <p class="text-xs text-gray-400 mt-2">※ オート専用ブローチはスコア計算の対象外です</p>
+        <p class="text-xs text-gray-400 mt-2">※ 最初の20ノーツは縮小の計算対象外です</p>
       </section>
 
       <!-- 計算ボタン -->


### PR DESCRIPTION
## Summary
- カード詳細テーブルの下に「※ 最初の20ノーツは縮小の計算対象外です」の注釈を追加

## Test plan
- [ ] スコア計算画面のカード詳細テーブル下に注釈が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)