### PR TITLE
feat: イベント情報 (一覧 + 詳細) ページの追加

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,6 +52,7 @@ const repoUrl = 'https://github.com/yo4raw/i7';
           <li><a href={base} class="hover:text-indigo-200 transition-colors">ホーム</a></li>
           <li><a href={`${base}cards/`} class="hover:text-indigo-200 transition-colors">カード一覧</a></li>
           <li><a href={`${base}songs/`} class="hover:text-indigo-200 transition-colors">楽曲一覧</a></li>
+          <li><a href={`${base}events/`} class="hover:text-indigo-200 transition-colors">イベント情報</a></li>
           <li><a href={`${base}mycard/`} class="hover:text-indigo-200 transition-colors">所持カード</a></li>
           <li><a href={`${base}score-calc/`} class="hover:text-indigo-200 transition-colors">スコア計算</a></li>
           <li><a href={`${base}rabbit-note/`} class="hover:text-indigo-200 transition-colors">ラビットノート</a></li>
@@ -62,6 +63,7 @@ const repoUrl = 'https://github.com/yo4raw/i7';
         <li><a href={base} class="block py-1 hover:text-indigo-200">ホーム</a></li>
         <li><a href={`${base}cards/`} class="block py-1 hover:text-indigo-200">カード一覧</a></li>
         <li><a href={`${base}songs/`} class="block py-1 hover:text-indigo-200">楽曲一覧</a></li>
+        <li><a href={`${base}events/`} class="block py-1 hover:text-indigo-200">イベント情報</a></li>
         <li><a href={`${base}mycard/`} class="block py-1 hover:text-indigo-200">所持カード</a></li>
         <li><a href={`${base}score-calc/`} class="block py-1 hover:text-indigo-200">スコア計算</a></li>
         <li><a href={`${base}rabbit-note/`} class="block py-1 hover:text-indigo-200">ラビットノート</a></li>

