### PR TITLE
feat: スコア計算画面に縮小カバー率を追加

### DIFF
--- a/src/lib/score/constants.ts
+++ b/src/lib/score/constants.ts
@@ -16,13 +16,12 @@ export const SCOREUP_ASSIST_MULTIPLIER = 1.2;
 export const SCOREUP_BADGE_RATE = 0.15;
 export const MC_ITERATIONS = 5000;
 export const MC_CHUNK_SIZE = 50;
-/** センタースキル増加量パターン（キーワード → 増加率%） */
+/** センタースキル増加率（レアリティ → 増加率%） */
 export const CENTER_SKILL_RATES: Record<string, number> = {
-  'かなり': 10,
-  'やや': 7,
-  '大きく': 6,
+  'UR': 10,
+  'SSR': 7,
 };
-export const DEFAULT_CENTER_SKILL_RATE = 10;
+export const DEFAULT_CENTER_SKILL_RATE = 6;
 
 export { EVENT_BONUS_MULTIPLIER } from '../data/eventBonusTiers';
 export type { EventBonusTier } from '../data/eventBonusTiers';

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -51,13 +51,10 @@ function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5
   };
 }
 
-/** センタースキルの増加率を解析する */
-export function parseCenterSkillRate(ctSkill: string | null): number {
-  if (!ctSkill) return 0;
-  for (const [keyword, rate] of Object.entries(CENTER_SKILL_RATES)) {
-    if (ctSkill.includes(keyword)) return rate;
-  }
-  return DEFAULT_CENTER_SKILL_RATE;
+/** レアリティからセンタースキル増加率を取得する */
+export function getCenterSkillRate(rarity: string | null): number {
+  if (!rarity) return 0;
+  return CENTER_SKILL_RATES[rarity] ?? DEFAULT_CENTER_SKILL_RATE;
 }
 
 /** チームアピール値を計算する */
@@ -172,8 +169,8 @@ export function computeTeam(
   let shoutRate = 0, beatRate = 0, melodyRate = 0;
   const centerAttr = deck[0] ? normalizeAttribute(deck[0].attribute) : null;
   const friendAttr = deck[5] ? normalizeAttribute(deck[5].attribute) : null;
-  const centerRate = deck[0] ? parseCenterSkillRate(deck[0].ct_skill) : 0;
-  const friendRate = deck[5] ? parseCenterSkillRate(deck[5].ct_skill) : 0;
+  const centerRate = deck[0] ? getCenterSkillRate(deck[0].rarity) : 0;
+  const friendRate = deck[5] ? getCenterSkillRate(deck[5].rarity) : 0;
 
   if (centerAttr === 'Shout') shoutRate += centerRate;
   if (centerAttr === 'Beat') beatRate += centerRate;
@@ -197,6 +194,87 @@ export function computeTeam(
     broachBeat: broachBeatTotal,
     broachMelody: broachMelodyTotal,
     broachScoreBonus,
+  };
+}
+
+/** 縮小カバー率を計算する（100%発動 + 確率考慮の期待値） */
+export function calcShrinkCoverage(team: ComputedTeam, notesCount: number, offsetSeconds: number = 0): {
+  coverageRate: number;
+  coveredSeconds: number;
+  expectedCoverageRate: number;
+  expectedCoveredSeconds: number;
+  effectiveSeconds: number;
+} | null {
+  const shrinkCards = team.cards.filter(dc => dc.skill?.isShrink && dc.skill.count > 0);
+  if (shrinkCards.length === 0) return null;
+
+  const zero = { coverageRate: 0, coveredSeconds: 0, expectedCoverageRate: 0, expectedCoveredSeconds: 0, effectiveSeconds: 0 };
+  const effectiveSeconds = team.songDuration - offsetSeconds;
+  if (effectiveSeconds <= 0) return zero;
+  if (notesCount <= 0) return { ...zero, effectiveSeconds };
+
+  // 全縮小カードの発動区間を収集（確率付き）
+  const intervals: { start: number; end: number; prob: number }[] = [];
+  for (const dc of shrinkCards) {
+    const skill = dc.skill!;
+    const prob = skill.per / 100;
+    const numActivations = Math.floor(notesCount / skill.count);
+    for (let k = 1; k <= numActivations; k++) {
+      const noteIndex = k * skill.count - 1;
+      const activationTime = noteIndex / notesCount * team.songDuration;
+      const start = Math.max(activationTime, offsetSeconds);
+      const end = Math.min(activationTime + skill.value, team.songDuration);
+      if (start < end) intervals.push({ start, end, prob });
+    }
+  }
+
+  if (intervals.length === 0) return { ...zero, effectiveSeconds };
+
+  // --- 100%発動: 区間マージ ---
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  const merged: [number, number][] = [[sorted[0].start, sorted[0].end]];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = merged[merged.length - 1];
+    if (sorted[i].start <= last[1]) {
+      last[1] = Math.max(last[1], sorted[i].end);
+    } else {
+      merged.push([sorted[i].start, sorted[i].end]);
+    }
+  }
+  const coveredSeconds = merged.reduce((sum, [s, e]) => sum + (e - s), 0);
+
+  // --- 期待値: 各時間セグメントで「少なくとも1つ発動中」の確率を積分 ---
+  // イベント収集（全区間の開始・終了時刻）
+  const times = new Set<number>();
+  for (const iv of intervals) {
+    times.add(iv.start);
+    times.add(iv.end);
+  }
+  const sortedTimes = [...times].sort((a, b) => a - b);
+
+  let expectedCoveredSeconds = 0;
+  for (let i = 0; i < sortedTimes.length - 1; i++) {
+    const segStart = sortedTimes[i];
+    const segEnd = sortedTimes[i + 1];
+    const segLen = segEnd - segStart;
+    if (segLen <= 0) continue;
+
+    // このセグメントをカバーする全区間の「不発動確率」の積
+    let probNone = 1;
+    for (const iv of intervals) {
+      if (iv.start <= segStart && iv.end >= segEnd) {
+        probNone *= (1 - iv.prob);
+      }
+    }
+    expectedCoveredSeconds += segLen * (1 - probNone);
+  }
+
+  return {
+    coverageRate: coveredSeconds / effectiveSeconds,
+    coveredSeconds,
+    expectedCoverageRate: expectedCoveredSeconds / effectiveSeconds,
+    expectedCoveredSeconds,
+    effectiveSeconds,
   };
 }
 
