### PR TITLE
refactor: 共通化のための storage / ui ユーティリティを抽出

### DIFF
--- a/src/lib/cardListRenderer.ts
+++ b/src/lib/cardListRenderer.ts
@@ -7,6 +7,7 @@
  */
 
 import { RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTR_BG, ATTR_BG_HOVER, ATTR_HEX } from './constants';
+import { ATTR_TEXT_CLASS } from './ui';
 import { attrDonutSvg } from './donutChart';
 
 // --- 設定 ---
@@ -37,14 +38,14 @@ export interface CardListItem {
 
 // --- localStorage 所持数管理 ---
 
-const STORAGE_KEY = 'i7_card_counts';
+import { STORAGE_KEYS, loadJson, saveJson } from './storage';
 
 export function loadCounts(): Record<string, number> {
-  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+  return loadJson<Record<string, number>>(STORAGE_KEYS.CARD_COUNTS, {});
 }
 
 export function saveCounts(counts: Record<string, number>) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(counts));
+  saveJson(STORAGE_KEYS.CARD_COUNTS, counts);
 }
 
 export function getCount(cardId: number): number {
@@ -166,9 +167,9 @@ export function renderMobileCard(card: CardListItem, opts: RenderOptions = {}): 
         <div class="flex items-center gap-2 mt-1">
           ${statsPie(card.shout_max || 0, card.beat_max || 0, card.melody_max || 0)}
           <div class="flex gap-2 text-xs">
-            <span class="text-red-500">S:${card.shout_max || 0} <span class="text-gray-400">${pct.sPct}%</span></span>
-            <span class="text-green-500">B:${card.beat_max || 0} <span class="text-gray-400">${pct.bPct}%</span></span>
-            <span class="text-blue-500">M:${card.melody_max || 0} <span class="text-gray-400">${pct.mPct}%</span></span>
+            <span class="${ATTR_TEXT_CLASS.Shout}">S:${card.shout_max || 0} <span class="text-gray-400">${pct.sPct}%</span></span>
+            <span class="${ATTR_TEXT_CLASS.Beat}">B:${card.beat_max || 0} <span class="text-gray-400">${pct.bPct}%</span></span>
+            <span class="${ATTR_TEXT_CLASS.Melody}">M:${card.melody_max || 0} <span class="text-gray-400">${pct.mPct}%</span></span>
           </div>
         </div>
       </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,13 @@ export const ATTRIBUTE_MAP: Record<number, string> = {
   3: 'Melody',
 };
 
+/** 属性キーと表示名のペア。ノート集計などでループ処理するとき用 */
+export const ATTRS = [
+  { key: 'shout', name: 'Shout' },
+  { key: 'beat', name: 'Beat' },
+  { key: 'melody', name: 'Melody' },
+] as const;
+
 /** 属性色: 属性名キー */
 export const ATTR_HEX: Record<string, string> = {
   Shout: '#ef4444', Beat: '#22c55e', Melody: '#3b82f6',

--- a/src/lib/data/fetchCardsJson.ts
+++ b/src/lib/data/fetchCardsJson.ts
@@ -70,10 +70,21 @@ export interface Card {
 
 const CARDS_GID = 480354522;
 
+/** 正規化後の ap_skill_type の識別子。マジック文字列の集約ポイント */
+export const SKILL_TYPE = {
+  MISS_TO_GOOD: 'MISS→Good',
+  SCOREUP_TIMER: 'スコアアップ（タイマー）',
+  SCOREUP_PREFIX: 'スコアアップ（',
+  SHRINK: '判定縮小スコアアップ',
+  SHRINK_PREFIX: '判定縮小（',
+  SHRINK_TIMER: '判定縮小（タイマー）',
+  BAD_TO_PERFECT: 'BAD以上をPerfectに変更',
+} as const;
+
 /** ap_skill_type の表記揺れを正規化するマップ */
 const SKILL_TYPE_NORMALIZE: Record<string, string> = {
-  'MISS→GOOD': 'MISS→Good',
-  '判定領域を': '判定縮小スコアアップ',
+  'MISS→GOOD': SKILL_TYPE.MISS_TO_GOOD,
+  '判定領域を': SKILL_TYPE.SHRINK,
 };
 
 const MIN_EXPECTED_CARDS = 100;
@@ -96,8 +107,8 @@ export async function fetchCardsJson(): Promise<Card[]> {
       row.ap_skill_type = `スコアアップ（${row.ap_skill_req}）`;
     }
     // 判定縮小系も発動条件を括弧付きで表示（例: 判定縮小（Perfect）、判定縮小（コンボ）、判定縮小（タイマー））
-    if (row.ap_skill_type === '判定縮小スコアアップ' && row.ap_skill_req) {
-      row.ap_skill_type = `判定縮小（${row.ap_skill_req}）`;
+    if (row.ap_skill_type === SKILL_TYPE.SHRINK && row.ap_skill_req) {
+      row.ap_skill_type = `${SKILL_TYPE.SHRINK_PREFIX}${row.ap_skill_req}）`;
     }
     // groupname が null の場合、キャラクター名からグループを解決
     if (!row.groupname && row.name) {

--- a/src/lib/data/rabbitNote.ts
+++ b/src/lib/data/rabbitNote.ts
@@ -1,3 +1,5 @@
+import { STORAGE_KEYS, loadJson, saveJson } from '../storage';
+
 export interface RabbitNoteEntry {
   shout: number;
   beat: number;
@@ -7,12 +9,10 @@ export interface RabbitNoteEntry {
 /** キャラクター名 → { shout, beat, melody } */
 export type RabbitNoteMap = Record<string, RabbitNoteEntry>;
 
-const STORAGE_KEY = 'i7_rabbit_notes';
-
 export function loadRabbitNotes(): RabbitNoteMap {
-  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+  return loadJson<RabbitNoteMap>(STORAGE_KEYS.RABBIT_NOTES, {});
 }
 
 export function saveRabbitNotes(notes: RabbitNoteMap): void {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(notes)); } catch {}
+  saveJson(STORAGE_KEYS.RABBIT_NOTES, notes);
 }

--- a/src/lib/data/sharedBroachs.ts
+++ b/src/lib/data/sharedBroachs.ts
@@ -1,3 +1,5 @@
+import type { AttributeName } from '../score/types';
+
 export interface SharedBroach {
   id: number;
   name: string;
@@ -5,7 +7,7 @@ export interface SharedBroach {
   beat: number;
   melody: number;
   /** 設定時、カードの属性がこれと一致する場合のみ効果が発動する */
-  targetAttribute?: 'Shout' | 'Beat' | 'Melody';
+  targetAttribute?: AttributeName;
 }
 
 export const SHARED_BROACHS: SharedBroach[] = [

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -17,13 +17,14 @@ import {
 import type { EventBonusTier } from './constants';
 import { XorShift128Plus } from './rng';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
+import { SKILL_TYPE } from '../data/fetchCardsJson';
 import { SHARED_BROACHS } from '../data/sharedBroachs';
 import type { RabbitNoteMap } from '../data/rabbitNote';
 
 /** カードからスキル情報を解析する */
 function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5 = 5): CardSkill | null {
   const type = card.ap_skill_type;
-  if (!type || type === 'MISS→Good') return null;
+  if (!type || type === SKILL_TYPE.MISS_TO_GOOD) return null;
 
   const sl = getApSkillLevel(card, skillLevel);
   const count = sl.count;
@@ -32,8 +33,8 @@ function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 | 4 | 5
 
   if (count == null || per == null) return null;
 
-  const isTimer = type === 'スコアアップ（タイマー）';
-  const isShrink = type === '判定縮小スコアアップ' || type.startsWith('判定縮小（');
+  const isTimer = type === SKILL_TYPE.SCOREUP_TIMER;
+  const isShrink = type === SKILL_TYPE.SHRINK || type.startsWith(SKILL_TYPE.SHRINK_PREFIX);
 
   let skillType: CardSkill['skillType'] = 'scoreUp';
   if (isTimer) skillType = 'timerScoreUp';
@@ -609,8 +610,8 @@ export async function runSimulation(
         cardIndex: dc.slotIndex,
         cardname: dc.cardname,
         skillType: dc.skill!.originalType ?? (
-          dc.skill!.skillType === 'timerScoreUp' ? 'スコアアップ（タイマー）'
-          : dc.skill!.isShrink ? '判定縮小スコアアップ'
+          dc.skill!.skillType === 'timerScoreUp' ? SKILL_TYPE.SCOREUP_TIMER
+          : dc.skill!.isShrink ? SKILL_TYPE.SHRINK
           : 'スコアアップ'
         ),
         avgActivations: totalActivations[c] / iterations,

--- a/src/lib/score/noteFlattener.ts
+++ b/src/lib/score/noteFlattener.ts
@@ -1,13 +1,8 @@
 import type { Song, SongNoteGroup } from '../data/fetchSongsJson';
-import type { FlatNote, AttributeName } from './types';
+import type { FlatNote } from './types';
+import { ATTRS } from '../constants';
 import { LIGHT_MULTIPLIER } from './constants';
 import { XorShift128Plus } from './rng';
-
-const ATTRS: { key: 'shout' | 'beat' | 'melody'; name: AttributeName }[] = [
-  { key: 'shout', name: 'Shout' },
-  { key: 'beat', name: 'Beat' },
-  { key: 'melody', name: 'Melody' },
-];
 
 const TYPES: { suffix: 'white' | 'color'; type: 'white' | 'color' }[] = [
   { suffix: 'white', type: 'white' },

--- a/src/lib/score/skillFormatter.ts
+++ b/src/lib/score/skillFormatter.ts
@@ -1,4 +1,5 @@
 import type { ApSkillLevel } from '../data/fetchCardsJson';
+import { SKILL_TYPE } from '../data/fetchCardsJson';
 
 /**
  * スキル種別・発動条件・レベル別数値から自然文の効果表示を生成する。
@@ -13,24 +14,24 @@ export function formatSkillEffect(
   const c = sl.count;
   const p = sl.per;
   const v = sl.value;
-  if (skillType === 'スコアアップ（タイマー）') {
+  if (skillType === SKILL_TYPE.SCOREUP_TIMER) {
     return `${c}秒毎に${p}％の確率でスコア${v}UP`;
   }
-  if (skillType === '判定縮小スコアアップ' || skillType.startsWith('判定縮小（')) {
+  if (skillType === SKILL_TYPE.SHRINK || skillType.startsWith(SKILL_TYPE.SHRINK_PREFIX)) {
     if (sl.rate == null) return '-';
     const mult = sl.rate >= 10 ? sl.rate / 100 : sl.rate;
-    if (skillType === '判定縮小（タイマー）') {
+    if (skillType === SKILL_TYPE.SHRINK_TIMER) {
       return `${c}秒毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
     }
     return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間判定領域を縮小してスコアを${mult}倍に`;
   }
-  if (skillType === 'BAD以上をPerfectに変更') {
+  if (skillType === SKILL_TYPE.BAD_TO_PERFECT) {
     if (req === 'タイマー') {
       return `${c}秒毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
     }
     return `${req ?? ''}${c}回毎に${p}％の確率で${v}秒間BAD以上をPerfectに`;
   }
-  if (skillType.startsWith('スコアアップ（')) {
+  if (skillType.startsWith(SKILL_TYPE.SCOREUP_PREFIX)) {
     return `${req ?? ''}${c}回毎に${p}％の確率でスコア${v}UP`;
   }
   return '-';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,32 @@
+/**
+ * localStorage JSON ヘルパ
+ *
+ * JSON.parse / JSON.stringify を try/catch でラップし、
+ * パース失敗・quota 超過・プライベートモード等で例外が飛ぶのを防ぐ。
+ */
+
+export const STORAGE_KEYS = {
+  CARD_COUNTS: 'i7_card_counts',
+  RABBIT_NOTES: 'i7_rabbit_notes',
+  SELECTED_SONGS: 'i7_selected_songs',
+  SAVED_DECKS: 'i7_saved_decks',
+  SCORE_CALC_STATE: 'i7_score_calc_state',
+} as const;
+
+export function loadJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveJson(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota 超過 / プライベートモード等は無視
+  }
+}

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,0 +1,35 @@
+/**
+ * UI 共通ヘルパ
+ *
+ * 画像 URL 組み立て・星表示・属性テキストクラスなど、
+ * ページ間で重複しがちな DOM 文字列生成を集約する。
+ */
+
+import { CARD_IMAGE_BASE_URL, CARD_THUMB_BASE_URL, SONG_IMAGE_BASE_URL } from './constants';
+import type { AttributeName } from './score/types';
+
+/** 属性の Tailwind テキスト色クラス (`text-red-500` etc.) */
+export const ATTR_TEXT_CLASS: Record<AttributeName, string> = {
+  Shout: 'text-red-500',
+  Beat: 'text-green-500',
+  Melody: 'text-blue-500',
+};
+
+export function cardImageUrl(id: number | string): string {
+  return `${CARD_IMAGE_BASE_URL}/${id}.png`;
+}
+
+export function cardThumbUrl(id: number | string): string {
+  return `${CARD_THUMB_BASE_URL}/${id}.png`;
+}
+
+export function songImageUrl(id: number | string): string {
+  return `${SONG_IMAGE_BASE_URL}/${id}.png`;
+}
+
+/** 星 n 個 + 空星 (5-n) 個を文字列で返す。n が falsy なら空文字 */
+export function starsText(n: number | null | undefined): string {
+  if (!n) return '';
+  const filled = Math.max(0, Math.min(5, n));
+  return '★'.repeat(filled) + '☆'.repeat(5 - filled);
+}

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -2,7 +2,8 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
-import { CARD_IMAGE_BASE_URL, ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
+import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
+import { ATTR_TEXT_CLASS, cardImageUrl } from '../../lib/ui';
 import { attrDonutSvg } from '../../lib/donutChart';
 import { formatSkillEffect } from '../../lib/score/skillFormatter';
 
@@ -62,7 +63,7 @@ const otherSkills = [
   </div>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
     <div class="md:col-span-1">
-      <img src={`${CARD_IMAGE_BASE_URL}/${card.ID}.png`} alt={card.cardname || ''}
+      <img src={cardImageUrl(card.ID)} alt={card.cardname || ''}
            class="w-full rounded-lg shadow-md bg-gray-200"
            loading="lazy"
            onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 280%22><rect width=%22200%22 height=%22280%22 fill=%22%23e5e7eb%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 fill=%22%239ca3af%22 font-size=%2216%22>No Image</text></svg>'" />
@@ -184,9 +185,9 @@ const otherSkills = [
           <div class="border rounded p-3">
             <p class="font-medium">{b.card_name || ''} - {b.name || ''}</p>
             <div class="flex gap-4 mt-2 text-sm">
-              <span class="text-red-500">Shout: {b.shout ?? '-'}</span>
-              <span class="text-blue-500">Beat: {b.beat ?? '-'}</span>
-              <span class="text-green-500">Melody: {b.melody ?? '-'}</span>
+              <span class={ATTR_TEXT_CLASS.Shout}>Shout: {b.shout ?? '-'}</span>
+              <span class={ATTR_TEXT_CLASS.Beat}>Beat: {b.beat ?? '-'}</span>
+              <span class={ATTR_TEXT_CLASS.Melody}>Melody: {b.melody ?? '-'}</span>
             </div>
             {b.condition && <p class="text-xs text-gray-500 mt-1">条件: {b.condition}{b.group ? `（${b.group}）` : ''}</p>}
           </div>

--- a/src/pages/decks/index.astro
+++ b/src/pages/decks/index.astro
@@ -32,14 +32,15 @@ const base = import.meta.env.BASE_URL;
   <script>
     import type { Card } from '../../lib/data/fetchCardsJson';
     import type { Song } from '../../lib/data/fetchSongsJson';
-    import { RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTRIBUTE_MAP } from '../../lib/constants';
+    import { RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
+    import { normalizeAttribute } from '../../lib/score/types';
+    import { STORAGE_KEYS, loadJson, saveJson } from '../../lib/storage';
+    import { cardThumbUrl } from '../../lib/ui';
 
     const allCards: Card[] = JSON.parse(document.getElementById('card-data')!.textContent!);
     const allSongs: Song[] = JSON.parse(document.getElementById('song-data')!.textContent!);
-    const thumbUrl = (window as any).__CARD_THUMB_BASE_URL__ || '';
     const base = (window as any).__BASE_URL__ || '/';
 
-    const SAVED_DECKS_KEY = 'i7_saved_decks';
     const SLOT_LABELS = ['センター', 'メンバー1', 'メンバー2', 'メンバー3', 'メンバー4', 'フレンド'];
     const DISPLAY_ORDER = [1, 2, 0, 3, 4, 5];
 
@@ -59,18 +60,11 @@ const base = import.meta.env.BASE_URL;
     }
 
     function loadSavedDecks(): SavedDeck[] {
-      try { return JSON.parse(localStorage.getItem(SAVED_DECKS_KEY) || '[]'); } catch { return []; }
+      return loadJson<SavedDeck[]>(STORAGE_KEYS.SAVED_DECKS, []);
     }
 
     function writeSavedDecks(decks: SavedDeck[]) {
-      try { localStorage.setItem(SAVED_DECKS_KEY, JSON.stringify(decks)); } catch {}
-    }
-
-    function normalizeAttr(attr: string | number | null): string {
-      if (typeof attr === 'number') return ATTRIBUTE_MAP[attr] || 'Shout';
-      const num = Number(attr);
-      if (!isNaN(num) && ATTRIBUTE_MAP[num]) return ATTRIBUTE_MAP[num];
-      return attr as string || 'Shout';
+      saveJson(STORAGE_KEYS.SAVED_DECKS, decks);
     }
 
     function render() {
@@ -111,13 +105,13 @@ const base = import.meta.env.BASE_URL;
             </div>`;
           }
 
-          const attr = normalizeAttr(card.attribute);
+          const attr = normalizeAttribute(card.attribute);
           const rarityClass = RARITY_BADGE_CLASSES[card.rarity || ''] || 'bg-gray-300';
           const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300';
 
           return `<div class="flex flex-col items-center">
             <div class="text-[9px] ${labelClass} mb-0.5">${label}</div>
-            <img src="${thumbUrl}/${card.ID}.png" alt="" class="w-10 h-auto rounded"
+            <img src="${cardThumbUrl(card.ID!)}" alt="" class="w-10 h-auto rounded"
               onerror="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 67%22><rect width=%2248%22 height=%2267%22 fill=%22%23e5e7eb%22/></svg>'" loading="lazy" />
             <div class="flex gap-0.5 mt-0.5">
               <span class="px-0.5 py-px text-[7px] font-bold text-white rounded ${rarityClass}">${card.rarity || '?'}</span>
@@ -174,7 +168,7 @@ const base = import.meta.env.BASE_URL;
       const decks = loadSavedDecks();
       const target = decks.find(d => d.id === deckId);
       if (!target) return;
-      try { localStorage.setItem('i7_score_calc_state', JSON.stringify(target.state)); } catch {}
+      saveJson(STORAGE_KEYS.SCORE_CALC_STATE, target.state);
       window.location.href = base + 'score-calc/';
     }
 

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -4,6 +4,7 @@ import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
 import { CARD_THUMB_BASE_URL } from '../../lib/constants';
+import { ATTR_TEXT_CLASS } from '../../lib/ui';
 
 const [allCards, allSongsRaw, allBroachs] = await Promise.all([
   fetchCardsJson(),
@@ -62,9 +63,9 @@ const base = import.meta.env.BASE_URL;
             </tr>
           </thead>
           <tbody>
-            <tr><td class="py-1 text-red-500 font-medium">Shout</td><td id="area-s-white" class="text-right py-1"></td><td id="area-s-color" class="text-right py-1"></td><td id="area-s-total" class="text-right py-1 font-bold"></td></tr>
-            <tr><td class="py-1 text-green-500 font-medium">Beat</td><td id="area-b-white" class="text-right py-1"></td><td id="area-b-color" class="text-right py-1"></td><td id="area-b-total" class="text-right py-1 font-bold"></td></tr>
-            <tr><td class="py-1 text-blue-500 font-medium">Melody</td><td id="area-m-white" class="text-right py-1"></td><td id="area-m-color" class="text-right py-1"></td><td id="area-m-total" class="text-right py-1 font-bold"></td></tr>
+            <tr><td class={`py-1 ${ATTR_TEXT_CLASS.Shout} font-medium`}>Shout</td><td id="area-s-white" class="text-right py-1"></td><td id="area-s-color" class="text-right py-1"></td><td id="area-s-total" class="text-right py-1 font-bold"></td></tr>
+            <tr><td class={`py-1 ${ATTR_TEXT_CLASS.Beat} font-medium`}>Beat</td><td id="area-b-white" class="text-right py-1"></td><td id="area-b-color" class="text-right py-1"></td><td id="area-b-total" class="text-right py-1 font-bold"></td></tr>
+            <tr><td class={`py-1 ${ATTR_TEXT_CLASS.Melody} font-medium`}>Melody</td><td id="area-m-white" class="text-right py-1"></td><td id="area-m-color" class="text-right py-1"></td><td id="area-m-total" class="text-right py-1 font-bold"></td></tr>
           </tbody>
         </table>
       </section>
@@ -102,13 +103,13 @@ const base = import.meta.env.BASE_URL;
             <tr><td class="text-gray-500 py-1">ブローチ加算</td><td id="stat-broach" class="text-right py-1 font-medium"></td></tr>
             <tr id="stat-broach-score-row" class="hidden"><td class="text-gray-500 py-1">ブローチスコア加算</td><td id="stat-broach-score" class="text-right py-1 font-medium text-purple-600"></td></tr>
             <tr><td class="text-gray-500 py-1">センター/フレンドボーナス</td><td id="stat-bonus" class="text-right py-1 font-medium"></td></tr>
-            <tr id="stat-bonus-s-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Shout <span id="stat-bonus-s-rate" class="text-gray-400"></span></td><td id="stat-bonus-s" class="text-right py-1 text-red-500 text-xs"></td></tr>
-            <tr id="stat-bonus-b-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Beat <span id="stat-bonus-b-rate" class="text-gray-400"></span></td><td id="stat-bonus-b" class="text-right py-1 text-green-500 text-xs"></td></tr>
-            <tr id="stat-bonus-m-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Melody <span id="stat-bonus-m-rate" class="text-gray-400"></span></td><td id="stat-bonus-m" class="text-right py-1 text-blue-500 text-xs"></td></tr>
+            <tr id="stat-bonus-s-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Shout <span id="stat-bonus-s-rate" class="text-gray-400"></span></td><td id="stat-bonus-s" class={`text-right py-1 ${ATTR_TEXT_CLASS.Shout} text-xs`}></td></tr>
+            <tr id="stat-bonus-b-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Beat <span id="stat-bonus-b-rate" class="text-gray-400"></span></td><td id="stat-bonus-b" class={`text-right py-1 ${ATTR_TEXT_CLASS.Beat} text-xs`}></td></tr>
+            <tr id="stat-bonus-m-row" class="hidden"><td class="text-gray-500 py-1 pl-4 text-xs">Melody <span id="stat-bonus-m-rate" class="text-gray-400"></span></td><td id="stat-bonus-m" class={`text-right py-1 ${ATTR_TEXT_CLASS.Melody} text-xs`}></td></tr>
             <tr class="border-t"><td class="text-gray-500 py-1 font-medium">チームアピール合計</td><td id="stat-team-total" class="text-right py-1 font-bold"></td></tr>
-            <tr><td class="text-gray-500 py-1 pl-2">Shout</td><td id="stat-team-s" class="text-right py-1 text-red-500"></td></tr>
-            <tr><td class="text-gray-500 py-1 pl-2">Beat</td><td id="stat-team-b" class="text-right py-1 text-green-500"></td></tr>
-            <tr><td class="text-gray-500 py-1 pl-2">Melody</td><td id="stat-team-m" class="text-right py-1 text-blue-500"></td></tr>
+            <tr><td class="text-gray-500 py-1 pl-2">Shout</td><td id="stat-team-s" class={`text-right py-1 ${ATTR_TEXT_CLASS.Shout}`}></td></tr>
+            <tr><td class="text-gray-500 py-1 pl-2">Beat</td><td id="stat-team-b" class={`text-right py-1 ${ATTR_TEXT_CLASS.Beat}`}></td></tr>
+            <tr><td class="text-gray-500 py-1 pl-2">Melody</td><td id="stat-team-m" class={`text-right py-1 ${ATTR_TEXT_CLASS.Melody}`}></td></tr>
           </tbody>
         </table>
         <div class="mt-4 border-t pt-3">
@@ -263,9 +264,9 @@ const base = import.meta.env.BASE_URL;
                 <th class="text-left py-1 px-1">カード名</th>
                 <th class="text-center py-1 px-1">特訓</th>
                 <th class="text-center py-1 px-1">特効</th>
-                <th class="text-right py-1 px-1 text-red-500">Shout</th>
-                <th class="text-right py-1 px-1 text-green-500">Beat</th>
-                <th class="text-right py-1 px-1 text-blue-500">Melody</th>
+                <th class={`text-right py-1 px-1 ${ATTR_TEXT_CLASS.Shout}`}>Shout</th>
+                <th class={`text-right py-1 px-1 ${ATTR_TEXT_CLASS.Beat}`}>Beat</th>
+                <th class={`text-right py-1 px-1 ${ATTR_TEXT_CLASS.Melody}`}>Melody</th>
                 <th class="text-right py-1 px-1">ブローチS</th>
                 <th class="text-right py-1 px-1">ブローチB</th>
                 <th class="text-right py-1 px-1">ブローチM</th>
@@ -359,12 +360,13 @@ const base = import.meta.env.BASE_URL;
     import type { EventBonusTier } from '../../lib/data/eventBonusTiers';
     import { renderHistogramSvg } from '../../lib/score/histogram';
     import { attrDonutSvg } from '../../lib/donutChart';
-    import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTRIBUTE_MAP } from '../../lib/constants';
+    import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
+    import { normalizeAttribute } from '../../lib/score/types';
+    import { STORAGE_KEYS, loadJson, saveJson } from '../../lib/storage';
+    import { ATTR_TEXT_CLASS, cardThumbUrl } from '../../lib/ui';
     import { SHARED_BROACHS } from '../../lib/data/sharedBroachs';
     import { loadCounts } from '../../lib/cardListRenderer';
     import { loadRabbitNotes } from '../../lib/data/rabbitNote';
-
-    const thumbUrl = (window as any).__CARD_THUMB_BASE_URL__ || '';
 
     let allCards: Card[] = JSON.parse(document.getElementById('card-data')!.textContent!);
     let allSongs: Song[] = JSON.parse(document.getElementById('song-data')!.textContent!);
@@ -386,14 +388,6 @@ const base = import.meta.env.BASE_URL;
     // カード詳細テーブルの表示順（メンバー1, メンバー2, センター, メンバー3, メンバー4, フレンド）
     const DISPLAY_ORDER = [1, 2, 0, 3, 4, 5];
 
-    // --- 属性正規化 ---
-    function normalizeAttr(attr: string | number | null): string {
-      if (typeof attr === 'number') return ATTRIBUTE_MAP[attr] || 'Shout';
-      const num = Number(attr);
-      if (!isNaN(num) && ATTRIBUTE_MAP[num]) return ATTRIBUTE_MAP[num];
-      return attr as string || 'Shout';
-    }
-
     // --- 共有ブローチバリデーション ---
     function validateSharedBroachs(slotIndex: number) {
       const card = deck[slotIndex];
@@ -407,14 +401,8 @@ const base = import.meta.env.BASE_URL;
     }
 
     // --- 楽曲選択 ---
-    const SELECTED_SONGS_KEY = 'i7_selected_songs';
-
     function getSelectedSongIds(): Set<number> {
-      try {
-        const raw = localStorage.getItem(SELECTED_SONGS_KEY);
-        if (raw) return new Set(JSON.parse(raw));
-      } catch {}
-      return new Set();
+      return new Set(loadJson<number[]>(STORAGE_KEYS.SELECTED_SONGS, []));
     }
 
     function rebuildSongSelect() {
@@ -530,7 +518,7 @@ const base = import.meta.env.BASE_URL;
           continue;
         }
 
-        const attr = normalizeAttr(card.attribute);
+        const attr = normalizeAttribute(card.attribute);
         const attrColor = ATTR_HEX[attr] || '#6b7280';
         const rarityClass = RARITY_BADGE_CLASSES[card.rarity || ''] || 'bg-gray-300';
         const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300';
@@ -605,7 +593,7 @@ const base = import.meta.env.BASE_URL;
         container.className = 'slot-content border-2 border-solid rounded-lg p-1.5 flex flex-col items-center cursor-pointer min-h-[120px] transition-colors';
         container.style.borderColor = attrColor;
         container.innerHTML = `
-          <img src="${thumbUrl}/${card.ID}.png" alt="" class="w-full max-w-[60px] h-auto rounded mb-1"
+          <img src="${cardThumbUrl(card.ID!)}" alt="" class="w-full max-w-[60px] h-auto rounded mb-1"
             onerror="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 67%22><rect width=%2248%22 height=%2267%22 fill=%22%23e5e7eb%22/></svg>'" loading="lazy" />
           <div class="flex gap-0.5 mb-1">
             <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded ${rarityClass}">${card.rarity || '?'}</span>
@@ -714,7 +702,7 @@ const base = import.meta.env.BASE_URL;
       const attrCounts: Record<string, number> = { Shout: 0, Beat: 0, Melody: 0 };
       for (const c of deck) {
         if (!c) continue;
-        const a = normalizeAttr(c.attribute);
+        const a = normalizeAttribute(c.attribute);
         if (a in attrCounts) attrCounts[a]++;
       }
 
@@ -724,7 +712,7 @@ const base = import.meta.env.BASE_URL;
       const rows = DISPLAY_ORDER.map(i => {
         const card = deck[i];
         if (!card) return '';
-        const attr = normalizeAttr(card.attribute);
+        const attr = normalizeAttribute(card.attribute);
         const slotBroachs = resolvedMap.get(i) ?? [];
         const activeBroachs = slotBroachs.filter(rb => rb.active && rb.broach.broach_type !== 9);
         let bS = activeBroachs.reduce((s, rb) => s + (rb.broach.shout || 0) * (rb.multiplier ?? 1), 0);
@@ -774,9 +762,9 @@ const base = import.meta.env.BASE_URL;
           </td>
           <td class="py-1 px-1 text-center ${trainedClass}">${trainedLabel}</td>
           <td class="py-1 px-1 text-center ${bonusClass}">${bonusLabel}</td>
-          <td class="py-1 px-1 text-right text-red-500">${statShout.toLocaleString()}</td>
-          <td class="py-1 px-1 text-right text-green-500">${statBeat.toLocaleString()}</td>
-          <td class="py-1 px-1 text-right text-blue-500">${statMelody.toLocaleString()}</td>
+          <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${statShout.toLocaleString()}</td>
+          <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${statBeat.toLocaleString()}</td>
+          <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${statMelody.toLocaleString()}</td>
           <td class="py-1 px-1 text-right">${bS || '-'}</td>
           <td class="py-1 px-1 text-right">${bB || '-'}</td>
           <td class="py-1 px-1 text-right">${bM || '-'}</td>
@@ -791,8 +779,8 @@ const base = import.meta.env.BASE_URL;
       const friendCard = deck[5];
       const centerRate = centerCard ? getCenterSkillRate(centerCard.rarity) : 0;
       const friendRate = friendCard ? getCenterSkillRate(friendCard.rarity) : 0;
-      const centerAttr = centerCard ? normalizeAttr(centerCard.attribute) : null;
-      const friendAttr = friendCard ? normalizeAttr(friendCard.attribute) : null;
+      const centerAttr = centerCard ? normalizeAttribute(centerCard.attribute) : null;
+      const friendAttr = friendCard ? normalizeAttribute(friendCard.attribute) : null;
 
       let shoutRate = 0, beatRate = 0, melodyRate = 0;
       if (centerAttr === 'Shout') shoutRate += centerRate;
@@ -817,9 +805,9 @@ const base = import.meta.env.BASE_URL;
 
       $('card-detail-foot').innerHTML = `<tr class="border-t-2 border-gray-300 font-bold text-xs">
         <td colspan="4" class="py-1 px-1 text-right text-gray-700">合計</td>
-        <td class="py-1 px-1 text-right text-red-500">${totalShout.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right text-green-500">${totalBeat.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right text-blue-500">${totalMelody.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${totalShout.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${totalBeat.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${totalMelody.toLocaleString()}</td>
         <td class="py-1 px-1 text-right">${totalBS || '-'}</td>
         <td class="py-1 px-1 text-right">${totalBB || '-'}</td>
         <td class="py-1 px-1 text-right">${totalBM || '-'}</td>
@@ -877,7 +865,7 @@ const base = import.meta.env.BASE_URL;
           if (!name.includes(text) && !charName.includes(text)) return false;
         }
         if (rarity && card.rarity !== rarity) return false;
-        if (attribute && normalizeAttr(card.attribute) !== attribute) return false;
+        if (attribute && normalizeAttribute(card.attribute) !== attribute) return false;
         return true;
       });
 
@@ -887,13 +875,13 @@ const base = import.meta.env.BASE_URL;
       $('modal-result-count').textContent = `${filtered.length}件`;
 
       const html = filtered.slice(0, 200).map(card => {
-        const attr = normalizeAttr(card.attribute);
+        const attr = normalizeAttribute(card.attribute);
         const rarityClass = RARITY_BADGE_CLASSES[card.rarity || ''] || 'bg-gray-300';
         const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300';
         const total = (card.shout_max || 0) + (card.beat_max || 0) + (card.melody_max || 0);
 
         return `<div class="flex items-center gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer border-b border-gray-100" data-pick-card="${card.ID}">
-          <img src="${thumbUrl}/${card.ID}.png" alt="" class="w-10 h-auto rounded flex-shrink-0"
+          <img src="${cardThumbUrl(card.ID!)}" alt="" class="w-10 h-auto rounded flex-shrink-0"
             onerror="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 67%22><rect width=%2248%22 height=%2267%22 fill=%22%23e5e7eb%22/></svg>'" loading="lazy" />
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1">
@@ -968,8 +956,8 @@ const base = import.meta.env.BASE_URL;
         const fCard = deck[5];
         const cRate = cCard ? getCenterSkillRate(cCard.rarity) : 0;
         const fRate = fCard ? getCenterSkillRate(fCard.rarity) : 0;
-        const cAttr = cCard ? normalizeAttr(cCard.attribute) : null;
-        const fAttr = fCard ? normalizeAttr(fCard.attribute) : null;
+        const cAttr = cCard ? normalizeAttribute(cCard.attribute) : null;
+        const fAttr = fCard ? normalizeAttribute(fCard.attribute) : null;
         let sRate = 0, bRate = 0, mRate = 0;
         if (cAttr === 'Shout') sRate += cRate;
         if (cAttr === 'Beat') bRate += cRate;
@@ -1241,20 +1229,15 @@ const base = import.meta.env.BASE_URL;
     }
 
     function saveState() {
-      try { localStorage.setItem('i7_score_calc_state', JSON.stringify(buildStateObject())); } catch {}
+      saveJson(STORAGE_KEYS.SCORE_CALC_STATE, buildStateObject());
     }
 
     function restoreState() {
-      try {
-        const raw = localStorage.getItem('i7_score_calc_state');
-        if (!raw) return;
-        applyState(JSON.parse(raw));
-      } catch {}
+      const state = loadJson<ReturnType<typeof buildStateObject> | null>(STORAGE_KEYS.SCORE_CALC_STATE, null);
+      if (state) applyState(state);
     }
 
     // --- デッキ保存/読込 ---
-    const SAVED_DECKS_KEY = 'i7_saved_decks';
-
     interface SavedDeck {
       id: string;
       name: string;
@@ -1264,11 +1247,11 @@ const base = import.meta.env.BASE_URL;
     }
 
     function loadSavedDecks(): SavedDeck[] {
-      try { return JSON.parse(localStorage.getItem(SAVED_DECKS_KEY) || '[]'); } catch { return []; }
+      return loadJson<SavedDeck[]>(STORAGE_KEYS.SAVED_DECKS, []);
     }
 
     function writeSavedDecks(decks: SavedDeck[]) {
-      try { localStorage.setItem(SAVED_DECKS_KEY, JSON.stringify(decks)); } catch {}
+      saveJson(STORAGE_KEYS.SAVED_DECKS, decks);
     }
 
     function saveDeck() {

--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
-import { SONG_IMAGE_BASE_URL } from '../../lib/constants';
+import { ATTR_BADGE_BG } from '../../lib/constants';
 import { attrDonutSvg } from '../../lib/donutChart';
+import { ATTR_TEXT_CLASS, songImageUrl, starsText } from '../../lib/ui';
 
 export async function getStaticPaths() {
   const allSongs = filterValidSongs(await fetchSongsJson());
@@ -48,7 +49,7 @@ const infoRows = [
   { label: 'グループ', value: song.category },
   { label: 'アーティスト', value: song.artist },
   { label: '楽曲タイプ', value: song.song_type },
-  { label: '難易度', value: song.difficulty ? `${song.difficulty}${song.stars ? ' ' + '★'.repeat(song.stars) + '☆'.repeat(Math.max(0, 5 - song.stars)) : ''}` : null },
+  { label: '難易度', value: song.difficulty ? `${song.difficulty}${song.stars ? ' ' + starsText(song.stars) : ''}` : null },
   { label: 'ノーツ数', value: song.notes_count?.toLocaleString() },
   { label: '秒数', value: song.duration ? `${song.duration}秒` : null },
   { label: '更新日', value: song.updated_at },
@@ -64,7 +65,7 @@ const infoRows = [
   <div class="bg-white rounded-lg shadow p-6 mb-6">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <div class="md:col-span-1">
-        <img src={`${SONG_IMAGE_BASE_URL}/${song.id}.png`} alt={song.song_name || ''}
+        <img src={songImageUrl(song.id)} alt={song.song_name || ''}
              class="w-full rounded-lg shadow-md bg-gray-200"
              loading="lazy"
              onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 200%22><rect width=%22200%22 height=%22200%22 fill=%22%23e5e7eb%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 fill=%22%239ca3af%22 font-size=%2216%22>No Image</text></svg>'" />
@@ -73,7 +74,7 @@ const infoRows = [
         <h1 class="text-2xl font-bold mb-1">{song.song_name}</h1>
         <p class="text-gray-500 mb-4">{song.artist} / {song.category}</p>
         {song.stars && (
-          <p class="text-amber-400 text-lg mb-4">{'★'.repeat(song.stars)}{'☆'.repeat(Math.max(0, 5 - song.stars))}</p>
+          <p class="text-amber-400 text-lg mb-4">{starsText(song.stars)}</p>
         )}
         <table class="w-full text-sm">
           <tbody class="divide-y divide-gray-100">
@@ -96,21 +97,13 @@ const infoRows = [
       <div class="flex flex-col sm:flex-row items-center gap-6">
         <div class="w-36 h-36 flex-shrink-0" set:html={ratioChartHtml} />
         <div class="space-y-2">
-          <div class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full bg-red-500 inline-block"></span>
-            <span class="text-sm font-medium w-16">Shout</span>
-            <span class="text-sm">{sPct}%</span>
-          </div>
-          <div class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full bg-green-500 inline-block"></span>
-            <span class="text-sm font-medium w-16">Beat</span>
-            <span class="text-sm">{bPct}%</span>
-          </div>
-          <div class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full bg-blue-500 inline-block"></span>
-            <span class="text-sm font-medium w-16">Melody</span>
-            <span class="text-sm">{mPct}%</span>
-          </div>
+          {(['Shout', 'Beat', 'Melody'] as const).map((attr, i) => (
+            <div class="flex items-center gap-2">
+              <span class={`w-3 h-3 rounded-full inline-block ${ATTR_BADGE_BG[attr]}`}></span>
+              <span class="text-sm font-medium w-16">{attr}</span>
+              <span class="text-sm">{[sPct, bPct, mPct][i]}%</span>
+            </div>
+          ))}
         </div>
       </div>
     </section>
@@ -127,12 +120,12 @@ const infoRows = [
             <tr class="bg-gray-50 text-left text-xs text-gray-500">
               <th class="px-3 py-2">レベル</th>
               <th class="px-3 py-2 text-right">倍率</th>
-              <th class="px-3 py-2 text-right text-red-500">S白</th>
-              <th class="px-3 py-2 text-right text-red-500">S色</th>
-              <th class="px-3 py-2 text-right text-green-500">B白</th>
-              <th class="px-3 py-2 text-right text-green-500">B色</th>
-              <th class="px-3 py-2 text-right text-blue-500">M白</th>
-              <th class="px-3 py-2 text-right text-blue-500">M色</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Shout}`}>S白</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Shout}`}>S色</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Beat}`}>B白</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Beat}`}>B色</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Melody}`}>M白</th>
+              <th class={`px-3 py-2 text-right ${ATTR_TEXT_CLASS.Melody}`}>M色</th>
               <th class="px-3 py-2 text-right font-semibold">計</th>
             </tr>
           </thead>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -88,26 +88,22 @@ const base = import.meta.env.BASE_URL;
 
   <script>
     import { attrDonutSvg } from '../../lib/donutChart';
-    import { ATTR_HEX, SONG_IMAGE_BASE_URL } from '../../lib/constants';
+    import { ATTR_HEX } from '../../lib/constants';
     import type { Song } from '../../lib/data/fetchSongsJson';
+    import { STORAGE_KEYS, loadJson, saveJson } from '../../lib/storage';
+    import { songImageUrl, starsText } from '../../lib/ui';
 
     const base = (window as any).__BASE_URL__ || '/i7/';
-    const songImgBase = SONG_IMAGE_BASE_URL;
-    const SELECTED_SONGS_KEY = 'i7_selected_songs';
     const $ = (id: string) => document.getElementById(id)!;
 
     let allSongs: Song[] = JSON.parse(document.getElementById('song-data')!.textContent!) as Song[];
     let filtered: Song[] = [];
 
     // 選択済み曲IDセット（localStorageに永続化）
-    let selectedSongIds: Set<number> = new Set();
-    try {
-      const raw = localStorage.getItem(SELECTED_SONGS_KEY);
-      if (raw) selectedSongIds = new Set(JSON.parse(raw));
-    } catch {}
+    let selectedSongIds: Set<number> = new Set(loadJson<number[]>(STORAGE_KEYS.SELECTED_SONGS, []));
 
     function saveSelectedSongs() {
-      try { localStorage.setItem(SELECTED_SONGS_KEY, JSON.stringify([...selectedSongIds])); } catch {}
+      saveJson(STORAGE_KEYS.SELECTED_SONGS, [...selectedSongIds]);
       updateSelectedCount();
     }
 
@@ -153,8 +149,8 @@ const base = import.meta.env.BASE_URL;
     }
 
     function starsHtml(n: number): string {
-      if (!n) return '';
-      return `<div class="text-amber-400">${'★'.repeat(n)}${'☆'.repeat(Math.max(0, 5 - n))}</div>`;
+      const s = starsText(n);
+      return s ? `<div class="text-amber-400">${s}</div>` : '';
     }
 
     /** 属性比率から主属性の薄い背景色を返す */
@@ -188,7 +184,7 @@ const base = import.meta.env.BASE_URL;
       const bg = dominantAttrBg(sr, br, mr);
       const bgH = dominantAttrBgHover(sr, br, mr);
       const borderColor = dominantAttrBorder(sr, br, mr);
-      const imgUrl = `${songImgBase}/${song.id}.png`;
+      const imgUrl = songImageUrl(song.id!);
       const defaultBg = songRowBg(bg, imgUrl);
       const hoverBg = songRowBg(bgH, imgUrl);
 
@@ -214,7 +210,7 @@ const base = import.meta.env.BASE_URL;
       const mr = song.melody_ratio || 0;
       const bg = dominantAttrBg(sr, br, mr);
       const borderColor = dominantAttrBorder(sr, br, mr);
-      const imgUrl = `${songImgBase}/${song.id}.png`;
+      const imgUrl = songImageUrl(song.id!);
       const mobileBg = `linear-gradient(to right, rgba(255,255,255,1) 40%, rgba(255,255,255,0.65)), linear-gradient(${bg}, ${bg}), url(${imgUrl}) no-repeat right 25% / auto 500%`;
 
       const mobileChecked = song.id != null && selectedSongIds.has(song.id) ? 'checked' : '';
@@ -225,7 +221,7 @@ const base = import.meta.env.BASE_URL;
         <p class="font-medium text-sm text-indigo-600">${song.song_name || ''}</p>
         <p class="text-xs text-gray-500">${song.artist || ''} / ${song.category || ''}</p>
         <div class="flex gap-3 mt-1 text-xs text-gray-600">
-          <span>${song.difficulty || ''}${song.stars ? ' ' + '★'.repeat(song.stars) + '☆'.repeat(Math.max(0, 5 - song.stars)) : ''}</span>
+          <span>${song.difficulty || ''}${song.stars ? ' ' + starsText(song.stars) : ''}</span>
           <span>Notes: ${(song.notes_count || 0).toLocaleString()}</span>
           <span>${song.duration || '-'}秒</span>
         </div>


### PR DESCRIPTION
## Summary

ページ間で重複していたロジックを 4 フェーズに分けて共通モジュールに集約する。ふるまい変更なし（色交錯バグ 1 件の修正を除く）。

### Phase 1: `normalizeAttr` 重複除去
- `src/pages/decks/index.astro` と `src/pages/score-calc/index.astro` でローカル再実装されていた属性正規化関数を削除
- `src/lib/score/types.ts` の `normalizeAttribute` を再利用
- score-calc では 9 箇所の呼び出しを置換

### Phase 2: `src/lib/storage.ts` 新規
- `loadJson<T>(key, fallback)` / `saveJson(key, value)` / `STORAGE_KEYS` を追加
- 13 箇所に散在していた `try { JSON.parse(localStorage.getItem(...)) } catch` を集約
- 対象: `cardListRenderer`, `rabbitNote`, `songs/index`, `decks/index`, `score-calc/index`

### Phase 3: `src/lib/ui.ts` 新規
- `ATTR_TEXT_CLASS`: Shout/Beat/Melody の `text-red-500` / `text-green-500` / `text-blue-500` クラス
- `cardImageUrl` / `cardThumbUrl` / `songImageUrl`: 画像 URL 組み立て関数
- `starsText`: 星表示 `★`.repeat(n) + `☆`.repeat(5-n) の共通関数
- **副次バグ修正**: `cards/[id].astro:187-189` で Beat が `text-blue-500`・Melody が `text-green-500` になっていた色交錯バグを `ATTR_TEXT_CLASS` 置換の過程で修正（Beat → 緑、Melody → 青が正しい）

### Phase 4: `SKILL_TYPE` 定数 + `ATTRS` 定数 + 型統一
- `fetchCardsJson.ts` に `SKILL_TYPE` 定数を新設し、`engine.ts` / `skillFormatter.ts` のマジック文字列（`MISS→Good`, `スコアアップ（タイマー）`, `判定縮小スコアアップ`, `判定縮小（`, `BAD以上をPerfectに変更` 等）を参照に置換
- `constants.ts` に `ATTRS` 定数を追加し、`noteFlattener.ts` のインライン属性配列を共通定数化
- `sharedBroachs.ts` の `targetAttribute` 型を `AttributeName` 再利用に統一（インライン `'Shout' | 'Beat' | 'Melody'` を削除）

### 明示的に範囲外とした項目
- `cards/index.astro` と `songs/index.astro` のフィルタ/ソート共通化 — フィールド構造とページネーション有無が違い、抽象化コスト > 利益
- `MIN_EXPECTED_CARDS` throw vs songs/broachs の silent filter — 意図的な差なので統一しない
- 15 ファイル変更、+200 / −148 行、新規 2 ファイル（`storage.ts` 34 行 / `ui.ts` 36 行）

## Test plan
- [x] `npm run build` 2840 ページ生成成功
- [x] Playwright MCP で全ページ目視確認（`/score-calc/` MC シミュレーション動作、`/decks/` `/songs/` `/songs/1/` `/cards/1001/` `/cards/1500/` console エラーなし）
- [x] Beat/Melody 色交錯バグ修正を `/cards/1500/` の固有ブローチ表示で視覚確認
- [x] `npm run test` 11 既存失敗は `git stash` で pre-refactor にも同じ失敗があることを確認済み（リファクタによる新規失敗ゼロ）
- [ ] レビュー後マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)