### PR TITLE
fix: イベント開始時刻を 17:00 JST に統一

### DIFF
--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -84,13 +84,13 @@ const tiers: TierView[] = [
       <span
         id="status-badge"
         class="inline-block px-2 py-0.5 rounded text-xs font-semibold text-gray-500 bg-gray-100"
-        data-start={`${event.start_date}T00:00:00+09:00`}
+        data-start={`${event.start_date}T17:00:00+09:00`}
         data-end={`${event.end_date}T17:00:00+09:00`}
       >—</span>
     </div>
     <div class="mt-2 text-sm text-gray-600 space-y-0.5">
       <p>{event.eventtype}</p>
-      <p>{event.start_date} 〜 {event.end_date} 17:00 (JST)</p>
+      <p>{event.start_date} 17:00 〜 {event.end_date} 17:00 (JST)</p>
       <p id="status-remain" class="hidden"></p>
     </div>
     {event.comment && (

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -54,7 +54,7 @@ const base = import.meta.env.BASE_URL;
           <th class="px-3 py-2 w-40">状態</th>
           <th class="px-3 py-2">イベント名</th>
           <th class="px-3 py-2 w-56">イベントタイプ</th>
-          <th class="px-3 py-2 w-36">開始</th>
+          <th class="px-3 py-2 w-36">開始 (17:00)</th>
           <th class="px-3 py-2 w-44">終了 (17:00)</th>
         </tr>
       </thead>
@@ -63,7 +63,7 @@ const base = import.meta.env.BASE_URL;
           <tr
             class="event-row"
             data-id={ev.id}
-            data-start={`${ev.start_date}T00:00:00+09:00`}
+            data-start={`${ev.start_date}T17:00:00+09:00`}
             data-end={`${ev.end_date}T17:00:00+09:00`}
             data-type={ev.eventtype}
             data-name={ev.eventname}
@@ -75,7 +75,7 @@ const base = import.meta.env.BASE_URL;
             <td class="px-3 py-2 font-medium"><a href={`${base}events/${ev.id}/`} class="text-indigo-600 hover:underline">{ev.eventname}</a></td>
             <td class="px-3 py-2 text-xs text-gray-600">{ev.eventtype}</td>
             <td class="px-3 py-2 text-xs text-gray-700">{ev.start_date}</td>
-            <td class="px-3 py-2 text-xs text-gray-700">{ev.end_date} 17:00</td>
+            <td class="px-3 py-2 text-xs text-gray-700">{ev.end_date}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
イベントの実施中判定で、これまで開始時刻を `start_date` の **00:00 JST** として扱っていたが、ゲーム内の実仕様では終了時刻と同じく **17:00 JST** 区切り。開始時刻側も 17:00 に合わせて統一する。

## 変更内容
- 一覧ページ (`src/pages/events/index.astro`)
  - テーブル見出し「開始」→「開始 (17:00)」
  - テーブル値の「終了」列から「17:00」を削除して、見出しと重複しない一貫表記に整理
  - `data-start` 属性を `T00:00:00+09:00` → `T17:00:00+09:00` に変更
- 詳細ページ (`src/pages/events/[id].astro`)
  - 期間表示を「YYYY-MM-DD 〜 YYYY-MM-DD 17:00 (JST)」→「YYYY-MM-DD 17:00 〜 YYYY-MM-DD 17:00 (JST)」に変更
  - `data-start` 属性を同様に 17:00 に変更

## 影響
- 実施中判定期間: `start_date 00:00` 〜 `end_date 17:00` → `start_date 17:00` 〜 `end_date 17:00` に短縮
- 現在実施中の「Re:vale記念日2026」(2026-04-15 〜 2026-04-22) は、2026-04-15 17:00 以降 〜 2026-04-22 17:00 までが実施中扱い
- 同様に「開催予定」「終了」のステータス境界も 17:00 基準に統一

## Test plan
- [ ] `/events/` の一覧で「開始 (17:00)」列見出しになっている
- [ ] 実施中イベントの残り時間カウントダウンが正しく動作
- [ ] 詳細ページで「YYYY-MM-DD 17:00 〜 YYYY-MM-DD 17:00 (JST)」と表示される
- [ ] 開始日当日の 17:00 より前は「開催予定」、17:00 以降は「実施中」に変わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)