@@ -253,8 +331,9 @@ export function calcMaxScore(team: ComputedTeam, notes: FlatNote[], options?: Sc
         counters[c] = 0;
         if (skill.isShrink) {
           const noteTime = n / N * team.songDuration;
+          const shrinkDuration = skill.value;
           const endNote = Math.min(
-            Math.floor(((noteTime + skill.spTime) / team.songDuration) * N),
+            Math.floor(((noteTime + shrinkDuration) / team.songDuration) * N),
             N,
           );
           shrinkEndNotes[c] = Math.max(shrinkEndNotes[c], endNote);
@@ -335,8 +414,9 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
           activations[c]++;
           if (skill.isShrink) {
             const noteTime = n / N * team.songDuration;
+            const shrinkDuration = skill.value;
             const endNote = Math.min(
-              Math.floor(((noteTime + skill.spTime) / team.songDuration) * N),
+              Math.floor(((noteTime + shrinkDuration) / team.songDuration) * N),
               N,
             );
             shrinkEndNotes[c] = Math.max(shrinkEndNotes[c], endNote);

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -116,6 +116,18 @@ const base = import.meta.env.BASE_URL;
             <span class="text-gray-500">理論最高値（スキル全発動）</span>
             <span id="score-max" class="font-medium"></span>
           </div>
+          <div id="shrink-coverage-row" class="flex items-center justify-between text-sm mt-1 hidden">
+            <span class="text-gray-500">縮小カバー率（100%発動時）</span>
+            <span class="flex items-center gap-1">
+              <span id="shrink-coverage-val" class="font-medium text-orange-600"></span>
+              <input type="number" id="shrink-offset-input" value="0" min="0" step="1" class="w-12 border border-gray-300 rounded px-1 py-0.5 text-xs text-right" />
+              <span class="text-gray-400 text-xs">秒除外</span>
+            </span>
+          </div>
+          <div id="shrink-expected-row" class="flex justify-between text-sm mt-1 hidden">
+            <span class="text-gray-500">縮小カバー率（期待値）</span>
+            <span id="shrink-expected-val" class="font-medium text-orange-600"></span>
+          </div>
         </div>
         <div class="mt-4 bg-indigo-50 rounded-lg p-3 text-center">
           <div class="text-xs text-gray-500">MC平均スコア</div>
@@ -322,7 +334,7 @@ const base = import.meta.env.BASE_URL;
     import type { Song } from '../../lib/data/fetchSongsJson';
     import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
     import type { ComputedTeam, SimulationResult, ScoreOptions } from '../../lib/score/types';
-    import { computeTeam, calcMinScore, calcMaxScore, runSimulation, flattenNotes, parseCenterSkillRate } from '../../lib/score/engine';
+    import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, runSimulation, flattenNotes, getCenterSkillRate } from '../../lib/score/engine';
     import { resolveDeckBroachs, type ResolvedBroach } from '../../lib/score/broachResolver';
     import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER } from '../../lib/score/constants';
     import { EVENT_BONUS_TIERS, EVENT_BONUS_MULTIPLIER, BONUS_LABEL, BONUS_CLASS, ALL_SELECT_CLASSES } from '../../lib/data/eventBonusTiers';
@@ -758,8 +770,8 @@ const base = import.meta.env.BASE_URL;
       // センタースキルによる加算値を計算
       const centerCard = deck[0];
       const friendCard = deck[5];
-      const centerRate = centerCard ? parseCenterSkillRate(centerCard.ct_skill) : 0;
-      const friendRate = friendCard ? parseCenterSkillRate(friendCard.ct_skill) : 0;
+      const centerRate = centerCard ? getCenterSkillRate(centerCard.rarity) : 0;
+      const friendRate = friendCard ? getCenterSkillRate(friendCard.rarity) : 0;
       const centerAttr = centerCard ? normalizeAttr(centerCard.attribute) : null;
       const friendAttr = friendCard ? normalizeAttr(friendCard.attribute) : null;
 
@@ -903,6 +915,8 @@ const base = import.meta.env.BASE_URL;
         $('area-values-section').classList.add('hidden');
         $('mc-results').classList.add('hidden');
         $('skill-stats').classList.add('hidden');
+        $('shrink-coverage-row').classList.add('hidden');
+        $('shrink-expected-row').classList.add('hidden');
         $('final-result').textContent = '---';
         simulationResult = null;
         return;
@@ -944,6 +958,9 @@ const base = import.meta.env.BASE_URL;
       $('score-min').textContent = minScore.toLocaleString();
       $('score-max').textContent = maxScore.toLocaleString();
 
+      // 縮小カバー率
+      updateShrinkCoverage(team, selectedSong);
+
       // 楽曲属性面積値
       renderAreaValues(team, selectedSong);
 
@@ -952,6 +969,22 @@ const base = import.meta.env.BASE_URL;
       $('skill-stats').classList.add('hidden');
       $('final-result').textContent = '---';
       simulationResult = null;
+    }
+
+    function updateShrinkCoverage(team: ComputedTeam, song: Song) {
+      const offset = Number(($('shrink-offset-input') as HTMLInputElement).value) || 0;
+      const shrinkCoverage = calcShrinkCoverage(team, song.notes_count || 0, offset);
+      if (shrinkCoverage) {
+        $('shrink-coverage-row').classList.remove('hidden');
+        $('shrink-expected-row').classList.remove('hidden');
+        const pct = (shrinkCoverage.coverageRate * 100).toFixed(1);
+        $('shrink-coverage-val').textContent = `${pct}%（${shrinkCoverage.coveredSeconds.toFixed(1)}秒 / ${shrinkCoverage.effectiveSeconds.toFixed(1)}秒）`;
+        const expPct = (shrinkCoverage.expectedCoverageRate * 100).toFixed(1);
+        $('shrink-expected-val').textContent = `${expPct}%（${shrinkCoverage.expectedCoveredSeconds.toFixed(1)}秒 / ${shrinkCoverage.effectiveSeconds.toFixed(1)}秒）`;
+      } else {
+        $('shrink-coverage-row').classList.add('hidden');
+        $('shrink-expected-row').classList.add('hidden');
+      }
     }
 
     function renderAreaValues(team: ComputedTeam, song: Song) {
@@ -1310,6 +1343,13 @@ const base = import.meta.env.BASE_URL;
       // スキルオプション変更時に再計算
       $('opt-scoreup-assist').addEventListener('change', recalculate);
       $('opt-scoreup-badge').addEventListener('change', recalculate);
+
+      // 縮小カバー率の除外秒数変更時に再計算
+      $('shrink-offset-input').addEventListener('input', () => {
+        if (!selectedSong || deck.filter(c => c !== null).length === 0) return;
+        const team = computeTeam(deck, allBroachs, selectedSong, deckBonusTiers, deckTrained, undefined, deckSharedBroachs, deckSkillLevels, loadRabbitNotes());
+        updateShrinkCoverage(team, selectedSong);
+      });
 
       // 状態復元
       restoreState();


### PR DESCRIPTION
## Summary
- スコア内訳に「縮小カバー率（100%発動時）」と「縮小カバー率（期待値）」を追加
- 判定縮小スキルの持続時間計算を `sp_time`（特訓回数）から `value`（持続秒数）に修正
- 除外秒数の入力欄を追加し、曲の有効時間をユーザーが調整可能に
- センタースキル増加率をレアリティベースに変更

## 詳細
### 縮小カバー率
- **100%発動時**: 全発動を前提に時間区間マージでカバー秒数を算出
- **期待値**: 各発動の確率（per%）を考慮し、時間セグメントごとにP(少なくとも1つ発動中)を積分
- 複数枚の判定縮小カードの重複も正確に計算
- 除外秒数入力で有効時間を調整可能（デフォルト0秒）

### バグ修正
- 判定縮小スキルの持続時間に `sp_time`（特訓回数）を使用していた問題を `value`（持続秒数）に修正
- `calcMaxScore` と `runOnce`（MCシミュレーション）の両方を修正

## Test plan
- [ ] 判定縮小カードを含むデッキで縮小カバー率が表示されること
- [ ] 判定縮小カードなしのデッキでは行が非表示であること
- [ ] 除外秒数を変更すると即座に再計算されること
- [ ] MCシミュレーション結果が修正後の持続時間で計算されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)