--- a/src/lib/data/fetchEventsCsv.ts
+++ b/src/lib/data/fetchEventsCsv.ts
@@ -1,6 +1,18 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+export interface EventSpecialTier {
+  cardIds: number[];
+  costumeIds: number[];
+  effect: string[];
+  param_up: number;
+  item_up: number;
+  bpt_up: number;
+  ept_up: number;
+  gpt_up: number;
+  score_up: number;
+}
+
 export interface EventRow {
   id: number;
   eventname: string;
@@ -9,6 +21,9 @@ export interface EventRow {
   end_date: string;
   special3_member: string;
   comment: string;
+  gold: EventSpecialTier;
+  silver: EventSpecialTier;
+  bronze: EventSpecialTier;
 }
 
 function parseCsv(text: string): string[][] {
@@ -55,6 +70,27 @@ function parseCsv(text: string): string[][] {
   return rows.filter(r => r.length > 1 || (r.length === 1 && r[0] !== ''));
 }
 
+function parseIdList(s: string): number[] {
+  return (s || '')
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean)
+    .map(x => Number(x))
+    .filter(n => Number.isFinite(n) && n > 0);
+}
+
+function parseEffectList(s: string): string[] {
+  return (s || '')
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean);
+}
+
+function toNum(s: string): number {
+  const n = Number((s || '').trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
 export async function fetchEventsCsv(): Promise<EventRow[]> {
   const csvPath = path.resolve(process.cwd(), 'public/events/events.csv');
   const text = await readFile(csvPath, 'utf-8');
@@ -62,14 +98,29 @@ export async function fetchEventsCsv(): Promise<EventRow[]> {
   if (rows.length < 2) return [];
 
   const header = rows[0];
-  const idx = (name: string) => header.indexOf(name);
-  const iId = idx('ID');
-  const iName = idx('eventname');
-  const iType = idx('eventtype');
-  const iStart = idx('start_date');
-  const iEnd = idx('end_date');
-  const iMember = idx('special3_member');
-  const iComment = idx('comment');
+  const col = (name: string) => header.indexOf(name);
+
+  const iId = col('ID');
+  const iName = col('eventname');
+  const iType = col('eventtype');
+  const iStart = col('start_date');
+  const iEnd = col('end_date');
+  const iMember = col('special3_member');
+  const iComment = col('comment');
+
+  function readTier(r: string[], n: 1 | 2 | 3): EventSpecialTier {
+    return {
+      cardIds: parseIdList(r[col(`special${n}_rID`)] ?? ''),
+      costumeIds: parseIdList(r[col(`special${n}_ID`)] ?? ''),
+      effect: parseEffectList(r[col(`special${n}_effect`)] ?? ''),
+      param_up: toNum(r[col(`special${n}_param_up`)] ?? ''),
+      item_up: toNum(r[col(`special${n}_item_up`)] ?? ''),
+      bpt_up: toNum(r[col(`special${n}_bpt_up`)] ?? ''),
+      ept_up: toNum(r[col(`special${n}_ept_up`)] ?? ''),
+      gpt_up: toNum(r[col(`special${n}_gpt_up`)] ?? ''),
+      score_up: toNum(r[col(`special${n}_score_up`)] ?? ''),
+    };
+  }
 
   return rows.slice(1).map(r => ({
     id: Number(r[iId] ?? 0),
@@ -79,5 +130,35 @@ export async function fetchEventsCsv(): Promise<EventRow[]> {
     end_date: (r[iEnd] ?? '').trim(),
     special3_member: (r[iMember] ?? '').trim(),
     comment: (r[iComment] ?? '').trim(),
+    gold: readTier(r, 1),
+    silver: readTier(r, 2),
+    bronze: readTier(r, 3),
   })).filter(e => e.id > 0 && e.eventname && e.start_date && e.end_date);
+}
+
+const EFFECT_LABEL: Record<string, string> = {
+  param: 'パラメータ',
+  item: 'アイテム',
+  bpt: '基礎Pt',
+  ept: 'イベントPt',
+  gpt: 'グレードPt',
+  score: 'スコア',
+};
+
+export function formatEffectSummary(tier: EventSpecialTier): string {
+  const parts: string[] = [];
+  const map: Array<[string, number]> = [
+    ['param', tier.param_up],
+    ['item', tier.item_up],
+    ['bpt', tier.bpt_up],
+    ['ept', tier.ept_up],
+    ['gpt', tier.gpt_up],
+    ['score', tier.score_up],
+  ];
+  for (const [key, v] of map) {
+    if (v > 0 && tier.effect.includes(key)) {
+      parts.push(`${EFFECT_LABEL[key] ?? key} +${v}%`);
+    }
+  }
+  return parts.join(' / ');
 }

--- a/src/lib/data/fetchEventsCsv.ts
+++ b/src/lib/data/fetchEventsCsv.ts
@@ -1,0 +1,83 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface EventRow {
+  id: number;
+  eventname: string;
+  eventtype: string;
+  start_date: string;
+  end_date: string;
+  special3_member: string;
+  comment: string;
+}
+
+function parseCsv(text: string): string[][] {
+  const src = text.replace(/^\uFEFF/, '');
+  const rows: string[][] = [];
+  let cur = '';
+  let row: string[] = [];
+  let inQuote = false;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (inQuote) {
+      if (c === '"') {
+        if (src[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuote = false;
+        }
+      } else {
+        cur += c;
+      }
+    } else {
+      if (c === '"') {
+        inQuote = true;
+      } else if (c === ',') {
+        row.push(cur);
+        cur = '';
+      } else if (c === '\n') {
+        row.push(cur);
+        rows.push(row);
+        row = [];
+        cur = '';
+      } else if (c === '\r') {
+        // handled by \n
+      } else {
+        cur += c;
+      }
+    }
+  }
+  if (cur !== '' || row.length > 0) {
+    row.push(cur);
+    rows.push(row);
+  }
+  return rows.filter(r => r.length > 1 || (r.length === 1 && r[0] !== ''));
+}
+
+export async function fetchEventsCsv(): Promise<EventRow[]> {
+  const csvPath = path.resolve(process.cwd(), 'public/events/events.csv');
+  const text = await readFile(csvPath, 'utf-8');
+  const rows = parseCsv(text);
+  if (rows.length < 2) return [];
+
+  const header = rows[0];
+  const idx = (name: string) => header.indexOf(name);
+  const iId = idx('ID');
+  const iName = idx('eventname');
+  const iType = idx('eventtype');
+  const iStart = idx('start_date');
+  const iEnd = idx('end_date');
+  const iMember = idx('special3_member');
+  const iComment = idx('comment');
+
+  return rows.slice(1).map(r => ({
+    id: Number(r[iId] ?? 0),
+    eventname: (r[iName] ?? '').trim(),
+    eventtype: (r[iType] ?? '').trim(),
+    start_date: (r[iStart] ?? '').trim(),
+    end_date: (r[iEnd] ?? '').trim(),
+    special3_member: (r[iMember] ?? '').trim(),
+    comment: (r[iComment] ?? '').trim(),
+  })).filter(e => e.id > 0 && e.eventname && e.start_date && e.end_date);
+}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -1,0 +1,230 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { fetchEventsCsv, formatEffectSummary, type EventRow, type EventSpecialTier } from '../../lib/data/fetchEventsCsv';
+import { fetchCardsJson, type Card } from '../../lib/data/fetchCardsJson';
+import { ATTR_BADGE_BG, RARITY_BADGE_CLASSES } from '../../lib/constants';
+import { cardThumbUrl } from '../../lib/ui';
+
+export async function getStaticPaths() {
+  const [events, cards] = await Promise.all([
+    fetchEventsCsv(),
+    fetchCardsJson(),
+  ]);
+  const cardMap = new Map<number, Card>();
+  for (const c of cards as Card[]) {
+    if (c.ID != null) cardMap.set(c.ID, c);
+  }
+  const pick = (ids: number[]): Card[] =>
+    ids.map(id => cardMap.get(id)).filter((c): c is Card => !!c);
+
+  return (events as EventRow[]).map(ev => ({
+    params: { id: String(ev.id) },
+    props: {
+      event: ev,
+      goldCards: pick(ev.gold.cardIds),
+      silverCards: pick(ev.silver.cardIds),
+      bronzeCards: pick(ev.bronze.cardIds),
+    },
+  }));
+}
+
+interface Props {
+  event: EventRow;
+  goldCards: Card[];
+  silverCards: Card[];
+  bronzeCards: Card[];
+}
+
+const { event, goldCards, silverCards, bronzeCards } = Astro.props as Props;
+const base = import.meta.env.BASE_URL;
+
+interface TierView {
+  key: 'gold' | 'silver' | 'bronze';
+  label: string;
+  cards: Card[];
+  tier: EventSpecialTier;
+  badgeClass: string;
+  borderClass: string;
+}
+
+const tiers: TierView[] = [
+  {
+    key: 'gold',
+    label: '金特効',
+    cards: goldCards,
+    tier: event.gold,
+    badgeClass: 'bg-yellow-100 text-yellow-800 border-yellow-400',
+    borderClass: 'border-l-4 border-yellow-500',
+  },
+  {
+    key: 'silver',
+    label: '銀特効',
+    cards: silverCards,
+    tier: event.silver,
+    badgeClass: 'bg-gray-200 text-gray-700 border-gray-400',
+    borderClass: 'border-l-4 border-gray-400',
+  },
+  {
+    key: 'bronze',
+    label: '銅特効',
+    cards: bronzeCards,
+    tier: event.bronze,
+    badgeClass: 'bg-amber-100 text-amber-800 border-amber-400',
+    borderClass: 'border-l-4 border-amber-500',
+  },
+];
+---
+
+<BaseLayout title={event.eventname}>
+  <a href={`${base}events/`} class="text-sm text-indigo-600 hover:underline">← イベント一覧へ戻る</a>
+
+  <div class="mt-2 mb-6">
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">{event.eventname}</h1>
+      <span
+        id="status-badge"
+        class="inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100"
+        data-start={`${event.start_date}T00:00:00+09:00`}
+        data-end={`${event.end_date}T17:00:00+09:00`}
+      >—</span>
+    </div>
+    <div class="mt-2 text-sm text-gray-600 space-y-0.5">
+      <p>{event.eventtype}</p>
+      <p>{event.start_date} 〜 {event.end_date} 17:00 (JST)</p>
+      <p id="status-remain" class="hidden"></p>
+    </div>
+    {event.comment && (
+      <p class="mt-3 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded px-3 py-2">{event.comment}</p>
+    )}
+  </div>
+
+  {tiers.map(t => (
+    <section class={`mb-6 rounded-lg bg-white shadow p-4 ${t.borderClass}`}>
+      <div class="flex items-center justify-between gap-2 flex-wrap mb-3">
+        <span class={`inline-block px-3 py-1 rounded text-sm font-bold border ${t.badgeClass}`}>{t.label}</span>
+        <span class="text-xs text-gray-500">対象 {t.cards.length} 枚</span>
+      </div>
+
+      {formatEffectSummary(t.tier) && (
+        <p class="text-sm text-gray-700 mb-2">{formatEffectSummary(t.tier)}</p>
+      )}
+      {t.key === 'bronze' && event.special3_member && (
+        <p class="text-xs text-gray-500 mb-3">対象: {event.special3_member}</p>
+      )}
+
+      {t.cards.length === 0 ? (
+        <p class="text-sm text-gray-400">対象カードなし</p>
+      ) : (
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
+          {t.cards.map(card => {
+            const attr = card.attribute || '';
+            const rarity = card.rarity || '';
+            const attrBg = ATTR_BADGE_BG[attr] || 'bg-gray-400';
+            const rarityBg = RARITY_BADGE_CLASSES[rarity] || 'bg-gray-300';
+            return (
+              <a
+                href={`${base}cards/${card.ID}/`}
+                class="flex items-center gap-2 p-2 rounded border border-gray-200 hover:bg-gray-50 hover:shadow-sm transition-shadow"
+              >
+                <img
+                  src={cardThumbUrl(card.ID!)}
+                  alt=""
+                  class="w-12 h-auto rounded flex-shrink-0"
+                  loading="lazy"
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-1 mb-0.5">
+                    <span class={`px-1 py-0.5 text-[9px] font-bold text-white rounded ${rarityBg}`}>{rarity || '?'}</span>
+                    {attr && <span class={`px-1 py-0.5 text-[9px] font-bold text-white rounded ${attrBg}`}>{attr}</span>}
+                  </div>
+                  <div class="text-xs font-medium truncate text-gray-800">{card.cardname || '-'}</div>
+                  <div class="text-[11px] text-gray-500 truncate">{card.name || ''}</div>
+                </div>
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  ))}
+
+  <script>
+    type Status = 'live' | 'upcoming' | 'past';
+
+    const badge = document.getElementById('status-badge');
+    const remainEl = document.getElementById('status-remain');
+    const start = Date.parse(badge?.dataset.start || '');
+    const end = Date.parse(badge?.dataset.end || '');
+
+    function classify(now: number, s: number, e: number): Status {
+      if (now < s) return 'upcoming';
+      if (now >= e) return 'past';
+      return 'live';
+    }
+
+    function formatRemaining(ms: number): string {
+      if (ms <= 0) return '';
+      const t = Math.floor(ms / 1000);
+      const d = Math.floor(t / 86400);
+      const h = Math.floor((t % 86400) / 3600);
+      const m = Math.floor((t % 3600) / 60);
+      const s = t % 60;
+      if (d > 0) return `${d}日 ${h}時間 ${m}分 ${s}秒`;
+      if (h > 0) return `${h}時間 ${m}分 ${s}秒`;
+      if (m > 0) return `${m}分 ${s}秒`;
+      return `${s}秒`;
+    }
+
+    function formatShort(ms: number): string {
+      if (ms <= 0) return '';
+      const t = Math.floor(ms / 1000);
+      const d = Math.floor(t / 86400);
+      const h = Math.floor((t % 86400) / 3600);
+      const m = Math.floor((t % 3600) / 60);
+      if (d > 0) return `${d}日 ${h}時間`;
+      if (h > 0) return `${h}時間 ${m}分`;
+      return `${m}分`;
+    }
+
+    function render(): Status {
+      if (!badge || !remainEl || Number.isNaN(start) || Number.isNaN(end)) return 'past';
+      const now = Date.now();
+      const st = classify(now, start, end);
+
+      badge.classList.remove(
+        'text-gray-500', 'bg-gray-100',
+        'text-white', 'bg-red-600', 'animate-pulse',
+        'text-blue-700', 'bg-blue-100',
+        'text-gray-400', 'bg-gray-50'
+      );
+      remainEl.classList.add('hidden');
+      remainEl.classList.remove('text-red-600', 'text-gray-500', 'font-medium');
+
+      if (st === 'live') {
+        badge.textContent = '実施中';
+        badge.classList.add('text-white', 'bg-red-600', 'animate-pulse');
+        remainEl.textContent = `残り ${formatRemaining(end - now)}`;
+        remainEl.classList.remove('hidden');
+        remainEl.classList.add('text-red-600', 'font-medium');
+      } else if (st === 'upcoming') {
+        badge.textContent = '開催予定';
+        badge.classList.add('text-blue-700', 'bg-blue-100');
+        remainEl.textContent = `開始まで ${formatShort(start - now)}`;
+        remainEl.classList.remove('hidden');
+        remainEl.classList.add('text-gray-500');
+      } else {
+        badge.textContent = '終了';
+        badge.classList.add('text-gray-400', 'bg-gray-50');
+      }
+      return st;
+    }
+
+    function tick() {
+      const st = render();
+      const interval = st === 'live' ? 1000 : 30000;
+      setTimeout(tick, interval);
+    }
+
+    tick();
+  </script>
+</BaseLayout>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -72,7 +72,7 @@ const base = import.meta.env.BASE_URL;
               <span class="status-badge inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100">—</span>
               <div class="status-remain text-xs mt-1 text-gray-500 hidden"></div>
             </td>
-            <td class="px-3 py-2 font-medium">{ev.eventname}</td>
+            <td class="px-3 py-2 font-medium"><a href={`${base}events/${ev.id}/`} class="text-indigo-600 hover:underline">{ev.eventname}</a></td>
             <td class="px-3 py-2 text-xs text-gray-600">{ev.eventtype}</td>
             <td class="px-3 py-2 text-xs text-gray-700">{ev.start_date}</td>
             <td class="px-3 py-2 text-xs text-gray-700">{ev.end_date} 17:00</td>
@@ -94,7 +94,7 @@ const base = import.meta.env.BASE_URL;
         data-name={ev.eventname}
       >
         <div class="flex items-start justify-between gap-2 mb-1">
-          <p class="font-medium text-sm flex-1">{ev.eventname}</p>
+          <a href={`${base}events/${ev.id}/`} class="font-medium text-sm flex-1 text-indigo-600 hover:underline">{ev.eventname}</a>
           <span class="status-badge shrink-0 inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100">—</span>
         </div>
         <div class="status-remain text-xs text-gray-500 hidden mb-1"></div>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -1,0 +1,277 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv';
+
+const allEvents = await fetchEventsCsv();
+allEvents.sort((a, b) => b.id - a.id);
+
+const eventTypes = [...new Set(allEvents.map(e => e.eventtype).filter(Boolean))].sort();
+
+const base = import.meta.env.BASE_URL;
+---
+
+<BaseLayout title="イベント情報">
+  <h1 class="text-2xl font-bold mb-6">イベント情報</h1>
+
+  <!-- 検索フォーム -->
+  <div class="bg-white rounded-lg shadow p-4 mb-6">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div>
+        <label for="search-text" class="block text-xs font-medium text-gray-500 mb-1">イベント名検索</label>
+        <input type="text" id="search-text" placeholder="イベント名"
+               class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" />
+      </div>
+      <div>
+        <label for="search-type" class="block text-xs font-medium text-gray-500 mb-1">イベントタイプ</label>
+        <select id="search-type" class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400">
+          <option value="">すべて</option>
+          {eventTypes.map(t => <option value={t}>{t}</option>)}
+        </select>
+      </div>
+      <div>
+        <label for="search-status" class="block text-xs font-medium text-gray-500 mb-1">状態</label>
+        <select id="search-status" class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400">
+          <option value="">すべて</option>
+          <option value="live">実施中</option>
+          <option value="upcoming">開催予定</option>
+          <option value="past">終了</option>
+        </select>
+      </div>
+    </div>
+    <div class="mt-3 flex items-center gap-3">
+      <button id="btn-reset" class="text-sm text-indigo-600 hover:underline">条件リセット</button>
+      <span id="result-count" class="text-sm text-gray-500">{allEvents.length}件を表示</span>
+    </div>
+  </div>
+
+  <p class="text-xs text-gray-500 mb-3">※ 終了時刻は各イベント終了日の 17:00 (JST) として扱います。</p>
+
+  <!-- デスクトップテーブル -->
+  <div class="hidden md:block overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-gray-100 text-left text-xs text-gray-500 uppercase">
+          <th class="px-3 py-2 w-40">状態</th>
+          <th class="px-3 py-2">イベント名</th>
+          <th class="px-3 py-2 w-56">イベントタイプ</th>
+          <th class="px-3 py-2 w-36">開始</th>
+          <th class="px-3 py-2 w-44">終了 (17:00)</th>
+        </tr>
+      </thead>
+      <tbody id="table-body" class="divide-y divide-gray-100">
+        {allEvents.map(ev => (
+          <tr
+            class="event-row"
+            data-id={ev.id}
+            data-start={`${ev.start_date}T00:00:00+09:00`}
+            data-end={`${ev.end_date}T17:00:00+09:00`}
+            data-type={ev.eventtype}
+            data-name={ev.eventname}
+          >
+            <td class="px-3 py-2 align-top">
+              <span class="status-badge inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100">—</span>
+              <div class="status-remain text-xs mt-1 text-gray-500 hidden"></div>
+            </td>
+            <td class="px-3 py-2 font-medium">{ev.eventname}</td>
+            <td class="px-3 py-2 text-xs text-gray-600">{ev.eventtype}</td>
+            <td class="px-3 py-2 text-xs text-gray-700">{ev.start_date}</td>
+            <td class="px-3 py-2 text-xs text-gray-700">{ev.end_date} 17:00</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- モバイルカード -->
+  <div id="mobile-cards" class="md:hidden space-y-3">
+    {allEvents.map(ev => (
+      <div
+        class="event-card rounded-lg shadow p-3 bg-white"
+        data-id={ev.id}
+        data-start={`${ev.start_date}T00:00:00+09:00`}
+        data-end={`${ev.end_date}T17:00:00+09:00`}
+        data-type={ev.eventtype}
+        data-name={ev.eventname}
+      >
+        <div class="flex items-start justify-between gap-2 mb-1">
+          <p class="font-medium text-sm flex-1">{ev.eventname}</p>
+          <span class="status-badge shrink-0 inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100">—</span>
+        </div>
+        <div class="status-remain text-xs text-gray-500 hidden mb-1"></div>
+        <p class="text-xs text-gray-600">{ev.eventtype}</p>
+        <p class="text-xs text-gray-700 mt-1">
+          <span>{ev.start_date}</span>
+          <span class="mx-1">〜</span>
+          <span>{ev.end_date} 17:00</span>
+        </p>
+      </div>
+    ))}
+  </div>
+
+  <script>
+    type Status = 'live' | 'upcoming' | 'past';
+
+    interface Row {
+      el: HTMLElement;
+      start: number;
+      end: number;
+      type: string;
+      name: string;
+      status: Status;
+    }
+
+    const rows: Row[] = [];
+    document.querySelectorAll<HTMLElement>('.event-row, .event-card').forEach((el) => {
+      const start = Date.parse(el.dataset.start || '');
+      const end = Date.parse(el.dataset.end || '');
+      if (Number.isNaN(start) || Number.isNaN(end)) return;
+      rows.push({
+        el,
+        start,
+        end,
+        type: el.dataset.type || '',
+        name: el.dataset.name || '',
+        status: 'past',
+      });
+    });
+
+    function classifyStatus(now: number, start: number, end: number): Status {
+      if (now < start) return 'upcoming';
+      if (now >= end) return 'past';
+      return 'live';
+    }
+
+    function formatRemaining(ms: number): string {
+      if (ms <= 0) return '';
+      const totalSec = Math.floor(ms / 1000);
+      const d = Math.floor(totalSec / 86400);
+      const h = Math.floor((totalSec % 86400) / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+      const s = totalSec % 60;
+      if (d > 0) return `残り ${d}日 ${h}時間 ${m}分 ${s}秒`;
+      if (h > 0) return `残り ${h}時間 ${m}分 ${s}秒`;
+      if (m > 0) return `残り ${m}分 ${s}秒`;
+      return `残り ${s}秒`;
+    }
+
+    function applyBadge(el: HTMLElement, status: Status) {
+      const badge = el.querySelector<HTMLElement>('.status-badge');
+      if (!badge) return;
+      badge.classList.remove(
+        'text-gray-500', 'bg-gray-100',
+        'text-white', 'bg-red-600', 'animate-pulse',
+        'text-blue-700', 'bg-blue-100',
+        'text-gray-400', 'bg-gray-50'
+      );
+      if (status === 'live') {
+        badge.textContent = '実施中';
+        badge.classList.add('text-white', 'bg-red-600', 'animate-pulse');
+      } else if (status === 'upcoming') {
+        badge.textContent = '開催予定';
+        badge.classList.add('text-blue-700', 'bg-blue-100');
+      } else {
+        badge.textContent = '終了';
+        badge.classList.add('text-gray-400', 'bg-gray-50');
+      }
+    }
+
+    function applyRowStyle(el: HTMLElement, status: Status) {
+      el.classList.remove('bg-red-50', 'border-l-4', 'border-red-500', 'opacity-60');
+      if (status === 'live') {
+        el.classList.add('bg-red-50', 'border-l-4', 'border-red-500');
+      } else if (status === 'past') {
+        el.classList.add('opacity-60');
+      }
+    }
+
+    function render() {
+      const now = Date.now();
+      for (const r of rows) {
+        r.status = classifyStatus(now, r.start, r.end);
+        applyBadge(r.el, r.status);
+        applyRowStyle(r.el, r.status);
+        const remainEl = r.el.querySelector<HTMLElement>('.status-remain');
+        if (remainEl) {
+          if (r.status === 'live') {
+            remainEl.textContent = formatRemaining(r.end - now);
+            remainEl.classList.remove('hidden', 'text-gray-500');
+            remainEl.classList.add('text-red-600', 'font-medium');
+          } else if (r.status === 'upcoming') {
+            remainEl.textContent = `開始まで ${formatRemainingShort(r.start - now)}`;
+            remainEl.classList.remove('hidden', 'text-red-600', 'font-medium');
+            remainEl.classList.add('text-gray-500');
+          } else {
+            remainEl.textContent = '';
+            remainEl.classList.add('hidden');
+          }
+        }
+      }
+      applyFilters();
+    }
+
+    function formatRemainingShort(ms: number): string {
+      if (ms <= 0) return '';
+      const totalSec = Math.floor(ms / 1000);
+      const d = Math.floor(totalSec / 86400);
+      const h = Math.floor((totalSec % 86400) / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+      if (d > 0) return `${d}日 ${h}時間`;
+      if (h > 0) return `${h}時間 ${m}分`;
+      return `${m}分`;
+    }
+
+    const $ = <T extends HTMLElement = HTMLElement>(id: string) => document.getElementById(id) as T;
+
+    function applyFilters() {
+      const text = ($<HTMLInputElement>('search-text').value || '').toLowerCase();
+      const type = $<HTMLSelectElement>('search-type').value;
+      const status = $<HTMLSelectElement>('search-status').value as Status | '';
+
+      let visible = 0;
+      for (const r of rows) {
+        const nameMatch = !text || r.name.toLowerCase().includes(text);
+        const typeMatch = !type || r.type === type;
+        const statusMatch = !status || r.status === status;
+        const show = nameMatch && typeMatch && statusMatch;
+        if (show) {
+          r.el.classList.remove('hidden');
+          visible++;
+        } else {
+          r.el.classList.add('hidden');
+        }
+      }
+      // rows は desktop+mobile を両方含むので表示件数はイベント単位に換算
+      const perItem = rows.length / Math.max(1, new Set(rows.map(r => r.el.dataset.id)).size);
+      const countEl = $('result-count');
+      if (countEl) countEl.textContent = `${Math.round(visible / perItem)}件を表示`;
+    }
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const searchText = $('search-text') as HTMLInputElement;
+    searchText?.addEventListener('input', () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(applyFilters, 200);
+    });
+    $('search-type')?.addEventListener('change', applyFilters);
+    $('search-status')?.addEventListener('change', applyFilters);
+    $('btn-reset')?.addEventListener('click', () => {
+      ($('search-text') as HTMLInputElement).value = '';
+      ($('search-type') as HTMLSelectElement).value = '';
+      ($('search-status') as HTMLSelectElement).value = '';
+      applyFilters();
+    });
+
+    // 実施中のイベントがあれば 1 秒ごとに更新、無ければ 30 秒ごと
+    function scheduleTick() {
+      const hasLive = rows.some(r => r.status === 'live');
+      const interval = hasLive ? 1000 : 30000;
+      setTimeout(() => {
+        render();
+        scheduleTick();
+      }, interval);
+    }
+
+    render();
+    scheduleTick();
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
ヘッダーに「イベント情報」を追加し、一覧ページと詳細ページを新設。

- **一覧ページ** `/events/`: 状態 / イベント名 / イベントタイプ / 開始 / 終了 (17:00) をテーブル表示。現在時刻と比較して 3 状態 (実施中 / 開催予定 / 終了) に分類し、実施中は赤バッジ + animate-pulse + 残り時間秒単位カウントダウン。3 条件フィルタ (イベント名 / タイプ / 状態)。
- **詳細ページ** `/events/[id]/`: 全 72 イベント分を `getStaticPaths()` で静的生成。金/銀/銅の特効ごとに対象カードをサムネイル + レアリティ + 属性 + カード名 + アイドル名のカード形式 grid で表示。各カードはカード詳細ページへリンク。実施中バッジとカウントダウンも表示。

## 実装のポイント
- 終了時刻 = `end_date` の **17:00 JST** として扱う (全ページ共通の仕様)
- 実施中は 1 秒刻み、それ以外は 30 秒刻みで再描画 (不要な更新を抑制)
- CSV パース時の重要発見: 親サイト (`event.php?ID=X&view=detail`) と CSV を突合した結果、**`special{N}_rID` が実際のカード ID (`card.ID` と対応)**、`special{N}_ID` は別体系の衣装 ID と判明。`fetchEventsCsv.ts` で `cardIds` (= _rID) と `costumeIds` (= _ID) に分けて保持
- カード表示は既存 `src/pages/score-calc/` のカードパターンを踏襲 (`RARITY_BADGE_CLASSES`, `ATTR_BADGE_BG`, `cardThumbUrl`)

## 変更ファイル
| ファイル | 操作 | 備考 |
|:---|:---|:---|
| `src/layouts/BaseLayout.astro` | 変更 | desktop / mobile 両ナビに「イベント情報」追加 |
| `src/lib/data/fetchEventsCsv.ts` | 新規 → 拡張 | CSV パーサ本体、`EventSpecialTier` 型、`formatEffectSummary()` 追加 |
| `src/pages/events/index.astro` | 新規 → 更新 | 一覧、イベント名を詳細ページリンクに |
| `src/pages/events/[id].astro` | 新規 | 詳細ページ (全 72 件を SSG) |

## 検証結果
- ビルド成功 (2914 ページ、うち events 詳細 72 件)
- 実施中イベント「Re:vale記念日2026」で:
  - 一覧ページ: 赤バッジ + カウントダウン + 左赤ボーダー
  - 詳細ページ: 金特効 2 枚 (記念日2026 百/千) + 銀特効 26 枚 (記念日シリーズ等) + 銅特効 多数、各カードがサムネ + 属性 + レアリティ + カード名 + アイドル名で表示
- 過去イベント「Marie MariageⅦ」(2021) で終了バッジ + グレーアウトを確認
- モバイル (390px): 1 列縦積み + ハンバーガーメニューに「イベント情報」追加確認
- コンソールエラーなし

## Test plan
- [ ] `/events/` から任意のイベント名をクリックして詳細ページへ遷移
- [ ] 詳細ページで金/銀/銅の各セクションにカードが正しく表示される
- [ ] カードをクリックしてそのカードの詳細 `/cards/{id}/` に遷移
- [ ] 実施中イベントで残り時間が秒単位で更新される
- [ ] モバイルビューで縦積みカード表示、ハンバーガーメニューに項目が含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)