### PR TITLE
ci: イベントDB CSV を毎朝 JST 04:00 に自動取得するワークフロー追加

### DIFF
--- a/.github/workflows/fetch-event-db.yml
+++ b/.github/workflows/fetch-event-db.yml
@@ -1,0 +1,70 @@
+name: Fetch event DB
+
+on:
+  schedule:
+    # JST 04:00 = UTC 19:00 (前日)
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fetch-event-db:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download event DB CSV
+        id: fetch
+        shell: bash
+        run: |
+          mkdir -p public/events
+          DEST="public/events/events.csv"
+          TMP="$(mktemp)"
+
+          HTTP_CODE=$(curl -sS -X POST \
+            --connect-timeout 10 --max-time 60 \
+            --data 'db=event&code=utf8' \
+            -o "$TMP" -w "%{http_code}" \
+            'https://i7.step-on-dream.net/admin/download.php' || true)
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Download failed: HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+          SIZE=$(wc -c < "$TMP" | tr -d ' ')
+          if [ "$SIZE" -lt 1024 ]; then
+            echo "Downloaded file too small: $SIZE bytes"
+            exit 1
+          fi
+          if ! head -1 "$TMP" | grep -q 'eventname'; then
+            echo "Header validation failed (expected 'eventname' in first line)"
+            head -3 "$TMP"
+            exit 1
+          fi
+
+          mv "$TMP" "$DEST"
+
+          ROWS=$(($(wc -l < "$DEST") - 1))
+          echo "rows=$ROWS" >> "$GITHUB_OUTPUT"
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: public/events/events.csv
+          commit-message: "Update event DB CSV"
+          branch: auto/update-event-db
+          delete-branch: true
+          title: "Update event DB (${{ steps.fetch.outputs.rows }} rows)"
+          body: |
+            ## Summary
+            Automatically fetched event DB from source server.
+
+            - **Source**: `POST https://i7.step-on-dream.net/admin/download.php` (`db=event`, `code=utf8`)
+            - **Destination**: `public/events/events.csv`
+            - **Rows**: ${{ steps.fetch.outputs.rows }}
+            - **Size**: ${{ steps.fetch.outputs.size }} bytes


### PR DESCRIPTION
## Summary
- `https://i7.step-on-dream.net/admin/index.php` の「イベントDBをダウンロード(utf8)」を毎朝 JST 04:00 (UTC 19:00) に取得する GitHub Actions ワークフローを追加
- 取得先: `POST https://i7.step-on-dream.net/admin/download.php` (`db=event&code=utf8`)
- 保存先: `public/events/events.csv` (Astro ビルド時に `dist/events/events.csv` → `/i7/events/events.csv` として配信)
- 差分があれば `peter-evans/create-pull-request@v8` で `auto/update-event-db` ブランチに PR を作成

## 設計ポイント
- **差分検知**: peter-evans/create-pull-request の標準挙動に任せる (作業ツリーに差分がなければ PR は作成されない)
- **固定ブランチ名 `auto/update-event-db`**: 単一ファイル更新のため、未マージ PR があれば同ブランチに force push して追従
- **安全策**: HTTP 200 / サイズ ≥1KB / ヘッダー行に `eventname` 含有、の 3 段検証でエラーページ誤コミットを防止
- **BOM 保持**: サーバー応答の UTF-8 BOM (`\uFEFF`) はそのまま保存

## ローカル検証済み
- 同じ curl コマンドで HTTP 200 / 64,161 bytes / 72 行のイベントデータを取得できることを確認
- ヘッダー検証 (`eventname` 含有) が通ることを確認
- YAML 構文チェック済み

## Test plan
- [ ] マージ後、Actions 画面から `Fetch event DB` を `workflow_dispatch` で手動実行
- [ ] 初回実行で `auto/update-event-db` ブランチと PR が作成されることを確認
- [ ] 生成された PR をマージ
- [ ] `npm run build && npm run preview` で `http://localhost:4321/i7/events/events.csv` が 200 を返し CSV が配信されることを確認
- [ ] 翌日 JST 04:00 のスケジュール実行で、差分がなければ PR が上がらないこと／差分があれば既存ブランチが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)