### PR TITLE
fix: about ページの謝辞セクションを整形しクレジットの重複を解消

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -55,14 +55,6 @@ const base = import.meta.env.BASE_URL;
         </dd>
       </div>
       <div class="flex flex-col sm:flex-row sm:gap-4">
-        <dt class="font-semibold sm:w-40 shrink-0">アドバイザー</dt>
-        <dd>
-          <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a>
-          <span class="mx-1 text-gray-400">/</span>
-          <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
-        </dd>
-      </div>
-      <div class="flex flex-col sm:flex-row sm:gap-4">
         <dt class="font-semibold sm:w-40 shrink-0">衣装・画像取得元</dt>
         <dd>
           <a href="https://i7.step-on-dream.net/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">i7.step-on-dream.net</a>
@@ -118,6 +110,21 @@ const base = import.meta.env.BASE_URL;
     <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
       <li>所持カード・デッキ・ラビットノート値などのユーザー入力は、ブラウザの <code class="px-1 py-0.5 bg-gray-100 rounded">localStorage</code> のみに保存され、サーバーへ送信されません。</li>
       <li>データのエクスポート・完全削除はブラウザの設定または各ページ上のクリア機能から行えます。</li>
+    </ul>
+  </section>
+
+  <section class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">謝辞</h2>
+    <p class="text-sm text-gray-700 mb-2">
+      本サイト作成の際、下記のお二人には多大なるお力添えをいただきました。感謝いたします。
+    </p>
+    <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
+      <li>
+        <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a>
+      </li>
+      <li>
+        <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
+      </li>
     </ul>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- 「謝辞」セクションに別セクション (プライバシー) の文言が紛れ込み、\`<ul>\` / \`<li>\` の閉じタグが崩れていたのを整形
- 本文を \`<p>\` に分離、2アカウントを \`<li>\` でリスト化
- 「クレジット > アドバイザー」行を削除して「謝辞」セクションに一本化（重複解消）

## 変更詳細
- \`src/pages/about/index.astro\`:
  - 「謝辞」セクション: 導入文を \`<p>\`、\`@megoonarite\` / \`@miyaaaaaki_i7\` を \`<ul><li>\` に構造化
  - 「クレジット」セクション: \`アドバイザー\` 行を削除

## Test plan
- [x] \`docker compose up preview\` で表示確認済み (\`tmp/about-after.png\`)
- [ ] マージ後、\`v1.7.29\` タグで Cloudflare Workers にデプロイし本番で表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)