### PR TITLE
feat: 開催中イベントの特効カードをスコア計算でデフォルト反映

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -3,16 +3,28 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
+import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
 import { CARD_THUMB_BASE_URL } from '../../lib/constants';
 import { ATTR_TEXT_CLASS } from '../../lib/ui';
 
-const [allCards, allSongsRaw, allBroachs] = await Promise.all([
+const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchCardsJson(),
   fetchSongsJson(),
   fetchFixedBroachsJson(),
+  fetchEventsCsv(),
 ]);
 
 const allSongs = filterValidSongs(allSongsRaw);
+
+const eventsForBonus = allEvents.map(e => ({
+  id: e.id,
+  start_date: e.start_date,
+  end_date: e.end_date,
+  gold: e.gold.cardIds,
+  silver: e.silver.cardIds,
+  bronze: e.bronze.cardIds,
+}));
+
 const base = import.meta.env.BASE_URL;
 ---
 
@@ -382,6 +394,7 @@ const base = import.meta.env.BASE_URL;
   <script type="application/json" id="card-data" set:html={JSON.stringify(allCards)}></script>
   <script type="application/json" id="song-data" set:html={JSON.stringify(allSongs)}></script>
   <script type="application/json" id="broach-data" set:html={JSON.stringify(allBroachs)}></script>
+  <script type="application/json" id="events-data" set:html={JSON.stringify(eventsForBonus)}></script>
   <script define:vars={{ base, CARD_THUMB_BASE_URL }}>
     window.__BASE_URL__ = base;
     window.__CARD_THUMB_BASE_URL__ = CARD_THUMB_BASE_URL;
@@ -411,6 +424,43 @@ const base = import.meta.env.BASE_URL;
     let allCards: Card[] = JSON.parse(document.getElementById('card-data')!.textContent!);
     let allSongs: Song[] = JSON.parse(document.getElementById('song-data')!.textContent!);
     let allBroachs: FixedBroach[] = JSON.parse(document.getElementById('broach-data')!.textContent!);
+
+    interface EventForBonus {
+      id: number;
+      start_date: string;
+      end_date: string;
+      gold: number[];
+      silver: number[];
+      bronze: number[];
+    }
+    const allEventsForBonus: EventForBonus[] =
+      JSON.parse(document.getElementById('events-data')!.textContent!);
+
+    const TIER_RANK: Record<EventBonusTier, number> = { none: 0, bronze: 1, silver: 2, gold: 3 };
+
+    function buildDefaultTierMap(): Map<number, EventBonusTier> {
+      const now = Date.now();
+      const map = new Map<number, EventBonusTier>();
+      const upgrade = (id: number, tier: EventBonusTier) => {
+        const cur = map.get(id) ?? 'none';
+        if (TIER_RANK[tier] > TIER_RANK[cur]) map.set(id, tier);
+      };
+      for (const ev of allEventsForBonus) {
+        const start = Date.parse(`${ev.start_date}T00:00:00+09:00`);
+        const end = Date.parse(`${ev.end_date}T17:00:00+09:00`);
+        if (!(now >= start && now < end)) continue;
+        for (const id of ev.gold) upgrade(id, 'gold');
+        for (const id of ev.silver) upgrade(id, 'silver');
+        for (const id of ev.bronze) upgrade(id, 'bronze');
+      }
+      return map;
+    }
+    const defaultTierMap = buildDefaultTierMap();
+
+    function defaultTierFor(card: Card | null): EventBonusTier {
+      if (!card || card.ID == null) return 'none';
+      return defaultTierMap.get(card.ID) ?? 'none';
+    }
 
     const $ = (id: string) => document.getElementById(id)!;
 
@@ -948,6 +998,7 @@ const base = import.meta.env.BASE_URL;
           const card = allCards.find(c => c.ID === cardId);
           if (card && activeModalSlot >= 0) {
             deck[activeModalSlot] = card;
+            deckBonusTiers[activeModalSlot] = defaultTierFor(card);
             validateSharedBroachs(activeModalSlot);
             closeCardPicker();
             renderDeckSlots();


### PR DESCRIPTION
## Summary

- スコア計算ページでカードを選択した際、現在開催中のイベントで特効対象に含まれるカードであれば、該当する tier (金/銀/銅) の bonus が自動的に適用されるようにした
- 複数イベントが同時開催で同一カードが複数 tier に登録されている場合は最高 tier (gold > silver > bronze) を採用
- カード交換時も新カードに対する tier を再判定して上書き（旧カードの手動設定値は引き継がない）

## 実装概要

- `src/pages/score-calc/index.astro` の frontmatter で `fetchEventsCsv()` を呼び、UI 未使用フィールドを落とした軽量版 `eventsForBonus` を `<script id="events-data">` に JSON 埋め込み
- クライアント側で `Date.now()` と `${start_date}T00:00:00+09:00` 〜 `${end_date}T17:00:00+09:00` を比較して live 判定（既存の events ページと同じ判定式）
- `Map<cardId, EventBonusTier>` を初期化時に 1 回だけ構築し、カード選択ハンドラ (`deck[activeModalSlot] = card` の直後) で `deckBonusTiers[activeModalSlot] = defaultTierFor(card)` を挿入
- `card.ID` = `events.csv` の `special{N}_rID` でマッチング（`public/events/README.md` で明記済み）
- localStorage の `bonusTiers` スキーマは不変、保存値を優先する既存の復元挙動を維持

## Test plan

- [x] 現在 live な「Re:vale記念日2026」(2026-04-15〜04-22) の特効カードで手動確認
  - [x] カード 3681 (金特効) → gold が自動設定
  - [x] カード 715 (銀特効) → silver が自動設定
  - [x] カード 144 (銅特効) → bronze が自動設定
  - [x] 対象外カード選択 → none のまま
  - [x] gold 設定済みスロットに対象外カードを再選択 → none に上書き
- [x] `npm run build` 成功
- [x] ブラウザで `/i7/score-calc/` にアクセスし、スクリーンショット確認 (`tmp/score-calc-event-bonus-default.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)