### PR TITLE
feat: カード詳細画面のAPスキルパネルも効果文を文章化

### DIFF
--- a/src/lib/score/skillFormatter.ts
+++ b/src/lib/score/skillFormatter.ts
@@ -1,0 +1,37 @@
+import type { ApSkillLevel } from '../data/fetchCardsJson';
+
+/**
+ * スキル種別・発動条件・レベル別数値から自然文の効果表示を生成する。
+ * 非公式DB (i7.step-on-dream.net) のスキル行表記と一致する文面を返す。
+ */
+export function formatSkillEffect(
+  skillType: string | null,
+  req: string | null,
+  sl: ApSkillLevel,
+): string {
+  if (!skillType || sl.count == null || sl.per == null || sl.value == null) return '-';
+  const c = sl.count;
+  const p = sl.per;
+  const v = sl.value;
+  if (skillType === 'スコアアップ（タイマー）') {
+    return `${c}秒毎に${p}％の確率でスコア${v}UP`;
+  }
+  if (skillType === '判定縮小スコアアップ' || skillType.startsWith('判定縮小（')) {
+    if (sl.rate == null) return '-';
+    const mult = sl.rate >= 10 ? sl.rate / 100 : sl.rate;
+    if (skillType === '判定縮小（タイマー）') {
+      return `${c}秒毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
+    }
+    return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
+  }
+  if (skillType === 'BAD以上をPerfectに変更') {
+    if (req === 'タイマー') {
+      return `${c}秒毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
+    }
+    return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
+  }
+  if (skillType.startsWith('スコアアップ（')) {
+    return `${req ?? ''}${c}回毎に${p}％の確率でスコア${v}UP`;
+  }
+  return '-';
+}

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -4,6 +4,7 @@ import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
 import { CARD_IMAGE_BASE_URL, ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
 import { attrDonutSvg } from '../../lib/donutChart';
+import { formatSkillEffect } from '../../lib/score/skillFormatter';
 
 export async function getStaticPaths() {
   const [cards, broachs] = await Promise.all([fetchCardsJson(), fetchFixedBroachsJson()]);
@@ -155,21 +156,15 @@ const otherSkills = [
           <table class="w-full text-sm">
             <thead>
               <tr class="bg-gray-50 text-left">
-                <th class="px-3 py-2">Lv</th>
-                <th class="px-3 py-2">発動回数</th>
-                <th class="px-3 py-2">発動確率</th>
-                <th class="px-3 py-2">効果値</th>
-                <th class="px-3 py-2">効果率</th>
+                <th class="px-3 py-2 w-16">Lv</th>
+                <th class="px-3 py-2">効果</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
               {apSkillLevels.map(lv => (
                 <tr>
                   <td class="px-3 py-2">Lv{lv.lv}</td>
-                  <td class="px-3 py-2">{lv.count ?? '-'}</td>
-                  <td class="px-3 py-2">{lv.per != null ? lv.per + '%' : '-'}</td>
-                  <td class="px-3 py-2">{lv.value ?? '-'}</td>
-                  <td class="px-3 py-2">{lv.rate ?? '-'}</td>
+                  <td class="px-3 py-2">{formatSkillEffect(card.ap_skill_type, card.ap_skill_req, { count: lv.count, per: lv.per, value: lv.value, rate: lv.rate })}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -348,6 +348,7 @@ const base = import.meta.env.BASE_URL;
 
   <script>
     import { getApSkillLevel, type Card } from '../../lib/data/fetchCardsJson';
+    import { formatSkillEffect } from '../../lib/score/skillFormatter';
     import type { Song } from '../../lib/data/fetchSongsJson';
     import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
     import type { ComputedTeam, SimulationResult, ScoreOptions } from '../../lib/score/types';
@@ -370,39 +371,6 @@ const base = import.meta.env.BASE_URL;
     let allBroachs: FixedBroach[] = JSON.parse(document.getElementById('broach-data')!.textContent!);
 
     const $ = (id: string) => document.getElementById(id)!;
-
-    /** スキル種別・発動条件・レベル別数値から表示文を生成 */
-    function formatSkillEffect(
-      skillType: string | null,
-      req: string | null,
-      sl: { count: number | null; per: number | null; value: number | null; rate: number | null }
-    ): string {
-      if (!skillType || sl.count == null || sl.per == null || sl.value == null) return '-';
-      const c = sl.count;
-      const p = sl.per;
-      const v = sl.value;
-      if (skillType === 'スコアアップ（タイマー）') {
-        return `${c}秒毎に${p}％の確率でスコア${v}UP`;
-      }
-      if (skillType === '判定縮小スコアアップ' || skillType.startsWith('判定縮小（')) {
-        if (sl.rate == null) return '-';
-        const mult = sl.rate >= 10 ? sl.rate / 100 : sl.rate;
-        if (skillType === '判定縮小（タイマー）') {
-          return `${c}秒毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
-        }
-        return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
-      }
-      if (skillType === 'BAD以上をPerfectに変更') {
-        if (req === 'タイマー') {
-          return `${c}秒毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
-        }
-        return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
-      }
-      if (skillType.startsWith('スコアアップ（')) {
-        return `${req ?? ''}${c}回毎に${p}％の確率でスコア${v}UP`;
-      }
-      return '-';
-    }
 
     // --- 状態 ---
     let selectedSong: Song | null = null;


### PR DESCRIPTION
## Summary

カード詳細画面 (`src/pages/cards/[id].astro`) のAPスキルテーブルを、スコア計算画面と同じロジックで各レベル1文の自然文に統合:

**Before**: Lv / 発動回数 / 発動確率 / 効果値 / 効果率 の5列
**After**: Lv / 効果 の2列

| Lv | 効果 |
|---|---|
| Lv1 | Perfect26回毎に36％の確率で4秒間判定領域を縮小してスコアを1.2倍に |
| Lv5 | Perfect22回毎に40％の確率で5秒間判定領域を縮小してスコアを1.6倍に |

## 変更内容

- `src/lib/score/skillFormatter.ts` を新設し、`formatSkillEffect` 関数を共有モジュール化
- `src/pages/score-calc/index.astro`: 既存の inline 関数を削除し、共有モジュールを import
- `src/pages/cards/[id].astro`: 共有モジュールを import し、APスキルテーブルを2列に簡素化

## Test plan

- [x] `npm run build` 成功
- [x] card ID 3662 (判定縮小（Perfect）) の全5レベルが参考サイトと一致することを確認
- [x] card ID 3414 (BAD以上をPerfectに変更) の全5レベルが参考サイトと一致することを確認
- [x] スコア計算画面のカード詳細表示が共有モジュール経由でリグレッションなく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)