### PR TITLE
feat: BAD以上をPerfectに変更スキルの効果文を文章化

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -392,6 +392,12 @@ const base = import.meta.env.BASE_URL;
         }
         return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
       }
+      if (skillType === 'BAD以上をPerfectに変更') {
+        if (req === 'タイマー') {
+          return `${c}秒毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
+        }
+        return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
+      }
       if (skillType.startsWith('スコアアップ（')) {
         return `${req ?? ''}${c}回毎に${p}％の確率でスコア${v}UP`;
       }


### PR DESCRIPTION
## Summary

- スコア計算のカード詳細「効果」列で、`BAD以上をPerfectに変更` スキル（439件）を自然文で表示
- 参考サイト [i7.step-on-dream.net](https://i7.step-on-dream.net/card.php?ID=3414) のスキル行表記と文字単位で一致

## 文章テンプレート

| req | テンプレート | 実例 |
|---|---|---|
| Perfect / コンボ | `{req}{count}回毎に{per}％の確率で{value}秒間BAD以上をPerfectに` | `Perfect15回毎に50％の確率で5秒間BAD以上をPerfectに` (card ID 3414) |
| タイマー | `{count}秒毎に{per}％の確率で{value}秒間BAD以上をPerfectに` | — |

## 内訳

| req | 件数 |
|---|---|
| Perfect | 162 |
| コンボ | 179 |
| タイマー | 98 |

## Test plan

- [x] `npm run build` 成功
- [x] card ID 3414 (10th Anniversary 四葉環, req=Perfect) で `Perfect15回毎に50％の確率で5秒間BAD以上をPerfectに` が表示されることを確認
- [x] req=コンボ / タイマー のカードも適切な文面（0回/0秒…）が生成されることを確認（古いカードは Lv5 データ未登録のため値は 0）
- [x] 既存のスコアアップ系・判定縮小系スキルがリグレッションなく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)