### PR TITLE
refactor: サイト名を SITE_NAME 定数化し「i7ごったに部屋」に改称

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { execSync } from 'node:child_process';
 import '../styles/global.css';
+import { SITE_NAME } from '../lib/constants.ts';
 
 interface Props {
   title: string;
@@ -25,7 +26,7 @@ const repoUrl = 'https://github.com/yo4raw/i7';
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="アイドリッシュセブン カードデータベース" />
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
-    <title>{title} | i7 カードDB</title>
+    <title>{title} | {SITE_NAME}</title>
     <script src="https://unpkg.com/htmx.org@2.0.4" is:inline></script>
     <!-- Google Tag Manager -->
     <script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -42,7 +43,7 @@ const repoUrl = 'https://github.com/yo4raw/i7';
     <!-- End Google Tag Manager (noscript) -->
     <header class="bg-indigo-700 text-white sticky top-0 z-50 shadow-md">
       <nav class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-        <a href={base} class="text-lg font-bold tracking-wide">i7 カードDB</a>
+        <a href={base} class="text-lg font-bold tracking-wide">{SITE_NAME}</a>
         <button id="menu-toggle" class="md:hidden p-1" aria-label="メニュー">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+export const SITE_NAME = 'i7ごったに部屋';
+
 export const CHARACTERS = [
   '和泉一織', '二階堂大和', '和泉三月', '四葉環',
   '逢坂壮五', '六弥ナギ', '七瀬陸',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../lib/data/fetchCardsJson.ts';
 import { fetchSongsJson } from '../lib/data/fetchSongsJson.ts';
 import { fetchEventsCsv } from '../lib/data/fetchEventsCsv.ts';
-import { RARITIES, RARITY_BADGE_CLASSES } from '../lib/constants.ts';
+import { RARITIES, RARITY_BADGE_CLASSES, SITE_NAME } from '../lib/constants.ts';
 
 const [cards, songs, events] = await Promise.all([
   fetchCardsJson(),
@@ -39,7 +39,7 @@ const base = import.meta.env.BASE_URL;
   <section class="mb-8">
     <h1 class="text-2xl font-bold mb-2">アイドリッシュセブン カードデータベース</h1>
     <p class="text-sm text-gray-600">
-      当サイト「i7 カードDB」は、スマートフォン向けゲーム『アイドリッシュセブン』のカード・楽曲・イベント情報をまとめた、ファンによる<strong>非公式</strong>のデータベースサイトです。
+      当サイト「{SITE_NAME}」は、スマートフォン向けゲーム『アイドリッシュセブン』のカード・楽曲・イベント情報をまとめた、ファンによる<strong>非公式</strong>のデータベースサイトです。
     </p>
   </section>
 

--- a/tests/card-list.test.ts
+++ b/tests/card-list.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
 
 const BASE = '/i7';
 
@@ -10,7 +11,7 @@ test.describe('カード一覧ページ', () => {
   });
 
   test('タイトルが正しい', async ({ page }) => {
-    await expect(page).toHaveTitle(/カード一覧.*i7 カードDB/);
+    await expect(page).toHaveTitle(new RegExp(`カード一覧.*${SITE_NAME}`));
   });
 
   test('検索フォームが表示される', async ({ page }) => {

--- a/tests/home.test.ts
+++ b/tests/home.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
 
 const BASE = '/i7';
 
@@ -8,7 +9,7 @@ test.describe('ホームページ', () => {
   });
 
   test('タイトルが正しい', async ({ page }) => {
-    await expect(page).toHaveTitle(/ホーム.*i7 カードDB/);
+    await expect(page).toHaveTitle(new RegExp(`ホーム.*${SITE_NAME}`));
   });
 
   test('ナビゲーションリンクが存在する', async ({ page }) => {
@@ -22,7 +23,7 @@ test.describe('ホームページ', () => {
   test('カード一覧・楽曲一覧のリンクカードが表示される', async ({ page }) => {
     await expect(page.getByText('カード一覧').first()).toBeVisible();
     await expect(page.getByText('楽曲一覧').first()).toBeVisible();
-    await expect(page.getByText('レアリティ別')).toBeVisible();
+    await expect(page.getByText('カード内訳')).toBeVisible();
   });
 
   test('カード枚数と楽曲数が0より大きい', async ({ page }) => {

--- a/tests/mycard.test.ts
+++ b/tests/mycard.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
 
 const BASE = '/i7';
 
@@ -8,7 +9,7 @@ test.describe('所持カードページ', () => {
   });
 
   test('タイトルが正しい', async ({ page }) => {
-    await expect(page).toHaveTitle(/所持カード一覧.*i7 カードDB/);
+    await expect(page).toHaveTitle(new RegExp(`所持カード一覧.*${SITE_NAME}`));
   });
 
   test('所持カードがない場合は空メッセージが表示される', async ({ page }) => {

--- a/tests/song-list.test.ts
+++ b/tests/song-list.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
 
 const BASE = '/i7';
 
@@ -10,7 +11,7 @@ test.describe('楽曲一覧ページ', () => {
   });
 
   test('タイトルが正しい', async ({ page }) => {
-    await expect(page).toHaveTitle(/楽曲一覧.*i7 カードDB/);
+    await expect(page).toHaveTitle(new RegExp(`楽曲一覧.*${SITE_NAME}`));
   });
 
   test('検索フォームが表示される', async ({ page }) => {


### PR DESCRIPTION
## Summary

- ハードコードされていた「i7 カードDB」の文字列を `src/lib/constants.ts` の **`SITE_NAME` 定数に集約**。
- 新しいサイト名 **「i7ごったに部屋」** に改称 (定数 1 箇所の変更で全体に反映)。
- 前 PR (#105) で変更したホームの「レアリティ別」→「カード内訳」の差分を E2E テストにも反映。

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `src/lib/constants.ts` | `SITE_NAME = 'i7ごったに部屋'` を追加 |
| `src/layouts/BaseLayout.astro` | `<title>` とヘッダーロゴで定数を参照 |
| `src/pages/index.astro` | ヒーロー下の「当サイト『〇〇』は…」で定数を参照 |
| `tests/{home,card-list,song-list,mycard}.test.ts` | タイトル検証の正規表現を `new RegExp(\`...\${SITE_NAME}\`)` に置換 |
| `tests/home.test.ts` | 「レアリティ別」→「カード内訳」に追随修正 |

## Motivation

#105 でトップページを再構成した際に、サイト名がレイアウト・ホーム・各 E2E テストに 7 箇所重複していたので、1 箇所に集約して改称を 1 行差分で済むようにした。

## Test plan

- [ ] CI ビルド成功 (`npm run build`)
- [ ] ヘッダーロゴ / ブラウザタブのタイトルが「i7ごったに部屋」になっていること
- [ ] ホームページ冒頭の「当サイト『i7ごったに部屋』は…」表記
- [ ] E2E テスト (`npm run test`) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)