### PR TITLE
fix: ヒストグラムX軸ラベルの表記を桁区切り数値に統一

### DIFF
--- a/src/lib/score/histogram.ts
+++ b/src/lib/score/histogram.ts
@@ -61,9 +61,7 @@ export function renderHistogramSvg(
   const xLabels = Array.from({ length: labelCount + 1 }, (_, i) => {
     const val = minScore + (range * i) / labelCount;
     const x = MARGIN.left + (INNER_WIDTH * i) / labelCount;
-    const label = val >= 1000000
-      ? `${(val / 10000).toFixed(0)}万`
-      : Math.round(val).toLocaleString();
+    const label = Math.round(val).toLocaleString();
     return `<text x="${x}" y="${MARGIN.top + INNER_HEIGHT + 16}" text-anchor="middle" fill="#6b7280" font-size="9">${label}</text>`;
   }).join('\n    ');
 


### PR DESCRIPTION
## Summary
- スコア計算画面のシミュレーション結果ヒストグラムで、X軸ラベルが 1,000,000 を境に「3桁カンマ数値」(例: `988,568`) と「万単位」(例: `108万`) の表記が混在して視認性が悪かった問題を修正。
- `src/lib/score/histogram.ts` の条件分岐を削除し、全ラベルを `toLocaleString()` による桁区切り数値に統一。

### Before / After
- Before: `801,493 / 895,031 / 988,568 / 108万 / 118万 / 127万`
- After: `801,493 / 895,031 / 988,568 / 1,082,106 / 1,175,643 / 1,269,181`

## Test plan
- [ ] スコア計算画面で楽曲とカードを設定しシミュレーション実行
- [ ] ヒストグラム下部のX軸ラベルが全て桁区切り数値で統一表示されること
- [ ] 平均値マーカー(赤線)の位置と度数分布の形状は従来通り保たれていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)