### PR TITLE
refactor: サイト名を「i7マネ部屋(β)」に変更

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const SITE_NAME = 'i7ごったに部屋';
+export const SITE_NAME = 'i7マネ部屋(β)';
 
 export const CHARACTERS = [
   '和泉一織', '二階堂大和', '和泉三月', '四葉環',


### PR DESCRIPTION
## Summary
- サイト名を「i7ごったに部屋」から「**i7マネ部屋(β)**」に変更
- アイナナファンの通称「マネ(ージャー)」を取り込み、略称で呼びやすく当事者感のある名前に
- 変更箇所は `src/lib/constants.ts` の `SITE_NAME` 定数 1 行のみ(全参照箇所は定数経由で自動追従)

## Test plan
- [ ] `docker compose up preview` でヘッダー・`<title>` が「i7マネ部屋(β)」になっているか確認
- [ ] `npm run test` で Playwright E2E(SITE_NAME 参照箇所)がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)