### PR TITLE
feat: グローバルフッターにクレジット表記を追加

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,6 +62,9 @@ const base = import.meta.env.BASE_URL;
     <main class="flex-1 max-w-7xl mx-auto px-4 py-6 w-full">
       <slot />
     </main>
+    <footer class="text-xs text-gray-500 text-center py-3 px-4">
+      Special thanks to <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a> and <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a> / created by <a href="https://x.com/yo4raw_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@yo4raw_i7</a>
+    </footer>
     <script>
       const toggle = document.getElementById('menu-toggle');
       const mobileNav = document.getElementById('mobile-nav');


### PR DESCRIPTION
## Summary
- 全ページ共通の `BaseLayout.astro` にグローバルフッターを追加
- 協力者（@megoonarite, @miyaaaaaki_i7）と作者（@yo4raw_i7）へのクレジットを x.com リンク付きで表記
- スタイルは控えめ（`text-xs text-gray-500`）で目立たないよう配置

## Test plan
- [x] `npm run build` 成功を確認
- [x] ローカルプレビューでホーム／カード一覧画面にフッターが表示されることを確認
- [x] 3つの @ ハンドルが `https://x.com/*` にリンクされていることを accessibility snapshot で検証
- [x] `target="_blank"` で新規タブ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)