### PR TITLE
feat: カード一覧/詳細に開催中イベントの特効表示とフィルタを追加

### DIFF
--- a/src/lib/cardListRenderer.ts
+++ b/src/lib/cardListRenderer.ts
@@ -9,6 +9,7 @@
 import { RARITY_BADGE_CLASSES, ATTR_BADGE_BG, ATTR_BG, ATTR_BG_HOVER, ATTR_HEX } from './constants';
 import { ATTR_TEXT_CLASS } from './ui';
 import { attrDonutSvg } from './donutChart';
+import { bonusBadgeHtml, type EventBonusTier } from './data/eventBonusTiers';
 
 // --- 設定 ---
 
@@ -115,6 +116,8 @@ export function rowBg(attrColor: string, thumbUrl: string): string {
 export interface RenderOptions {
   /** カード名クリックでフィルタする data-filter-cardname 属性を付与するか */
   enableNameFilter?: boolean;
+  /** 現在開催中のイベント特効 tier。'none' または undefined なら表示なし */
+  eventBonusTier?: EventBonusTier;
 }
 
 export function renderTableRow(card: CardListItem, opts: RenderOptions = {}): string {
@@ -137,6 +140,7 @@ export function renderTableRow(card: CardListItem, opts: RenderOptions = {}): st
     <td class="px-3 py-2">${card.name || ''}</td>
     <td class="px-3 py-2">${rarityBadge(card.rarity)}</td>
     <td class="px-3 py-2">${attrBadge(card.attribute)}</td>
+    <td class="px-3 py-2 bonus-cell">${bonusBadgeHtml(opts.eventBonusTier)}</td>
     <td class="px-3 py-2">${statsPie(card.shout_max || 0, card.beat_max || 0, card.melody_max || 0)}</td>
     <td class="px-3 py-2 text-right">${(card.shout_max || 0).toLocaleString()}<div class="text-xs text-gray-400">${pct.sPct}%</div></td>
     <td class="px-3 py-2 text-right">${(card.beat_max || 0).toLocaleString()}<div class="text-xs text-gray-400">${pct.bPct}%</div></td>
@@ -161,7 +165,7 @@ export function renderMobileCard(card: CardListItem, opts: RenderOptions = {}): 
     <div class="flex gap-3" onclick="location.href='${_base}cards/${card.ID}/'" style="cursor:pointer">
       <div class="flex-shrink-0">${imgTag(card.ID)}</div>
       <div class="flex-1 min-w-0">
-        <div class="flex items-center gap-1 mb-1">${rarityBadge(card.rarity)} ${attrBadge(card.attribute)}</div>
+        <div class="flex items-center gap-1 mb-1">${rarityBadge(card.rarity)} ${attrBadge(card.attribute)} ${bonusBadgeHtml(opts.eventBonusTier)}</div>
         <p class="font-medium text-sm truncate"${nameAttr}><span class="text-indigo-600 hover:underline cursor-pointer">${card.cardname || ''}</span></p>
         <p class="text-xs text-gray-500">${card.name || ''}</p>
         <div class="flex items-center gap-2 mt-1">

--- a/src/lib/data/eventBonusTiers.ts
+++ b/src/lib/data/eventBonusTiers.ts
@@ -27,3 +27,42 @@ export const BONUS_CLASS: Record<EventBonusTier, string> =
 
 export const ALL_SELECT_CLASSES: string[] =
   EVENT_BONUS_TIERS.flatMap(t => t.selectClasses);
+
+export interface EventForBonus {
+  id: number;
+  start_date: string;
+  end_date: string;
+  gold: number[];
+  silver: number[];
+  bronze: number[];
+}
+
+export const TIER_RANK: Record<EventBonusTier, number> = { none: 0, bronze: 1, silver: 2, gold: 3 };
+
+export function isEventLive(start_date: string, end_date: string, now: number = Date.now()): boolean {
+  const s = Date.parse(`${start_date}T00:00:00+09:00`);
+  const e = Date.parse(`${end_date}T17:00:00+09:00`);
+  return now >= s && now < e;
+}
+
+export function buildLiveTierMap(events: EventForBonus[], now: number = Date.now()): Map<number, EventBonusTier> {
+  const map = new Map<number, EventBonusTier>();
+  const upgrade = (id: number, tier: EventBonusTier) => {
+    const cur = map.get(id) ?? 'none';
+    if (TIER_RANK[tier] > TIER_RANK[cur]) map.set(id, tier);
+  };
+  for (const ev of events) {
+    if (!isEventLive(ev.start_date, ev.end_date, now)) continue;
+    for (const id of ev.gold) upgrade(id, 'gold');
+    for (const id of ev.silver) upgrade(id, 'silver');
+    for (const id of ev.bronze) upgrade(id, 'bronze');
+  }
+  return map;
+}
+
+export function bonusBadgeHtml(tier: EventBonusTier | undefined | null): string {
+  if (!tier || tier === 'none') return '';
+  const def = EVENT_BONUS_TIERS.find(t => t.key === tier);
+  if (!def) return '';
+  return `<span class="inline-block px-1.5 py-0.5 text-xs font-bold rounded border ${def.selectClasses.join(' ')}">${def.shortLabel}</span>`;
+}

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -2,23 +2,47 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
+import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
 import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
 import { ATTR_TEXT_CLASS, cardImageUrl } from '../../lib/ui';
 import { attrDonutSvg } from '../../lib/donutChart';
 import { formatSkillEffect } from '../../lib/score/skillFormatter';
 
 export async function getStaticPaths() {
-  const [cards, broachs] = await Promise.all([fetchCardsJson(), fetchFixedBroachsJson()]);
-  return (cards as any[]).map((card: any) => ({
-    params: { id: String(card.ID) },
-    props: {
-      card,
-      broachs: (broachs as any[]).filter((b: any) => b.card_id === card.cardID),
-    },
-  }));
+  const [cards, broachs, events] = await Promise.all([
+    fetchCardsJson(),
+    fetchFixedBroachsJson(),
+    fetchEventsCsv(),
+  ]);
+  return (cards as any[]).map((card: any) => {
+    const cardId = card.ID;
+    const relatedEvents = events
+      .filter(e =>
+        e.gold.cardIds.includes(cardId) ||
+        e.silver.cardIds.includes(cardId) ||
+        e.bronze.cardIds.includes(cardId)
+      )
+      .map(e => ({
+        id: e.id,
+        eventname: e.eventname,
+        start_date: e.start_date,
+        end_date: e.end_date,
+        tier: e.gold.cardIds.includes(cardId)
+          ? 'gold'
+          : e.silver.cardIds.includes(cardId) ? 'silver' : 'bronze',
+      }));
+    return {
+      params: { id: String(cardId) },
+      props: {
+        card,
+        broachs: (broachs as any[]).filter((b: any) => b.card_id === card.cardID),
+        relatedEvents,
+      },
+    };
+  });
 }
 
-const { card, broachs } = Astro.props;
+const { card, broachs, relatedEvents } = Astro.props;
 const base = import.meta.env.BASE_URL;
 
 const infoRows = [
@@ -86,6 +110,12 @@ const otherSkills = [
           </tbody>
         </table>
       </div>
+
+      {/* 現在開催中の特効 (クライアント側で live 判定) */}
+      <section id="current-bonus-section" class="bg-white rounded-lg shadow p-4 hidden">
+        <h2 class="text-lg font-semibold mb-3">🎯 現在開催中の特効</h2>
+        <ul id="current-bonus-list" class="space-y-2 text-sm"></ul>
+      </section>
 
       {/* ステータス */}
       {(() => {
@@ -178,7 +208,7 @@ const otherSkills = [
 
   <!-- ブローチ情報 -->
   {broachs.length > 0 && (
-    <section class="bg-white rounded-lg shadow p-6 mb-6">
+    <section class="bg-white rounded-lg shadow p-6 mb-6" id="broach-section">
       <h2 class="text-lg font-semibold mb-4">固有ブローチ</h2>
       <div class="space-y-3">
         {broachs.map((b: any) => (
@@ -195,4 +225,43 @@ const otherSkills = [
       </div>
     </section>
   )}
+
+  <script type="application/json" id="related-events-data" set:html={JSON.stringify(relatedEvents)}></script>
+  <script define:vars={{ base }}>
+    window.__BASE_URL__ = base;
+  </script>
+  <script>
+    import { isEventLive, bonusBadgeHtml, TIER_RANK, type EventBonusTier } from '../../lib/data/eventBonusTiers';
+
+    interface RelatedEvent {
+      id: number;
+      eventname: string;
+      start_date: string;
+      end_date: string;
+      tier: EventBonusTier;
+    }
+
+    const raw = document.getElementById('related-events-data')?.textContent ?? '[]';
+    const relatedEvents: RelatedEvent[] = JSON.parse(raw);
+    const base = (window as any).__BASE_URL__ || '/i7/';
+
+    const liveHits = relatedEvents
+      .filter(r => isEventLive(r.start_date, r.end_date))
+      .sort((a, b) => TIER_RANK[b.tier] - TIER_RANK[a.tier]);
+
+    if (liveHits.length > 0) {
+      const list = document.getElementById('current-bonus-list');
+      const section = document.getElementById('current-bonus-section');
+      if (list && section) {
+        list.innerHTML = liveHits.map(h =>
+          `<li class="flex flex-wrap items-center gap-2">
+            ${bonusBadgeHtml(h.tier)}
+            <a href="${base}events/${h.id}/" class="text-indigo-600 hover:underline font-medium">${h.eventname}</a>
+            <span class="text-xs text-gray-500">${h.start_date} 〜 ${h.end_date}</span>
+          </li>`
+        ).join('');
+        section.classList.remove('hidden');
+      }
+    }
+  </script>
 </BaseLayout>

--- a/src/pages/cards/index.astro
+++ b/src/pages/cards/index.astro
@@ -1,10 +1,23 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
+import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
 import { CHARACTERS, RARITIES, ATTRIBUTES, CARD_THUMB_BASE_URL, ATTRIBUTE_MAP, PAGE_SIZE } from '../../lib/constants';
 
-const allCards = await fetchCardsJson() as any[];
+const [allCards, allEvents] = await Promise.all([
+  fetchCardsJson() as Promise<any[]>,
+  fetchEventsCsv(),
+]);
 const skillTypes = [...new Set(allCards.map((c: any) => c.ap_skill_type).filter(Boolean))].sort() as string[];
+
+const eventsForBonus = allEvents.map(e => ({
+  id: e.id,
+  start_date: e.start_date,
+  end_date: e.end_date,
+  gold: e.gold.cardIds,
+  silver: e.silver.cardIds,
+  bronze: e.bronze.cardIds,
+}));
 
 const base = import.meta.env.BASE_URL;
 ---
@@ -14,7 +27,7 @@ const base = import.meta.env.BASE_URL;
 
   <!-- 検索フォーム -->
   <div class="bg-white rounded-lg shadow p-4 mb-6">
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7 gap-3">
       <div>
         <label for="search-text" class="block text-xs font-medium text-gray-500 mb-1">名前検索</label>
         <input type="text" id="search-text" placeholder="カード名/キャラ名"
@@ -42,6 +55,14 @@ const base = import.meta.env.BASE_URL;
         <label for="search-skill" class="block text-xs font-medium text-gray-500 mb-1">スキルタイプ</label>
         <select id="search-skill" multiple class="w-full border border-gray-300 rounded px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 h-[4.5rem]">
           {skillTypes.map(s => <option value={s}>{s}</option>)}
+        </select>
+      </div>
+      <div id="bonus-filter-wrapper" class="hidden">
+        <label for="search-bonus" class="block text-xs font-medium text-gray-500 mb-1">特効</label>
+        <select id="search-bonus" multiple class="w-full border border-gray-300 rounded px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 h-[4.5rem]">
+          <option value="gold">金特効</option>
+          <option value="silver">銀特効</option>
+          <option value="bronze">銅特効</option>
         </select>
       </div>
       <div>
@@ -73,6 +94,7 @@ const base = import.meta.env.BASE_URL;
             <th class="px-3 py-2">キャラ</th>
             <th class="px-3 py-2">レア</th>
             <th class="px-3 py-2">属性</th>
+            <th id="bonus-th" class="px-3 py-2 hidden">特効</th>
             <th class="px-3 py-2 w-20">属性比率</th>
             <th class="px-3 py-2 text-right">Shout</th>
             <th class="px-3 py-2 text-right">Beat</th>
@@ -103,6 +125,7 @@ const base = import.meta.env.BASE_URL;
 
   <!-- ビルド時に埋め込んだカードデータ -->
   <script type="application/json" id="card-data" set:html={JSON.stringify(allCards)}></script>
+  <script type="application/json" id="events-data" set:html={JSON.stringify(eventsForBonus)}></script>
   <script define:vars={{ base, PAGE_SIZE, CARD_THUMB_BASE_URL, ATTRIBUTE_MAP }}>
     window.__BASE_URL__ = base;
     window.__PAGE_SIZE__ = PAGE_SIZE;
@@ -116,6 +139,7 @@ const base = import.meta.env.BASE_URL;
       getCount, setCount,
       renderTableRow, renderMobileCard,
     } from '../../lib/cardListRenderer';
+    import { buildLiveTierMap, type EventForBonus, type EventBonusTier } from '../../lib/data/eventBonusTiers';
 
     const base = (window as any).__BASE_URL__ || '/i7/';
     const PAGE_SIZE = (window as any).__PAGE_SIZE__ || 100;
@@ -123,9 +147,14 @@ const base = import.meta.env.BASE_URL;
 
     initRenderer({ base, thumbUrl: THUMB_URL });
 
-    const renderOpts = { enableNameFilter: true };
-
     let allCards: CardListItem[] = JSON.parse(document.getElementById('card-data')!.textContent!);
+    const allEventsForBonus: EventForBonus[] = JSON.parse(document.getElementById('events-data')!.textContent!);
+    const tierMap = buildLiveTierMap(allEventsForBonus);
+    const hasAnyLive = tierMap.size > 0;
+    if (hasAnyLive) {
+      document.getElementById('bonus-filter-wrapper')?.classList.remove('hidden');
+      document.getElementById('bonus-th')?.classList.remove('hidden');
+    }
     let filtered: CardListItem[] = [];
     let loadedPages = 0;
     let hasMore = true;
@@ -164,11 +193,12 @@ const base = import.meta.env.BASE_URL;
       }
 
       // ページ境界マーカー（スクロール位置 → URL 追跡用）
-      const markerTr = `<tr data-page-marker="${loadedPages}" aria-hidden="true" style="height:0"><td colspan="12" style="height:0;padding:0;border:0"></td></tr>`;
+      const markerTr = `<tr data-page-marker="${loadedPages}" aria-hidden="true" style="height:0"><td colspan="13" style="height:0;padding:0;border:0"></td></tr>`;
       const markerDiv = `<div data-page-marker="${loadedPages}" aria-hidden="true"></div>`;
 
-      const tableHtml = markerTr + page.map(c => renderTableRow(c, renderOpts)).join('');
-      const mobileHtml = markerDiv + page.map(c => renderMobileCard(c, renderOpts)).join('');
+      const optsFor = (c: CardListItem) => ({ enableNameFilter: true, eventBonusTier: tierMap.get(c.ID) });
+      const tableHtml = markerTr + page.map(c => renderTableRow(c, optsFor(c))).join('');
+      const mobileHtml = markerDiv + page.map(c => renderMobileCard(c, optsFor(c))).join('');
 
       $('table-body').insertAdjacentHTML('beforeend', tableHtml);
       $('mobile-cards').insertAdjacentHTML('beforeend', mobileHtml);
@@ -236,6 +266,9 @@ const base = import.meta.env.BASE_URL;
       const attributes = getSelectedValues($('search-attribute') as HTMLSelectElement);
       const characters = getSelectedValues($('search-character') as HTMLSelectElement);
       const skillTypes = getSelectedValues($('search-skill') as HTMLSelectElement);
+      const bonuses = hasAnyLive
+        ? getSelectedValues($('search-bonus') as HTMLSelectElement)
+        : [];
       const sortBy = ($('sort-by') as HTMLSelectElement).value;
 
       filtered = allCards.filter(card => {
@@ -245,6 +278,10 @@ const base = import.meta.env.BASE_URL;
         if (attributes.length && !attributes.includes(card.attribute)) return false;
         if (characters.length && !characters.includes(card.name)) return false;
         if (skillTypes.length && !skillTypes.includes(card.ap_skill_type || '')) return false;
+        if (bonuses.length) {
+          const t = tierMap.get(card.ID);
+          if (!t || !bonuses.includes(t)) return false;
+        }
         return true;
       });
 
@@ -301,6 +338,10 @@ const base = import.meta.env.BASE_URL;
       if (attributes.length) params.set('attr', attributes.join(','));
       if (characters.length) params.set('char', characters.join(','));
       if (skillTypes.length) params.set('skill', skillTypes.join(','));
+      if (hasAnyLive) {
+        const bonuses = getSelectedValues($('search-bonus') as HTMLSelectElement);
+        if (bonuses.length) params.set('bonus', bonuses.join(','));
+      }
       if (sortBy !== 'id-desc') params.set('sort', sortBy);
       if (currentVisiblePage > 1) params.set('page', String(currentVisiblePage));
 
@@ -321,6 +362,9 @@ const base = import.meta.env.BASE_URL;
       restoreMultiSelect($('search-attribute') as HTMLSelectElement, params.get('attr'));
       restoreMultiSelect($('search-character') as HTMLSelectElement, params.get('char'));
       restoreMultiSelect($('search-skill') as HTMLSelectElement, params.get('skill'));
+      if (hasAnyLive) {
+        restoreMultiSelect($('search-bonus') as HTMLSelectElement, params.get('bonus'));
+      }
       if (params.get('sort')) ($('sort-by') as HTMLSelectElement).value = params.get('sort')!;
       const pageParam = params.get('page');
       initialTargetPage = pageParam ? Math.max(1, parseInt(pageParam, 10) || 1) : 1;
@@ -389,12 +433,16 @@ const base = import.meta.env.BASE_URL;
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(applyFilters, 300);
     });
-    for (const id of ['search-rarity', 'search-attribute', 'search-character', 'search-skill', 'sort-by']) {
+    const filterSelects = ['search-rarity', 'search-attribute', 'search-character', 'search-skill', 'sort-by'];
+    if (hasAnyLive) filterSelects.push('search-bonus');
+    for (const id of filterSelects) {
       $(id).addEventListener('change', applyFilters);
     }
     $('btn-reset').addEventListener('click', () => {
       ($('search-text') as HTMLInputElement).value = '';
-      ['search-rarity', 'search-attribute', 'search-character', 'search-skill'].forEach(id => {
+      const resetIds = ['search-rarity', 'search-attribute', 'search-character', 'search-skill'];
+      if (hasAnyLive) resetIds.push('search-bonus');
+      resetIds.forEach(id => {
         const sel = $(id) as HTMLSelectElement;
         Array.from(sel.options).forEach(o => { o.selected = false; });
       });


### PR DESCRIPTION
## Summary

- カード一覧画面で、現在開催中 (live) のイベントで特効対象カードに金/銀/銅のバッジを表示
- カード一覧に「特効」フィルタ（金/銀/銅 複数選択）を追加、URL パラメータ連動
- カード詳細画面に「現在開催中の特効」セクションを追加し、対象イベント名と期間へのリンクを表示
- すべてクライアント側 `Date.now()` 判定なので、イベント終了時刻を過ぎたら自動で非表示に戻る

## 実装概要

- `src/lib/data/eventBonusTiers.ts` に共通ロジックを追加:
  - `EventForBonus` 型、`TIER_RANK`, `isEventLive(start, end, now)`
  - `buildLiveTierMap(events, now)`: live イベント特効の Map<cardId, tier> を構築（最高 tier 採用）
  - `bonusBadgeHtml(tier)`: バッジ HTML 文字列
- `src/lib/cardListRenderer.ts`:
  - `RenderOptions.eventBonusTier` を追加
  - `renderTableRow` に特効セル追加、`renderMobileCard` にバッジ追加
- `src/pages/cards/index.astro`:
  - frontmatter で `fetchEventsCsv()` → `eventsForBonus` 軽量 JSON を埋め込み
  - `#search-bonus` select と `#bonus-th` 列を追加（live イベントなしなら hidden のまま）
  - `applyFilters` / `updateUrlParams` / `restoreFromUrl` を拡張
- `src/pages/cards/[id].astro`:
  - `getStaticPaths` で各カードの関連イベントだけを props に抽出（全 events を埋め込まないのでページ HTML 肥大を回避）
  - `#current-bonus-section` を追加、クライアント JS で `isEventLive` で絞って tier 順に表示

## Test plan

- [x] `npm run build` 成功（2914 pages）
- [x] `/i7/cards/` で「特効」列と `#search-bonus` フィルタが表示される
- [x] Re:vale記念日2026 (2026-04-15〜04-22) 対象カード 3681/3682 に金バッジ
- [x] `?bonus=gold` で 2 件のみに絞り込まれる、URL も付与される
- [x] `/i7/cards/3681/` 詳細で「現在開催中の特効」セクションに `[金] Re:vale記念日2026 2026-04-15 〜 2026-04-22` が表示
- [x] 過去に特効対象だったが現在 live ではないカード (ID 13) では section が hidden のまま
- [x] 未来時刻で `isEventLive` が false を返すことを確認（自動非表示ロジック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)