### PR TITLE
feat: フッター右端にリリースバージョンを表示

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.resolve-ref.outputs.ref }}
+          fetch-tags: true
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { execSync } from 'node:child_process';
 import '../styles/global.css';
 
 interface Props {
@@ -7,6 +8,14 @@ interface Props {
 
 const { title } = Astro.props;
 const base = import.meta.env.BASE_URL;
+
+let version = 'dev';
+try {
+  version = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim();
+} catch {
+  // git 未使用環境やタグ不在時はフォールバック
+}
+const repoUrl = 'https://github.com/yo4raw/i7';
 ---
 
 <!doctype html>
@@ -62,8 +71,11 @@ const base = import.meta.env.BASE_URL;
     <main class="flex-1 max-w-7xl mx-auto px-4 py-6 w-full">
       <slot />
     </main>
-    <footer class="text-xs text-gray-500 text-center py-3 px-4">
-      Special thanks to <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a> and <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a> / created by <a href="https://x.com/yo4raw_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@yo4raw_i7</a>
+    <footer class="text-xs text-gray-500 py-3 px-4 flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
+      <span class="text-center">
+        Special thanks to <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a> and <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a> / created by <a href="https://x.com/yo4raw_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@yo4raw_i7</a>
+      </span>
+      <a href={`${repoUrl}/releases/tag/${version}`} target="_blank" rel="noopener noreferrer" class="ml-auto text-gray-400 hover:text-indigo-600 hover:underline">{version}</a>
     </footer>
     <script>
       const toggle = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- フッター右端に現在のリリースバージョン（例: `v1.7.14`）を表示
- GitHub の該当リリースページへのリンクを付与
- ビルド時に `git describe --tags --abbrev=0` で取得
- CI / deploy の `actions/checkout` に `fetch-tags: true` / `fetch-depth: 0` を追加（タグを確実に取得するため）

## Test plan
- [x] ローカルビルド成功・フッターに `v1.7.14` 表示確認
- [x] リンクが `https://github.com/yo4raw/i7/releases/tag/v1.7.14` を指すこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)