### PR TITLE
ci(fetch-new-th-cards): 取得結果をログに出力して原因切り分け可能に

### DIFF
--- a/.github/workflows/fetch-new-th-cards.yml
+++ b/.github/workflows/fetch-new-th-cards.yml
@@ -99,7 +99,8 @@ jobs:
           export -f fetch_thumbnail
 
           RESULTS=$(echo "$MISSING_IDS" | grep -E '^[0-9]+$' \
-            | xargs -P 10 -I {} bash -c 'fetch_thumbnail "$@"' _ {} || true)
+            | xargs -P 10 -I {} bash -c 'fetch_thumbnail "$@"' _ {} \
+            | tee /dev/stderr || true)
 
           DOWNLOADED=$(echo "$RESULTS" | grep -c "^OK:" || true)
           NEW_IDS=$(echo "$RESULTS" | grep "^OK:" | sed 's/^OK://' | sort -n | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g' || true)


### PR DESCRIPTION
## Summary
`fetch-new-th-cards.yml` の fetch_thumbnail 関数は `OK:` / `SKIP:` / `FAIL:` を per-ID で echo していたが、これらが `$()` コマンド置換で `RESULTS` 変数に吸い込まれ、**Actions ログには `Total downloaded: N` しか残らない**状態だった。

これを `| tee /dev/stderr` で stderr にも同時出力するよう変更。

## 効果
- 今後「detect はしたが downloaded=0」が起きた際に、どの ID が何の理由で失敗したかログから特定できる
- 例: `FAIL:3699` → HTTP 非 200 (404/5xx/タイムアウト等) / `SKIP:3699` → 200 だが非 PNG

## Test plan
- [ ] マージ後に `workflow_dispatch` で手動実行し、per-ID ログが Actions ログに出ることを確認
- [ ] 現在 3699 のサムネが未取得なので、このトリガで PR が作られれば挙動確認も兼ねられる

🤖 Generated with [Claude Code](https://claude.com/claude-code)