### PR TITLE
feat: 判定縮小スコアアップを発動条件別に書き分け（Perfect/コンボ）

### DIFF
--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -95,12 +95,8 @@ export async function fetchCardsJson(): Promise<Card[]> {
     if (row.ap_skill_type === 'スコアアップ' && row.ap_skill_req) {
       row.ap_skill_type = `スコアアップ（${row.ap_skill_req}）`;
     }
-    // 判定縮小系も発動条件を括弧付きで表示（例: 判定縮小（Perfect）、判定縮小（コンボ））
-    // タイマー系は実態が MISS→Perfect 変換で縮小挙動ではないため対象外（スプレッドシートの表記揺れ）
-    if (
-      row.ap_skill_type === '判定縮小スコアアップ' &&
-      (row.ap_skill_req === 'Perfect' || row.ap_skill_req === 'コンボ')
-    ) {
+    // 判定縮小系も発動条件を括弧付きで表示（例: 判定縮小（Perfect）、判定縮小（コンボ）、判定縮小（タイマー））
+    if (row.ap_skill_type === '判定縮小スコアアップ' && row.ap_skill_req) {
       row.ap_skill_type = `判定縮小（${row.ap_skill_req}）`;
     }
     // groupname が null の場合、キャラクター名からグループを解決

--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -95,6 +95,14 @@ export async function fetchCardsJson(): Promise<Card[]> {
     if (row.ap_skill_type === 'スコアアップ' && row.ap_skill_req) {
       row.ap_skill_type = `スコアアップ（${row.ap_skill_req}）`;
     }
+    // 判定縮小系も発動条件を括弧付きで表示（例: 判定縮小（Perfect）、判定縮小（コンボ））
+    // タイマー系は実態が MISS→Perfect 変換で縮小挙動ではないため対象外（スプレッドシートの表記揺れ）
+    if (
+      row.ap_skill_type === '判定縮小スコアアップ' &&
+      (row.ap_skill_req === 'Perfect' || row.ap_skill_req === 'コンボ')
+    ) {
+      row.ap_skill_type = `判定縮小（${row.ap_skill_req}）`;
+    }
     // groupname が null の場合、キャラクター名からグループを解決
     if (!row.groupname && row.name) {
       for (const group of CHARACTER_GROUPS) {

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -33,7 +33,7 @@ function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5
   if (count == null || per == null) return null;
 
   const isTimer = type === 'スコアアップ（タイマー）';
-  const isShrink = type === '判定縮小スコアアップ';
+  const isShrink = type === '判定縮小スコアアップ' || type.startsWith('判定縮小（');
 
   let skillType: CardSkill['skillType'] = 'scoreUp';
   if (isTimer) skillType = 'timerScoreUp';
@@ -42,6 +42,7 @@ function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5
   return {
     cardIndex: slotIndex,
     skillType,
+    originalType: type,
     count: count || 0,
     per: per || 0,
     value: value || 0,
@@ -606,9 +607,11 @@ export async function runSimulation(
       return {
         cardIndex: dc.slotIndex,
         cardname: dc.cardname,
-        skillType: dc.skill!.skillType === 'timerScoreUp' ? 'スコアアップ（タイマー）'
+        skillType: dc.skill!.originalType ?? (
+          dc.skill!.skillType === 'timerScoreUp' ? 'スコアアップ（タイマー）'
           : dc.skill!.isShrink ? '判定縮小スコアアップ'
-          : 'スコアアップ',
+          : 'スコアアップ'
+        ),
         avgActivations: totalActivations[c] / iterations,
         theoreticalRate: dc.skill!.per,
         avgScoreContribution: totalContributions[c] / iterations,

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -20,6 +20,8 @@ export interface FlatNote {
 export interface CardSkill {
   cardIndex: number;
   skillType: 'scoreUp' | 'timerScoreUp' | 'shrink' | 'none';
+  /** 表示用スキル種別（正規化後の ap_skill_type をそのまま保持） */
+  originalType: string | null;
   count: number;
   per: number;
   value: number;

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -384,7 +384,7 @@ const base = import.meta.env.BASE_URL;
       if (skillType === 'スコアアップ（タイマー）') {
         return `${c}秒毎に${p}％の確率でスコア${v}UP`;
       }
-      if (skillType === '判定縮小スコアアップ') {
+      if (skillType === '判定縮小スコアアップ' || skillType.startsWith('判定縮小（')) {
         if (sl.rate == null) return '-';
         const mult = sl.rate >= 10 ? sl.rate / 100 : sl.rate;
         return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -387,6 +387,9 @@ const base = import.meta.env.BASE_URL;
       if (skillType === '判定縮小スコアアップ' || skillType.startsWith('判定縮小（')) {
         if (sl.rate == null) return '-';
         const mult = sl.rate >= 10 ? sl.rate / 100 : sl.rate;
+        if (skillType === '判定縮小（タイマー）') {
+          return `${c}秒毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
+        }
         return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
       }
       if (skillType.startsWith('スコアアップ（')) {


### PR DESCRIPTION
## Summary

- カード詳細画面とスコア計算画面で「判定縮小スコアアップ」を `ap_skill_req` に応じて **判定縮小（Perfect）** / **判定縮小（コンボ）** / **判定縮小（タイマー）** と書き分け
- タイマー req の場合、効果文は `{count}秒毎に…` として表示（ノート数ではなく秒数が発動間隔のため）

## 内訳

| 正規化後タイプ | 件数 |
|---|---|
| 判定縮小（Perfect） | 80 |
| 判定縮小（コンボ） | 5 |
| 判定縮小（タイマー） | 50 |

## 変更内容

- `src/lib/data/fetchCardsJson.ts`: 正規化ロジック追加（req が設定されている全ての判定縮小カードを対象）
- `src/lib/score/engine.ts`: `isShrink` 検出を prefix 対応に更新、`CardSkill.originalType` で正規化後表記を保持
- `src/lib/score/types.ts`: `CardSkill` に `originalType` フィールド追加
- `src/pages/score-calc/index.astro`: `formatSkillEffect` の判定縮小分岐でタイマー req は秒毎に、それ以外は回毎にを使用

## Test plan

- [x] `npm run build` 成功
- [x] カード詳細画面で `判定縮小（Perfect）`（card ID 3662）/ `判定縮小（コンボ）`（card ID 1357）/ `判定縮小（タイマー）`（card ID 190）が表示されることを確認
- [x] スコア計算の card-data に 3 バリアントが正しく区別されていることを確認（80/5/50）
- [x] 既存の判定縮小スコア計算（shrink 判定・×1.6 倍率）がリグレッションなく動作することを確認（isShrink 判定が全タイプで true）

🤖 Generated with [Claude Code](https://claude.com/claude-code)