### PR TITLE
refactor: フッターを version 表示のみに簡素化

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,6 @@ try {
 } catch {
   // git 未使用環境やタグ不在時はフォールバック
 }
-const repoUrl = 'https://github.com/yo4raw/i7';
 ---
 
 <!doctype html>
@@ -74,11 +73,8 @@ const repoUrl = 'https://github.com/yo4raw/i7';
     <main class="flex-1 max-w-7xl mx-auto px-4 py-6 w-full">
       <slot />
     </main>
-    <footer class="text-xs text-gray-500 py-3 px-4 flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
-      <span class="text-center">
-        Special thanks to <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a> and <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a> / created by <a href="https://x.com/yo4raw_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@yo4raw_i7</a>
-      </span>
-      <a href={`${repoUrl}/releases/tag/${version}`} target="_blank" rel="noopener noreferrer" class="ml-auto text-gray-400 hover:text-indigo-600 hover:underline">{version}</a>
+    <footer class="text-xs text-gray-400 py-3 px-4 flex items-center justify-center">
+      <span>{version}</span>
     </footer>
     <script>
       const toggle = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- フッターのクレジット文言（Special thanks / created by）を削除し、表示を version のみに簡素化
- version から GitHub Releases への外部リンクを外し、`<span>` として非リンク表示に変更
- 未使用になった `repoUrl` 定数を削除

## Test plan
- [ ] ローカルプレビュー (`docker compose up preview`) でフッターに version のみが表示されることを確認
- [ ] version 文字列がリンクではなくテキストとして表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)