### PR TITLE
fix(home): 謝辞セクションの重複と壊れた HTML を整理

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,7 +155,7 @@ const base = import.meta.env.BASE_URL;
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">
     <h2 class="text-lg font-bold text-indigo-700 mb-3">謝辞</h2>
-    <dl class="text-sm text-gray-700 space-y-3">
+    <dl class="text-sm text-gray-700 space-y-3 mb-4">
       <div class="flex flex-col sm:flex-row sm:gap-4">
         <dt class="font-semibold sm:w-40 shrink-0">各種データの取得元</dt>
         <dd>
@@ -163,7 +163,7 @@ const base = import.meta.env.BASE_URL;
         </dd>
       </div>
       <div class="flex flex-col sm:flex-row sm:gap-4">
-        <dt class="font-semibold sm:w-40 shrink-0">スコア計算の仕様について下記のページを参考させていただきました</dt>
+        <dt class="font-semibold sm:w-40 shrink-0">スコア計算の仕様参考</dt>
         <dd>
           <a href="https://ota-life.com/id7-score-tool/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">オタライフ |【アイドリッシュセブン】スコア計算ツール無料配布【スマホ対応】</a>
         </dd>
@@ -180,28 +180,6 @@ const base = import.meta.env.BASE_URL;
         <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
       </li>
     </ul>
-  </section>
-
-  <section class="bg-white rounded-lg shadow p-6 mb-6">
-    <h2 class="text-lg font-bold text-indigo-700 mb-3">謝辞</h2>
-    <p class="text-sm text-gray-700 mb-2">
-      本サイト作成の際、下記のお二人には多大なるお力添えをいただきました。感謝いたします。
-    </p>
-    <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
-      <li>
-        <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a>
-      </li>
-      <li>
-        <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
-      </li>
-    </ul>
-      <div class="flex flex-col sm:flex-row sm:gap-4">
-        <dt class="font-semibold sm:w-40 shrink-0">各種データの取得元として下記のサイトを参照しております</dt>
-        <dd>
-          <a href="https://i7.step-on-dream.net/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">i7.step-on-dream.net</a>
-        </dd>
-      </div>
-      <div class="flex flex-col sm:flex-row sm:gap-4">
   </section>
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">


### PR DESCRIPTION
## Summary
- ホーム画面 `src/pages/index.astro` の謝辞セクションが編集途中の状態で残っており、`<h2>謝辞</h2>` や「データ取得元」の dt/dd ペアが重複、末尾の `<div>` が閉じタグなしで `</section>` に入って HTML 構造が壊れていた
- `<dl>` (データ提供元・参考ページ) と協力者謝辞 (`<p>` + `<ul>`) を 1 セクションにまとめ直し、重複ブロックと未閉 `<div>` を削除
- 長すぎる dt ラベル「スコア計算の仕様について下記のページを参考させていただきました」を `sm:w-40` に収まる「スコア計算の仕様参考」に短縮し、`<dl>` 末尾に `mb-4` を追加して協力者ブロックとの間を視覚的に区切り

## Test plan
- [ ] `docker compose up preview` でビルドが通ること
- [ ] `http://localhost:4321/` のホーム画面で「謝辞」セクションが 1 つだけ表示され、データ取得元・参考ページ・協力者リンクが正しい順序で並ぶこと
- [ ] DevTools で `</section>` まで HTML 構造が閉じていること (余計な空 `<div>` が残っていないこと)
- [ ] `npm run test` の `home.test.ts` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)