### PR TITLE
feat: スコア計算を外部仕様書に整合化（バッジ可変/アシスト属性値段階/per-note floor/算術期待値）

### DIFF
--- a/docs/score_calc_spec.md
+++ b/docs/score_calc_spec.md
@@ -1,230 +1,439 @@
 # IDOLiSH7 スコア計算仕様書
 
-> 出典: https://ota-life.com/id7-score/
+> 本ドキュメントは `src/lib/score/` の実装をソース・オブ・トゥルースとして、
+> スコア計算の現行仕様を記述する。外部サイト
+> [オタライフ「スコア計算のやり方」](https://ota-life.com/id7-score/) の
+> 仕様と一部差分があるが、各項目で実装を採用した理由を明記する。
+
+## 0. 全体像
+
+スコア計算は **完全クライアントサイド** で実行される。ユーザー端末上で:
+
+1. **`computeTeam()`** — デッキ 6 枠からチーム属性値を計算
+2. **`flattenNotes()`** — 楽曲のノート情報を 1 次元の `FlatNote[]` に展開
+3. **`runSimulation()`** — モンテカルロシミュレーション（既定 5000 回）でスコア分布を算出
+4. **`calcExpectedScore()`** — 外部サイト準拠の算術期待値を算出（参考値）
+5. **`calcShrinkCoverage()`** — 判定縮小スキルのカバー率を算出
 
 ## 1. 属性システム
 
-ゲーム内の3属性。カードと楽曲の両方が属性値を持ち、ライブ中に背景色が3色に変化して各属性値に連動する。
-
 | 属性 | 色 |
 |------|------|
-| Shout | 赤 |
-| Beat | 緑 |
-| Melody | 青 |
+| Shout（シャウト） | 🔴 赤 |
+| Beat（ビート）   | 🟢 緑 |
+| Melody（メロディ） | 🔵 青 |
 
-## 2. ノーツの種類と計算基準
+カード・楽曲の両方が 3 属性の値を持ち、ライブ中に属性背景色が切り替わる。
+正規化ユーティリティは `normalizeAttribute()`（`types.ts`）。
 
-| ノーツ種別 | カウント基準 | 分類呼称 |
-|-----------|------------|---------|
-| 白ノーツ・緑ノーツ | 始点をカウント | 白ノーツ |
-| 赤ノーツ・青ノーツ | 終点をカウント | 色ノーツ |
+## 2. 定数リファレンス
 
-白ノーツ数の算出:
+### 2-1. ノーツ素点レート (`NOTE_RATE`)
 
-```
-コンボ数 − 色ノーツ数 = 白ノーツ数
-```
+| ノーツ種別 | レート |
+|-----------|--------|
+| 白・緑（始点） — `white` | 0.025（2.5%） |
+| 赤・青（終点） — `color` | 0.030（3.0%） |
 
-## 3. スコア計算手順
+### 2-2. ライト倍率 (`LIGHT_MULTIPLIER`)
 
-### ステップ 1: デッキ属性値の計算
+| ノートグループ | 倍率 | 意味 |
+|---------------|------|------|
+| `notes_20` | 1.0 | ライト点灯前の約20ノーツ |
+| `light_2`  | 1.0 | ライト2つ点灯 |
+| `light_3`  | 1.1 | ライト3つ点灯（+10%） |
+| `light_4`  | 1.2 | ライト4つ点灯（+20%） |
+| `light_5`  | 1.3 | ライト5つ点灯（+30%） |
+| `light_6`  | 1.5 | ライト6つ点灯（+50%） |
+| `chorus_light_5` | 2.6 | ライト5でサビ突入（稀） |
+| `chorus_light_6` | 3.0 | ライト6サビ（通常） |
 
-> 実装: `computeTeam()` — `src/lib/score/engine.ts:67-164`
+### 2-3. その他の定数
 
-デッキ 6 枠（センター / メンバー 1-4 / フレンド）のカード属性値を合算し、チーム属性値を算出する。
+| 定数 | 値 | 用途 |
+|------|-----|------|
+| `SHRINK_MULTIPLIER` | 1.6 | 縮小中ノーツの合計倍率（追加分 = 0.6） |
+| `SCOREUP_ASSIST_MULTIPLIER` | 1.2 | スコアアップアシスト倍率 |
+| `DEFAULT_SCOREUP_BADGE_RATE` | 15 | バッジ倍率のデフォルト（%） |
+| `MC_ITERATIONS` | 5000 | MC シミュレーション既定回数 |
+| `MC_CHUNK_SIZE` | 50 | UI 応答性のためのチャンクサイズ |
+| `CENTER_SKILL_RATES` | UR=10 / SSR=7 | センタースキル増加率（%） |
+| `DEFAULT_CENTER_SKILL_RATE` | 6 | SR/R/N 用デフォルト |
+| `EVENT_BONUS_MULTIPLIER` | none=1.0 / bronze=2.0 / silver=2.2 / gold=2.4 | 特効ランク倍率 |
 
-#### 1-1. カードごとの基本属性値
+## 3. チーム属性値計算 (`computeTeam`)
 
-各カードの特訓状態に応じて属性値を取得する。
+入力: `deck`（6枚）、ブローチ一覧、楽曲、特効ランク、特訓フラグ、選択ブローチ、共有ブローチ、スキルレベル、ラビットノート。
+実装: `engine.ts:61-205`。
 
-```
-特訓済み → shout_max / beat_max / melody_max
-未特訓   → shout_min / beat_min / melody_min
-```
-
-#### 1-2. 特効倍率の適用
-
-カードごとに選択された特効ランクの倍率を基本属性値に乗算する。**小数点以下四捨五入**。
-
-```
-属性値 = round(基本属性値 × 特効倍率)
-```
-
-| 特効ランク | 倍率 | 定数名 |
-|-----------|------|--------|
-| なし | × 1.0 | `none` |
-| 銅特効 | × 1.5 | `bronze` |
-| 銀特効（100%） | × 2.0 | `silver` |
-| 金特効（120%） | × 2.2 | `gold` |
-
-> 定数: `EVENT_BONUS_MULTIPLIER` — `src/lib/score/constants.ts`
-
-各カードの属性値を全枠分合算し `rawShout` / `rawBeat` / `rawMelody` を得る。
-
-#### 1-3. ブローチ加算
-
-スロット 0〜4（自デッキ 5 枠）のカードのみ、`cardID` で紐付けされたブローチの属性値を加算する。フレンド枠（スロット 5）にはブローチは適用されない。
+### 3-1. カード単位の基本属性値
 
 ```
-broachShoutTotal = Σ slot 0-4 のブローチ Shout 値
-broachBeatTotal  = Σ slot 0-4 のブローチ Beat 値
-broachMelodyTotal = Σ slot 0-4 のブローチ Melody 値
+特訓済み → baseShout = shout_max, baseBeat = beat_max, baseMelody = melody_max
+未特訓   → baseShout = shout_min, baseBeat = beat_min, baseMelody = melody_min
 ```
 
-#### 1-4. センタースキル加算
+### 3-2. ラビットノート加算 + 特効倍率
 
-センター（スロット 0）とフレンド（スロット 5）のカードの `ct_skill`（センタースキル文字列）を解析し、対象属性にボーナス率を加算する。
+ラビットノート（キャラ別の追加ボーナス）を先に加算し、特効倍率を掛けて **四捨五入**。
 
-> 実装: `parseCenterSkillRate()` — `src/lib/score/engine.ts:58-64`
+```
+s = round((baseShout  + rabbitNote.shout)  × bonusMult)
+b = round((baseBeat   + rabbitNote.beat)   × bonusMult)
+m = round((baseMelody + rabbitNote.melody) × bonusMult)
 
-| `ct_skill` キーワード | ボーナス率 |
-|----------------------|-----------|
-| 「かなり」を含む | 10% |
-| 「やや」を含む | 7% |
-| 「大きく」を含む | 6% |
-| 上記以外のテキスト | 10%（デフォルト） |
-| `ct_skill` が null | 0%（ボーナスなし） |
+rawShout += s   // 6 枠合計
+rawBeat  += b
+rawMelody += m
+```
 
-> 定数: `CENTER_SKILL_RATES` / `DEFAULT_CENTER_SKILL_RATE` — `src/lib/score/constants.ts`
+**特効ランク (`EVENT_BONUS_MULTIPLIER`)**:
 
-ボーナスの適用先はカードの属性（Shout / Beat / Melody）で決定される。センターとフレンドが同属性の場合、ボーナスは累積する。
+| ランク | bonusMult | 備考 |
+|--------|-----------|------|
+| `none`   | 1.0 | 特効なし |
+| `bronze` | 2.0 | 銅特効（100%） |
+| `silver` | 2.2 | 銀特効（120%） |
+| `gold`   | 2.4 | 金特効（140%） |
 
-#### 1-5. チーム属性値の最終計算
+> **外部サイトとの差分**: 外部サイトは 100%/120% の 2 種のみを記載。現行ゲームでは 140% (gold) 特効が存在するため、実装側を採用。
 
-特効適用済みの合算値とブローチ合算値を加算し、センタースキルボーナス率を乗算する。**小数点以下切り捨て**。
+### 3-3. ブローチ加算 (`resolveDeckBroachs`)
+
+UR カードのみがブローチを装備可能。ブローチ種類ごとに条件判定を行い、
+属性値加算（種類 9 以外）またはスコア直接加算（種類 9）を行う。
+
+**ブローチ種類 (`broachResolver.ts:12-20`)**:
+
+| 種類 | 名称 | 発動条件 | 効果 |
+|-----|------|--------|------|
+| 1 | `ATTRIBUTE_UP` | 常時 | Shout/Beat/Melody 加算 |
+| 4 | `GROUP` | 自デッキ（スロット 0-4）が全員同グループ | 属性値加算 |
+| 5 | `IDOL_ATTR_COUNT` | 指定アイドル×指定属性のカード枚数 ≥ `limit` | 属性値加算 |
+| 6 | `ATTRIBUTE_UP_LIMITED` | 常時（デッキ全体で最大 `limit` 枚まで発動） | 属性値加算 |
+| 7 | `ALL_ATTRIBUTES` | デッキ内に Shout/Beat/Melody 全て存在（デッキ内 `limit` 枚まで） | 属性値加算 |
+| 8 | `AUTO_ONLY` | オートモード限定（本シミュレータでは常に無効） | — |
+| 9 | `SCORE_UP` | `broach.song === song.song_name` | スコア直接加算 (`broachScoreBonus`) |
+
+**デッキ内上限 (`limit`)**: 種類 6/7 は同一デッキで上限枚数までしか発動しない。`resolveDeckBroachs` が先着順で `count` を消費する。
+
+### 3-4. 共有ブローチ加算
+
+共有ブローチは複数カード間で共有可能。属性条件付きの場合、対象属性のカード枚数に応じて効果が倍化する。
+
+```
+if (sharedBroach.targetAttribute) {
+  count = デッキ内で対象属性を持つカード枚数
+  bShout += sharedBroach.shout × count
+  bBeat  += sharedBroach.beat  × count
+  bMelody += sharedBroach.melody × count
+} else {
+  bShout += sharedBroach.shout
+  bBeat  += sharedBroach.beat
+  bMelody += sharedBroach.melody
+}
+```
+
+### 3-5. センター／フレンド ボーナス
+
+センター（スロット 0）とフレンド（スロット 5）のレアリティに応じて、各カードの属性に対応する属性値にボーナス率を加算する。
+
+```
+centerRate = getCenterSkillRate(deck[0].rarity)   // UR=10, SSR=7, 他=6
+friendRate = getCenterSkillRate(deck[5].rarity)
+
+shoutRate = (centerAttr === 'Shout' ? centerRate : 0) + (friendAttr === 'Shout' ? friendRate : 0)
+beatRate  = (centerAttr === 'Beat'  ? centerRate : 0) + (friendAttr === 'Beat'  ? friendRate : 0)
+melodyRate = (centerAttr === 'Melody' ? centerRate : 0) + (friendAttr === 'Melody' ? friendRate : 0)
+```
+
+> **外部サイトとの差分**: 外部サイトは `ct_skill` テキスト内のキーワード（「かなり」「やや」「大きく」）で判定。実装はレアリティ判定（UR は必ず「かなり(10%)」、SSR は必ず「やや(7%)」という対応関係をコードにしたもの）。結果の数値は同じ。
+
+### 3-6. チーム属性値（最終）— 切り捨て
 
 ```
 teamShout  = floor((rawShout  + broachShoutTotal)  × (100 + shoutRate)  / 100)
 teamBeat   = floor((rawBeat   + broachBeatTotal)   × (100 + beatRate)   / 100)
-teamMelody = floor((rawMelody + broachMelodyTotal)  × (100 + melodyRate) / 100)
+teamMelody = floor((rawMelody + broachMelodyTotal) × (100 + melodyRate) / 100)
 ```
 
-> 戻り値: `ComputedTeam` — `src/lib/score/types.ts:37-49`
+### 3-7. スコアアップアシスト適用済み属性値
 
-#### 補足: スコアアップアシスト（未実装）
-
-仕様上、属性値の 20% を加算するスコアアップアシスト機能が存在するが、現在の実装には含まれていない。
-
-### ステップ 2: ノーツ素点計算
-
-| ノーツ種別 | 計算式 |
-|-----------|--------|
-| 白ノーツ・緑ノーツ | 属性値 × 2.5% = 素点（小数点以下切り捨て） |
-| 赤ノーツ・青ノーツ | 属性値 × 3.0% = 素点（小数点以下切り捨て） |
-
-### ステップ 3: ボーナス倍率適用
-
-#### コンボボーナス（ライト点灯による加算）
-
-| ライト点灯数 | ボーナス | 倍率 |
-|-------------|---------|------|
-| 3つ目 | 10% UP | × 1.1 |
-| 4つ目 | 20% UP | × 1.2 |
-| 5つ目 | 30% UP | × 1.3 |
-| 6つ目 | 50% UP | × 1.5 |
-
-#### サビボーナス
-
-| 条件 | 倍率 |
-|------|------|
-| ライト6つ点灯後のサビ区間 | 素点 × 3.0 |
-| ライト5つでサビ突入（稀） | 素点 × 2.6 |
-
-**計算順序**: サビボーナス = コンボボーナス適用後のスコア × 2倍
-
-### ステップ 4: ノーツ数カウント
-
-#### お手本モードの特殊ルール
-
-1. **青ノーツ終点**（パーフェクトスライド）: 加点されず、白扱い
-2. **緑終点が赤のとき**: 加点されず、白扱い
-3. **赤と白の同時押し**: 状況により両方白または両方赤扱い
-
-#### カウント効率化
-
-区間ごとに色ノーツのみカウントし、白ノーツは以下で算出:
+アシスト ON 時に使用する属性値を属性値段階で計算し、**floor** しておく。
 
 ```
-コンボ数 − 色ノーツ数 = 白ノーツ数
+teamShoutAssisted  = floor(teamShout  × 1.2)
+teamBeatAssisted   = floor(teamBeat   × 1.2)
+teamMelodyAssisted = floor(teamMelody × 1.2)
 ```
 
-### ステップ 5: 属性値による楽曲スコア計算
+ノーツ計算側でアシスト ON かどうかに応じて `teamShout`（unassisted）か `teamShoutAssisted` を選択する。
+
+## 4. ノート展開 (`flattenNotes`)
+
+`noteFlattener.ts`。楽曲データの 8 ノートグループ × 3 属性 × 2 種別（白/色）を 1 次元の `FlatNote[]` に展開する。
 
 ```
-Σ（1ノーツあたりのスコア × 該当エリアのノーツ数）= 属性値による楽曲スコア
+for groupKey in [notes_20, light_2, light_3, light_4, light_5, light_6, chorus_light_5, chorus_light_6]:
+  for attr in [Shout, Beat, Melody]:
+    for type in [white, color]:
+      count = song[groupKey][`${attr}_${type}`]
+      notes.push(FlatNote × count)
+
+// Fisher-Yates シャッフル（XorShift128Plus, seed=42 固定）
 ```
 
-### ステップ 6: アピールスキル期待値計算
+ノートの発生タイミングは実ゲーム上の配置と同期しないため、シャッフルによる近似。シード固定でビルドごとに同一順序。
 
-#### スコアアップスキル（必須計算対象）
+## 5. ノーツスコアの計算（per-note floor）
 
-**コンボ・パーフェクト型:**
-
-```
-楽曲ノーツ数 ÷ 発動条件 × 発動率 × 加算値 = 期待値
-楽曲ノーツ数 ÷ 発動条件 × 加算値 = 理論最大値
-```
-
-**タイマー型:**
+1 ノーツあたりのスコアは以下の 2 段階で切り捨てる:
 
 ```
-楽曲秒数 ÷ 発動条件 × 発動率 × 加算値 = 期待値
-楽曲秒数 ÷ 発動条件 × 加算値 = 理論最大値
+appeal = assist ON 時は teamXxxAssisted、OFF 時は teamXxx
+
+素点      = floor(appeal × NOTE_RATE[type])            // 白 0.025 / 色 0.030
+ノーツ得点 = floor(素点 × LIGHT_MULTIPLIER[group])      // コンボ/サビ倍率
 ```
 
-#### 判定領域縮小スキル（必須計算対象）
+実装: `engine.ts:223-227` の `calcNoteScore()` に集約。`calcMinScore` / `calcMaxScore` / `runOnce` / `calcExpectedScore` のすべてが同じ計算式を使う。
 
-**コンボ・パーフェクト型:**
+> **外部サイトとの差分**: 実装は以前「合計後に 1 回だけ floor」していたが、これだと微小誤差が出るため各ノーツで per-note floor するよう改修した（外部サイト準拠）。
 
-```
-（楽曲ノーツ数 ÷ 発動条件 × 発動率 × 発動秒数）÷ 楽曲秒数 × 縮小倍率 × 属性値による楽曲スコア
-```
+## 6. 判定縮小スキル
 
-**タイマー型:**
+### 6-1. 縮小効果の適用ルール
 
-```
-（楽曲秒数 ÷ 発動条件 × 発動率 × 発動秒数）÷ 楽曲秒数 × 縮小倍率 × 属性値による楽曲スコア
-```
-
-#### 縮小スキル全発動時の簡易計算
+縮小中（任意の縮小スキルが発動中）のノーツは、**未アシスト** の素点を基準に追加スコアが加算される:
 
 ```
-属性値による楽曲スコア × 縮小倍率 = 縮小スコア
+shrinkExtra = (shrinkActive && group !== 'notes_20')
+  ? floor(ノーツ得点(unassisted) × (SHRINK_MULTIPLIER - 1.0))   // × 0.6
+  : 0
 ```
 
-#### スコアアップアシスト使用時
+- `SHRINK_MULTIPLIER = 1.6` → 追加分は 0.6 倍
+- `notes_20` グループは除外（外部サイトの「最初の約 20 ノーツには縮小がかからない」に対応）
+- 未アシスト基準で計算することで、外部サイトの `縮小スコア = 属性値楽曲スコア × 0.6 ÷ 1.2`（アシスト時）と等価
+
+### 6-2. 縮小持続時間
+
+縮小スキルの発動時間は **`skill.value`（秒）** で表される。カードデータの skill value 欄が秒数を意味する。
 
 ```
-属性値による楽曲スコア × 縮小倍率 ÷ 1.2 = 縮小スコア
+// 発動時点
+noteTime = n / N × songDuration
+endNote = min(floor((noteTime + skill.value) / songDuration × N), N)
+shrinkEndNotes[cardIdx] = max(shrinkEndNotes[cardIdx], endNote)
+
+// ノート走査時
+shrinkActive = ∃c: shrinkEndNotes[c] > n
 ```
 
-※ 縮小スコアにはスコアアップが適用されないため
+> コミット `ae53bb8` で誤用していた `sp_time`（特訓時間）から `skill.value` に修正済。
 
-#### 非計算対象スキル
-
-- 判定強化
-- 判定ガード
-- コンボ継続
-
-### ステップ 7: 最終スコア計算
-
-#### ライブ終了時スコア
+## 7. ノーツスコアの合計とバッジ適用
 
 ```
-属性値による楽曲スコア + スコアアップスキル期待値 + 判定領域縮小スキル期待値 = ライブ終了時スコア期待値
+total = Σ (ノーツ得点 + shrinkExtra + scoreUpSum)   // ノーツ順
+最終スコア = floor(total × badgeMult) + broachScoreBonus
+  where badgeMult = 1 + scoreUpBadgeRate / 100
 ```
 
-#### スコアアップバッジ適用
+`scoreUpBadgeRate` は `ScoreOptions` で渡される %（例: 15 なら ×1.15）。0 または未指定の場合はバッジなし（×1.0）。
+
+> **外部サイトとの差分**: 外部サイトが 14% などの例示値を使っていることに対応し、実装を「ON/OFF 15% 固定」から「任意数値」に変更した。
+
+## 8. モンテカルロシミュレーション (`runSimulation` / `runOnce`)
+
+### 8-1. 実装位置
+
+`engine.ts:500`（`runSimulation`）／ `engine.ts:405`（`runOnce`）。
+
+### 8-2. RNG
+
+`XorShift128Plus`（`rng.ts`）。`seed` を指定しない場合は `Date.now()`。
+試行間で RNG を継続使用し、決定論性（同シード=同結果）を保つ。
+
+### 8-3. `runOnce` の流れ
+
+1. **Phase 1 — タイマースキル**: 各発動機会で `rng.next() × 100 < skill.per` なら発動。区間 `[startNote, endNote)` に `skill.value` を `timerBonus[n]` として記録。
+2. **Phase 2 — ノート順処理**: 各ノートで:
+   - 通常スキル/縮小スキルのカウンタ判定 → 確率ロール → 発動処理
+   - 縮小アクティブ判定
+   - ノーツ得点・shrinkExtra・scoreUpSum を合算
+   - 縮小 extra を発動中カードで按分して `contributions[c]` に記録（寄与率可視化用）
+3. **最終スコア**: `floor(totalScore × badgeMult) + broachScoreBonus`
+
+### 8-4. `runSimulation` の流れ
+
+1. `calcMinScore` / `calcMaxScore` で理論下限・上限を先に求める
+2. `iterations` 回 `runOnce` を呼ぶ（`MC_CHUNK_SIZE=50` 毎に `setTimeout(0)` で UI に制御を戻す）
+3. 試行結果から `mean / median / stddev / p90 / mcMin / mcMax` を計算
+4. カード別スキル統計 `cardStats[]` を生成
+
+### 8-5. 返り値 `SimulationResult`
+
+| フィールド | 内容 |
+|-----------|------|
+| `minScore` / `maxScore` | 理論下限・上限（`calcMinScore` / `calcMaxScore`） |
+| `scores[]` | 全試行スコア |
+| `mean` / `median` / `stddev` / `p90` | 統計量（四捨五入） |
+| `mcMin` / `mcMax` | 試行中の実測最小・最大 |
+| `cardStats[]` | カード別スキル発動統計 |
+
+## 9. 算術期待値 (`calcExpectedScore`)
+
+外部サイト準拠の **単純期待値** を MC と併記して提供（`engine.ts:398`）。
+
+### 9-1. 属性値による楽曲スコア
+
+全ノートを per-note floor で合算（= スキル全不発時のスコア、バッジ未適用）:
 
 ```
-ライブ終了時スコア × バッジ倍率 = 最終リザルト
+baseScore          = Σ calcNoteScore(assisted appeal, note)
+baseScoreUnassisted = Σ calcNoteScore(unassisted appeal, note)
 ```
 
-例: バッジ 14% UP の場合 → × 1.14 倍
+### 9-2. スコアアップ期待値
 
-## 4. 特殊条件・注意事項
+通常スキル/タイマースキルそれぞれに適用:
 
-- 縮小スキル全発動時、最初の約 20 ノーツは縮小効果が適用されない
-- お手本モードと実プレイでスコア計算に若干の相違がある
-- 同時押し時のノーツスコアは 2 倍になる
-- 計算結果と実績の誤差許容範囲: 1,000 以内（例: 計算 160,253 vs 実績 159,608）
+```
+for 各 scoreUp/timerScoreUp スキル:
+  denom = isTimer ? songDuration : notesCount
+  scoreUpExpected += (denom / skill.count) × (skill.per / 100) × skill.value
+scoreUpExpected = floor(scoreUpExpected)
+```
+
+### 9-3. 判定縮小期待値
+
+```
+coverage = calcShrinkCoverage(team, notesCount, 0)
+shrinkExpected = floor(baseScoreUnassisted × (SHRINK_MULTIPLIER - 1.0) × coverage.expectedCoverageRate)
+```
+
+未アシスト基準を使うのは外部サイトの `÷1.2` 補正と等価。
+
+### 9-4. 最終値
+
+```
+liveEndScore = baseScore + scoreUpExpected + shrinkExpected
+finalScore   = floor(liveEndScore × badgeMult) + broachScoreBonus
+```
+
+## 10. 縮小カバー率 (`calcShrinkCoverage`)
+
+`engine.ts:229-308`。縮小スキルが楽曲のうちどれだけの秒数をカバーするかを返す。
+
+### 10-1. 発動区間の生成
+
+```
+for 各縮小カード:
+  prob = skill.per / 100
+  numActivations = floor(notesCount / skill.count)
+  for k = 1 .. numActivations:
+    noteIndex = k × skill.count - 1
+    activationTime = noteIndex / notesCount × songDuration
+    start = max(activationTime, offsetSeconds)
+    end   = min(activationTime + skill.value, songDuration)
+    intervals.push({start, end, prob})
+```
+
+### 10-2. 100% 発動カバー率（区間マージ）
+
+```
+intervals を start でソート → 隣接重複をマージ
+coveredSeconds = Σ (merged.end - merged.start)
+coverageRate  = coveredSeconds / effectiveSeconds
+```
+
+### 10-3. 期待カバー率（確率積分）
+
+```
+times = { 各 interval の start, end }
+for 各セグメント [segStart, segEnd]:
+  probNone = Π (1 - interval.prob)  // このセグメントを覆う全 interval
+  probActive = 1 - probNone
+  expectedCoveredSeconds += segLen × probActive
+expectedCoverageRate = expectedCoveredSeconds / effectiveSeconds
+```
+
+`effectiveSeconds = songDuration - offsetSeconds`。
+
+## 11. スキル種別マッピング
+
+`engine.ts:24-52` の `parseSkill()`:
+
+| `ap_skill_type` (カードデータ) | `skillType` | `isTimer` | `isShrink` | 動作 |
+|------------------------------|-------------|----------|-----------|------|
+| `スコアアップ（タイマー）` | `timerScoreUp` | true | false | 一定秒毎に発動、区間内のノーツに `value` 加算 |
+| `判定縮小スコアアップ` | `shrink` | false | true | N ノーツ毎に発動、`value` 秒間縮小効果 |
+| `MISS→Good` / `null` | — | — | — | シミュ対象外（除外） |
+| その他（スコアアップ） | `scoreUp` | false | false | N ノーツ毎に発動、ノートに `value` 加算 |
+
+スキルレベル 1〜5 は `getApSkillLevel(card, skillLevel)` で取得し、`count / per / value` が変化する。
+
+## 12. データ型リファレンス
+
+### 12-1. 主要型 (`types.ts`)
+
+| 型 | 用途 |
+|----|------|
+| `FlatNote` | 1 ノーツ `{ attribute, type, group }` |
+| `CardSkill` | スキル情報 `{ skillType, count, per, value, isTimer, isShrink, spTime }` |
+| `DeckCard` | デッキ内カード情報（属性値＋ブローチ＋スキル） |
+| `ComputedTeam` | チーム属性値（`Shout / ShoutAssisted` 等を含む） |
+| `SimulationResult` | MC 結果 |
+| `ExpectedScore` | 算術期待値 `{ baseScore, scoreUpExpected, shrinkExpected, liveEndScore, finalScore }` |
+| `ScoreOptions` | `{ scoreUpAssist, scoreUpBadgeRate? }` |
+| `CardSkillStats` | カード別スキル発動統計 |
+
+### 12-2. ScoreOptions
+
+```typescript
+interface ScoreOptions {
+  scoreUpAssist: boolean;     // true で属性値に ×1.2 → floor を適用
+  scoreUpBadgeRate?: number;  // % (例: 15 → ×1.15)、0 / 未指定 でバッジなし
+}
+```
+
+## 13. 注意事項・設計上の制約
+
+- ノート順序は実ゲームと同期しない（シャッフル seed=42 固定）
+- ブローチは **UR カードのみ** 装備可能（`broachResolver.ts:122`）
+- フレンド枠（スロット 5）のブローチも種類 9 以外は属性値加算として機能する
+- 種類 8 (`AUTO_ONLY`) ブローチはシミュレーション対象外
+- `notes_20` グループ（最初の約 20 ノーツ）は縮小スキル効果の対象外
+- 縮小持続時間は `skill.value`（秒）— `spTime` ではない
+- MC は試行間で RNG を継続使用。シード固定で結果再現可能。
+- 算術期待値と MC 平均は **ほぼ一致** するが、MC は確率的揺れを含むため厳密には異なる
+
+## 14. 外部サイトとの差分まとめ
+
+| 項目 | 外部サイト | 実装 | 採用理由 |
+|------|-----------|------|---------|
+| 特効ランク | 100% / 120% のみ | + 140% (gold) | ゲーム内に 140% 特効が存在 |
+| センター判定 | `ct_skill` キーワード | レアリティ | 数値は同じ、レアリティ対応関係が確定的 |
+| バッジ倍率 | 可変（例 14%） | 可変（数値入力） | 外部サイト準拠に変更済 |
+| アシスト適用位置 | 属性値に ×1.2 | 属性値に ×1.2 → floor | 外部サイト準拠に変更済 |
+| 丸め | 各ノーツで floor | per-note floor | 外部サイト準拠に変更済 |
+| 期待値算出 | 算術式 | MC + 算術併記 | 両方表示 |
+| ブローチ仕様 | 記載薄い | 種類別詳細 | ゲーム内仕様を実装 |
+| スキルレベル | 記載なし | 1〜5 選択可能 | ゲーム内機能 |
+| 共有ブローチ | 記載なし | 実装済 | ゲーム内機能 |
+| ラビットノート | 言及のみ | 実装済 | ゲーム内機能 |
+
+## 15. 関連ファイル
+
+| パス | 役割 |
+|------|-----|
+| `src/lib/score/engine.ts` | `computeTeam`, `runSimulation`, `calcMinScore`, `calcMaxScore`, `calcExpectedScore`, `calcShrinkCoverage`, `parseSkill`, `getCenterSkillRate` |
+| `src/lib/score/types.ts` | 型定義 |
+| `src/lib/score/constants.ts` | 定数 |
+| `src/lib/score/noteFlattener.ts` | `flattenNotes` |
+| `src/lib/score/rng.ts` | XorShift128Plus |
+| `src/lib/score/histogram.ts` | `renderHistogramSvg` |
+| `src/lib/score/broachResolver.ts` | `resolveDeckBroachs`, `calcBroachScoreBonus` |
+| `src/lib/data/eventBonusTiers.ts` | `EVENT_BONUS_MULTIPLIER` |
+| `src/pages/score-calc/index.astro` | スコア計算 UI |

--- a/src/lib/score/constants.ts
+++ b/src/lib/score/constants.ts
@@ -13,7 +13,8 @@ export const LIGHT_MULTIPLIER: Record<string, number> = {
 
 export const SHRINK_MULTIPLIER = 1.6;
 export const SCOREUP_ASSIST_MULTIPLIER = 1.2;
-export const SCOREUP_BADGE_RATE = 0.15;
+/** スコアアップバッジ倍率のデフォルト値（%）。UI 初期値として使用 */
+export const DEFAULT_SCOREUP_BADGE_RATE = 15;
 export const MC_ITERATIONS = 5000;
 export const MC_CHUNK_SIZE = 50;
 /** センタースキル増加率（レアリティ → 増加率%） */

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -6,16 +6,16 @@ import {
   normalizeAttribute,
   type AttributeName, type FlatNote, type CardSkill, type DeckCard,
   type ComputedTeam, type SimulationResult, type CardSkillStats, type ScoreOptions,
+  type ExpectedScore,
 } from './types';
 import {
   NOTE_RATE, LIGHT_MULTIPLIER, SHRINK_MULTIPLIER,
-  SCOREUP_ASSIST_MULTIPLIER, SCOREUP_BADGE_RATE,
+  SCOREUP_ASSIST_MULTIPLIER,
   MC_CHUNK_SIZE, CENTER_SKILL_RATES, DEFAULT_CENTER_SKILL_RATE,
   EVENT_BONUS_MULTIPLIER,
 } from './constants';
 import type { EventBonusTier } from './constants';
 import { XorShift128Plus } from './rng';
-import { flattenNotes } from './noteFlattener';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
 import { SHARED_BROACHS } from '../data/sharedBroachs';
 import type { RabbitNoteMap } from '../data/rabbitNote';
@@ -183,10 +183,18 @@ export function computeTeam(
   const teamBeat = Math.floor((rawBeat + broachBeatTotal) * (100 + beatRate) / 100);
   const teamMelody = Math.floor((rawMelody + broachMelodyTotal) * (100 + melodyRate) / 100);
 
+  // スコアアップアシスト適用済み属性値（属性値段階で ×1.2 して floor）
+  const teamShoutAssisted = Math.floor(teamShout * SCOREUP_ASSIST_MULTIPLIER);
+  const teamBeatAssisted = Math.floor(teamBeat * SCOREUP_ASSIST_MULTIPLIER);
+  const teamMelodyAssisted = Math.floor(teamMelody * SCOREUP_ASSIST_MULTIPLIER);
+
   return {
     Shout: teamShout,
     Beat: teamBeat,
     Melody: teamMelody,
+    ShoutAssisted: teamShoutAssisted,
+    BeatAssisted: teamBeatAssisted,
+    MelodyAssisted: teamMelodyAssisted,
     cards,
     songDuration: song.duration || 0,
     rawShout, rawBeat, rawMelody,
@@ -195,6 +203,27 @@ export function computeTeam(
     broachMelody: broachMelodyTotal,
     broachScoreBonus,
   };
+}
+
+/** ScoreOptions.scoreUpBadgeRate からバッジ倍率を計算 */
+function getBadgeMult(options?: ScoreOptions): number {
+  const rate = options?.scoreUpBadgeRate;
+  if (!rate || rate <= 0) return 1.0;
+  return 1 + rate / 100;
+}
+
+/** アシスト ON 時は適用済み、OFF 時は通常の属性値を返す */
+function getAppeal(team: ComputedTeam, attribute: AttributeName, assist: boolean): number {
+  if (!assist) return team[attribute];
+  return attribute === 'Shout' ? team.ShoutAssisted
+    : attribute === 'Beat' ? team.BeatAssisted
+    : team.MelodyAssisted;
+}
+
+/** 1 ノーツのスコアを計算（属性値 → 素点 floor → コンボ倍率 floor） */
+function calcNoteScore(appeal: number, note: FlatNote): number {
+  const rawNote = Math.floor(appeal * NOTE_RATE[note.type]);
+  return Math.floor(rawNote * LIGHT_MULTIPLIER[note.group]);
 }
 
 /** 縮小カバー率を計算する（100%発動 + 確率考慮の期待値） */
@@ -280,19 +309,20 @@ export function calcShrinkCoverage(team: ComputedTeam, notesCount: number, offse
 
 /** スキル全不発の最低スコア */
 export function calcMinScore(team: ComputedTeam, notes: FlatNote[], options?: ScoreOptions): number {
-  const assistMult = options?.scoreUpAssist ? SCOREUP_ASSIST_MULTIPLIER : 1.0;
-  const badgeMult = options?.scoreUpBadge ? (1 + SCOREUP_BADGE_RATE) : 1.0;
+  const assist = options?.scoreUpAssist ?? false;
+  const badgeMult = getBadgeMult(options);
   let total = 0;
   for (const note of notes) {
-    total += team[note.attribute] * NOTE_RATE[note.type] * LIGHT_MULTIPLIER[note.group] * assistMult;
+    const appeal = getAppeal(team, note.attribute, assist);
+    total += calcNoteScore(appeal, note);
   }
-  return Math.floor(Math.floor(total) * badgeMult) + team.broachScoreBonus;
+  return Math.floor(total * badgeMult) + team.broachScoreBonus;
 }
 
 /** スキル全発動の最高スコア */
 export function calcMaxScore(team: ComputedTeam, notes: FlatNote[], options?: ScoreOptions): number {
-  const assistMult = options?.scoreUpAssist ? SCOREUP_ASSIST_MULTIPLIER : 1.0;
-  const badgeMult = options?.scoreUpBadge ? (1 + SCOREUP_BADGE_RATE) : 1.0;
+  const assist = options?.scoreUpAssist ?? false;
+  const badgeMult = getBadgeMult(options);
   const N = notes.length;
 
   // タイマースキル: 全タイミングで必ず発動
@@ -348,13 +378,71 @@ export function calcMaxScore(team: ComputedTeam, notes: FlatNote[], options?: Sc
       if (shrinkEndNotes[c] > n) { shrinkActive = true; break; }
     }
 
-    const base = team[note.attribute] * NOTE_RATE[note.type] * LIGHT_MULTIPLIER[note.group];
-    const assistedBase = base * assistMult;
-    const shrinkExtra = (shrinkActive && note.group !== 'notes_20') ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
-    total += assistedBase + shrinkExtra + scoreUpSum;
+    // アシスト ON 時は適用済み属性値でノーツスコアを計算
+    const appeal = getAppeal(team, note.attribute, assist);
+    const noteScore = calcNoteScore(appeal, note);
+
+    // 縮小 extra は unassisted 属性値で計算（= 外部サイトの ÷1.2 補正と等価）
+    const appealUnassisted = team[note.attribute];
+    const noteScoreUnassisted = calcNoteScore(appealUnassisted, note);
+    const shrinkExtra = (shrinkActive && note.group !== 'notes_20')
+      ? Math.floor(noteScoreUnassisted * (SHRINK_MULTIPLIER - 1.0))
+      : 0;
+
+    total += noteScore + shrinkExtra + scoreUpSum;
   }
 
-  return Math.floor(Math.floor(total) * badgeMult) + team.broachScoreBonus;
+  return Math.floor(total * badgeMult) + team.broachScoreBonus;
+}
+
+/**
+ * 算術期待値によるスコア計算（外部サイト準拠の単純期待値）。
+ * - 属性値による楽曲スコア: スキル全不発時の素点合計（= calcMinScore のベース部分）
+ * - スコアアップ期待値: Σ( (タイマーなら songDuration, 通常なら notesCount) / count × per/100 × value )
+ * - 縮小期待値: baseScore(未アシスト) × (SHRINK_MULTIPLIER - 1) × expectedCoverageRate
+ */
+export function calcExpectedScore(
+  team: ComputedTeam,
+  notes: FlatNote[],
+  notesCount: number,
+  options?: ScoreOptions,
+): ExpectedScore {
+  const assist = options?.scoreUpAssist ?? false;
+  const badgeMult = getBadgeMult(options);
+
+  // 属性値による楽曲スコア（スキル全不発 = calcMinScore の broachScoreBonus・badgeMult 抜き）
+  let baseScore = 0;
+  let baseScoreUnassisted = 0;
+  for (const note of notes) {
+    baseScore += calcNoteScore(getAppeal(team, note.attribute, assist), note);
+    baseScoreUnassisted += calcNoteScore(team[note.attribute], note);
+  }
+
+  // スコアアップスキル期待値
+  let scoreUpExpected = 0;
+  for (const dc of team.cards) {
+    const skill = dc.skill;
+    if (!skill || skill.isShrink) continue;
+    if (skill.count <= 0) continue;
+    const denom = skill.isTimer ? team.songDuration : notesCount;
+    if (denom <= 0) continue;
+    scoreUpExpected += (denom / skill.count) * (skill.per / 100) * skill.value;
+  }
+  scoreUpExpected = Math.floor(scoreUpExpected);
+
+  // 縮小期待値: 未アシスト楽曲スコア × 縮小追加倍率 × 期待カバー率
+  let shrinkExpected = 0;
+  const coverage = calcShrinkCoverage(team, notesCount, 0);
+  if (coverage && coverage.effectiveSeconds > 0) {
+    shrinkExpected = Math.floor(
+      baseScoreUnassisted * (SHRINK_MULTIPLIER - 1.0) * coverage.expectedCoverageRate,
+    );
+  }
+
+  const liveEndScore = baseScore + scoreUpExpected + shrinkExpected;
+  const finalScore = Math.floor(liveEndScore * badgeMult) + team.broachScoreBonus;
+
+  return { baseScore, scoreUpExpected, shrinkExpected, liveEndScore, finalScore };
 }
 
 interface RunOnceResult {
@@ -365,8 +453,8 @@ interface RunOnceResult {
 
 /** MC 1回分の実行 */
 function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, options?: ScoreOptions): RunOnceResult {
-  const assistMult = options?.scoreUpAssist ? SCOREUP_ASSIST_MULTIPLIER : 1.0;
-  const badgeMult = options?.scoreUpBadge ? (1 + SCOREUP_BADGE_RATE) : 1.0;
+  const assist = options?.scoreUpAssist ?? false;
+  const badgeMult = getBadgeMult(options);
   const N = notes.length;
   const cardCount = team.cards.length;
   const activations = new Array<number>(cardCount).fill(0);
@@ -434,28 +522,37 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
       if (shrinkEndNotes[c] > n) { shrinkActive = true; break; }
     }
 
-    const base = team[note.attribute] * NOTE_RATE[note.type] * LIGHT_MULTIPLIER[note.group];
-    const assistedBase = base * assistMult;
-    const shrinkExtra = (shrinkActive && note.group !== 'notes_20') ? base * (SHRINK_MULTIPLIER - 1.0) : 0;
-    const noteScore = assistedBase + shrinkExtra + scoreUpSum;
-    totalScore += noteScore;
+    // アシスト ON 時は適用済み属性値でノーツスコアを計算（per-note floor）
+    const appeal = getAppeal(team, note.attribute, assist);
+    const noteScoreBase = calcNoteScore(appeal, note);
+
+    // 縮小 extra は unassisted 属性値で計算（= 外部サイトの ÷1.2 補正と等価）
+    const appealUnassisted = team[note.attribute];
+    const noteScoreUnassisted = calcNoteScore(appealUnassisted, note);
+    const shrinkExtra = (shrinkActive && note.group !== 'notes_20')
+      ? Math.floor(noteScoreUnassisted * (SHRINK_MULTIPLIER - 1.0))
+      : 0;
+
+    totalScore += noteScoreBase + shrinkExtra + scoreUpSum;
 
     // 判定縮小スキルのスコア寄与を発動中のカードに按分（notes_20は対象外）
-    if (shrinkActive && note.group !== 'notes_20') {
-      const extra = base * (SHRINK_MULTIPLIER - 1.0);
+    if (shrinkActive && note.group !== 'notes_20' && shrinkExtra > 0) {
       let activeShrinkCount = 0;
       for (let c = 0; c < cardCount; c++) {
         if (shrinkEndNotes[c] > n) activeShrinkCount++;
       }
-      for (let c = 0; c < cardCount; c++) {
-        if (shrinkEndNotes[c] > n) {
-          contributions[c] += extra / activeShrinkCount;
+      if (activeShrinkCount > 0) {
+        const share = shrinkExtra / activeShrinkCount;
+        for (let c = 0; c < cardCount; c++) {
+          if (shrinkEndNotes[c] > n) {
+            contributions[c] += share;
+          }
         }
       }
     }
   }
 
-  return { score: Math.floor(Math.floor(totalScore) * badgeMult) + team.broachScoreBonus, activations, contributions };
+  return { score: Math.floor(totalScore * badgeMult) + team.broachScoreBonus, activations, contributions };
 }
 
 /** MC シミュレーション実行（チャンク分割） */
@@ -504,7 +601,7 @@ export async function runSimulation(
   // カードごとのスキル発動統計
   const cardStats: CardSkillStats[] = team.cards
     .filter(dc => dc.skill && dc.skill.skillType !== 'none')
-    .map((dc, _, arr) => {
+    .map((dc) => {
       const c = team.cards.indexOf(dc);
       return {
         cardIndex: dc.slotIndex,

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -50,6 +50,10 @@ export interface ComputedTeam {
   Shout: number;
   Beat: number;
   Melody: number;
+  /** スコアアップアシスト適用済み属性値（floor(Shout × 1.2)） */
+  ShoutAssisted: number;
+  BeatAssisted: number;
+  MelodyAssisted: number;
   cards: DeckCard[];
   songDuration: number;
   rawShout: number;
@@ -76,7 +80,8 @@ export interface SimulationResult {
 
 export interface ScoreOptions {
   scoreUpAssist: boolean;
-  scoreUpBadge: boolean;
+  /** スコアアップバッジの倍率（%）。例: 15 → ×1.15。0 / undefined ならバッジなし */
+  scoreUpBadgeRate?: number;
 }
 
 export interface CardSkillStats {
@@ -86,4 +91,18 @@ export interface CardSkillStats {
   avgActivations: number;
   theoreticalRate: number;
   avgScoreContribution: number;
+}
+
+/** 算術期待値計算の結果（外部サイト準拠の単純期待値） */
+export interface ExpectedScore {
+  /** 属性値による楽曲スコア（スキル全不発時の素点合計） */
+  baseScore: number;
+  /** スコアアップスキル期待値の合計 */
+  scoreUpExpected: number;
+  /** 判定縮小スキル期待値 */
+  shrinkExpected: number;
+  /** ライブ終了時スコア（baseScore + scoreUpExpected + shrinkExpected） */
+  liveEndScore: number;
+  /** バッジ適用後の最終リザルト */
+  finalScore: number;
 }

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -78,8 +78,9 @@ const base = import.meta.env.BASE_URL;
             <span>SCOREUPアシスト（属性値×1.2）</span>
           </label>
           <label class="flex items-center gap-2">
-            <input type="checkbox" id="opt-scoreup-badge" class="rounded" />
-            <span>SCOREUPバッジ（最終スコア×1.15）</span>
+            <span class="w-48">SCOREUPバッジ倍率（%）</span>
+            <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 rounded px-2 py-1 text-sm" min="0" max="100" step="1" value="0" />
+            <span class="text-xs text-gray-500">0 で未装着、例: 15 → ×1.15</span>
           </label>
         </div>
         <div class="mt-3 pt-3 border-t">
@@ -155,6 +156,21 @@ const base = import.meta.env.BASE_URL;
           </tbody>
         </table>
         <div id="histogram-container" class="mt-4"></div>
+      </section>
+
+      <!-- 算術期待値（参考値） -->
+      <section id="expected-score" class="bg-white rounded-lg shadow p-4 hidden">
+        <h2 class="text-sm font-bold text-gray-700 mb-1">算術期待値（参考値）</h2>
+        <p class="text-[11px] text-gray-500 mb-3">外部サイト準拠の単純期待値（MC の確率的揺れを含まない決定論的な値）</p>
+        <table class="w-full text-sm">
+          <tbody>
+            <tr><td class="text-gray-500 py-1">属性値による楽曲スコア</td><td id="exp-base" class="text-right py-1"></td></tr>
+            <tr><td class="text-gray-500 py-1">スコアアップ期待値</td><td id="exp-scoreup" class="text-right py-1"></td></tr>
+            <tr><td class="text-gray-500 py-1">判定縮小期待値</td><td id="exp-shrink" class="text-right py-1"></td></tr>
+            <tr class="border-t"><td class="text-gray-500 py-1">ライブ終了時スコア</td><td id="exp-liveend" class="text-right py-1"></td></tr>
+            <tr><td class="text-gray-500 py-1 font-bold">最終リザルト</td><td id="exp-final" class="text-right py-1 font-bold"></td></tr>
+          </tbody>
+        </table>
       </section>
 
       <!-- スキル発動統計 -->
@@ -338,7 +354,7 @@ const base = import.meta.env.BASE_URL;
     import type { Song } from '../../lib/data/fetchSongsJson';
     import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
     import type { ComputedTeam, SimulationResult, ScoreOptions } from '../../lib/score/types';
-    import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, runSimulation, flattenNotes, getCenterSkillRate } from '../../lib/score/engine';
+    import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, calcExpectedScore, runSimulation, flattenNotes, getCenterSkillRate } from '../../lib/score/engine';
     import { resolveDeckBroachs, type ResolvedBroach } from '../../lib/score/broachResolver';
     import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER } from '../../lib/score/constants';
     import { EVENT_BONUS_TIERS, EVENT_BONUS_MULTIPLIER, BONUS_LABEL, BONUS_CLASS, ALL_SELECT_CLASSES } from '../../lib/data/eventBonusTiers';
@@ -920,6 +936,7 @@ const base = import.meta.env.BASE_URL;
         $('score-breakdown').classList.add('hidden');
         $('area-values-section').classList.add('hidden');
         $('mc-results').classList.add('hidden');
+        $('expected-score').classList.add('hidden');
         $('skill-stats').classList.add('hidden');
         $('shrink-coverage-row').classList.add('hidden');
         $('shrink-expected-row').classList.add('hidden');
@@ -989,7 +1006,7 @@ const base = import.meta.env.BASE_URL;
       // スコアオプション
       const scoreOptions: ScoreOptions = {
         scoreUpAssist: ($('opt-scoreup-assist') as HTMLInputElement).checked,
-        scoreUpBadge: ($('opt-scoreup-badge') as HTMLInputElement).checked,
+        scoreUpBadgeRate: parseFloat(($('opt-scoreup-badge-rate') as HTMLInputElement).value) || 0,
       };
 
       // 確定スコア
@@ -1006,6 +1023,7 @@ const base = import.meta.env.BASE_URL;
 
       // MC結果はリセット
       $('mc-results').classList.add('hidden');
+      $('expected-score').classList.add('hidden');
       $('skill-stats').classList.add('hidden');
       $('final-result').textContent = '---';
       simulationResult = null;
@@ -1085,7 +1103,7 @@ const base = import.meta.env.BASE_URL;
       // スコアオプション
       const scoreOptions: ScoreOptions = {
         scoreUpAssist: ($('opt-scoreup-assist') as HTMLInputElement).checked,
-        scoreUpBadge: ($('opt-scoreup-badge') as HTMLInputElement).checked,
+        scoreUpBadgeRate: parseFloat(($('opt-scoreup-badge-rate') as HTMLInputElement).value) || 0,
       };
 
       const result = await runSimulation(team, notes, iterations, (pct) => {
@@ -1112,6 +1130,15 @@ const base = import.meta.env.BASE_URL;
 
       // ヒストグラム
       $('histogram-container').innerHTML = renderHistogramSvg(result.scores, result.minScore, result.maxScore, result.mean);
+
+      // 算術期待値（外部サイト準拠）
+      const expected = calcExpectedScore(team, notes, selectedSong.notes_count || notes.length, scoreOptions);
+      $('expected-score').classList.remove('hidden');
+      $('exp-base').textContent = expected.baseScore.toLocaleString();
+      $('exp-scoreup').textContent = expected.scoreUpExpected.toLocaleString();
+      $('exp-shrink').textContent = expected.shrinkExpected.toLocaleString();
+      $('exp-liveend').textContent = expected.liveEndScore.toLocaleString();
+      $('exp-final').textContent = expected.finalScore.toLocaleString();
 
       // スキル発動統計
       if (result.cardStats.length > 0) {
@@ -1382,7 +1409,7 @@ const base = import.meta.env.BASE_URL;
 
       // スキルオプション変更時に再計算
       $('opt-scoreup-assist').addEventListener('change', recalculate);
-      $('opt-scoreup-badge').addEventListener('change', recalculate);
+      $('opt-scoreup-badge-rate').addEventListener('input', recalculate);
 
       // 縮小カバー率の除外秒数変更時に再計算
       $('shrink-offset-input').addEventListener('input', () => {


### PR DESCRIPTION
## Summary

外部仕様書 (https://ota-life.com/id7-score/) との乖離点を精査し、4 項目を実装へ反映した。

### 実装変更（乖離対応）

| 項目 | 変更内容 |
|------|---------|
| **バッジ倍率** | ON/OFF 固定 15% (×1.15) → 任意数値入力 (%)。0 で未装着 |
| **アシスト適用位置** | ノーツ素点に ×1.2 → 属性値段階で ×1.2 → floor（`ComputedTeam.ShoutAssisted` 等を新設） |
| **丸め方針** | 合計後 1 回 floor → 各ノーツで `floor(appeal × NOTE_RATE)` と `floor(素点 × LIGHT_MULTIPLIER)` の 2 段階 floor |
| **期待値算出** | MC のみ → MC + 算術期待値の両方表示（新関数 `calcExpectedScore`） |

### 実装が正しい（変更なし）

外部サイトと乖離していたが**実装が正しい**と判断した項目:

- 特効ランク（gold 140% は実装のみ → ゲーム内に存在）
- センター判定（レアリティベース）
- 縮小持続時間（`skill.value` を秒数として使用、ae53bb8 の修正を維持）
- `notes_20` グループ扱い
- ブローチ仕様（種類 1/4/5/6/7/8/9 の条件判定）
- スキルレベル 1〜5 選択
- 共有ブローチ・ラビットノート

### ドキュメント

`docs/score_calc_spec.md` を実装準拠で全面書き換え。外部サイト由来だった旧内容を削除し、計算フローを式付きで記載。外部サイトとの差分は末尾の比較表にまとめた。

## Test plan

- [x] `npm run build` 通過
- [x] `/score-calc` で初期表示確認（バッジ数値入力 UI）
- [x] MC 実行して「シミュレーション結果」と「算術期待値（参考値）」の両方が表示される
- [x] アシスト ON + バッジ 15% で値が妥当に変動
- [x] 縮小カバー率（100%発動・期待値）の両方表示維持
- [x] home / mycard / song-detail の E2E テスト通過（card-list/card-detail/song-list の失敗は本 PR 範囲外の既存不具合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)