### PR TITLE
feat(secrets): 同じカードを複数スロット配置可能にする探索ロジック更新

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,7 +155,7 @@ const base = import.meta.env.BASE_URL;
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">
     <h2 class="text-lg font-bold text-indigo-700 mb-3">謝辞</h2>
-    <dl class="text-sm text-gray-700 space-y-3">
+    <dl class="text-sm text-gray-700 space-y-3 mb-4">
       <div class="flex flex-col sm:flex-row sm:gap-4">
         <dt class="font-semibold sm:w-40 shrink-0">各種データの取得元</dt>
         <dd>
@@ -163,7 +163,7 @@ const base = import.meta.env.BASE_URL;
         </dd>
       </div>
       <div class="flex flex-col sm:flex-row sm:gap-4">
-        <dt class="font-semibold sm:w-40 shrink-0">スコア計算の仕様について下記のページを参考させていただきました</dt>
+        <dt class="font-semibold sm:w-40 shrink-0">スコア計算の仕様参考</dt>
         <dd>
           <a href="https://ota-life.com/id7-score-tool/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">オタライフ |【アイドリッシュセブン】スコア計算ツール無料配布【スマホ対応】</a>
         </dd>
@@ -180,28 +180,6 @@ const base = import.meta.env.BASE_URL;
         <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
       </li>
     </ul>
-  </section>
-
-  <section class="bg-white rounded-lg shadow p-6 mb-6">
-    <h2 class="text-lg font-bold text-indigo-700 mb-3">謝辞</h2>
-    <p class="text-sm text-gray-700 mb-2">
-      本サイト作成の際、下記のお二人には多大なるお力添えをいただきました。感謝いたします。
-    </p>
-    <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
-      <li>
-        <a href="https://x.com/megoonarite" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@megoonarite</a>
-      </li>
-      <li>
-        <a href="https://x.com/miyaaaaaki_i7" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">@miyaaaaaki_i7</a>
-      </li>
-    </ul>
-      <div class="flex flex-col sm:flex-row sm:gap-4">
-        <dt class="font-semibold sm:w-40 shrink-0">各種データの取得元として下記のサイトを参照しております</dt>
-        <dd>
-          <a href="https://i7.step-on-dream.net/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">i7.step-on-dream.net</a>
-        </dd>
-      </div>
-      <div class="flex flex-col sm:flex-row sm:gap-4">
   </section>
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">

--- a/src/pages/secrets/index.astro
+++ b/src/pages/secrets/index.astro
@@ -33,6 +33,7 @@ const base = import.meta.env.BASE_URL;
   <h1 class="text-2xl font-bold mb-4">🔐 Secrets - 理論値最大編成探索</h1>
   <p class="text-xs text-gray-500 mb-4">
     楽曲を選択すると、開催中イベントの <b>金特効</b> / <b>銀特効</b> の UR カードのみを対象に、理論期待値が最大となる 6 枚編成（フレンド含む）を総当たりで探索します。
+    <br />同じカードを複数スロットに配置することも許容します（例: 金特効を複数スロットに重複装備）。
     <br />スキルレベルは全て Lv5 / 特訓済み前提。固有ブローチは自動判定、共有ブローチ・SCOREUPアシスト・バッジは未装着として扱います。
   </p>
 
@@ -75,9 +76,14 @@ const base = import.meta.env.BASE_URL;
 
   <!-- 探索ボタン -->
   <div class="space-y-2 mb-4">
-    <button id="btn-search" class="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold text-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
-      🔍 総当たり探索を開始
-    </button>
+    <div class="flex gap-2">
+      <button id="btn-search" class="flex-1 bg-indigo-600 text-white py-3 rounded-lg font-bold text-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+        🔍 総当たり探索を開始
+      </button>
+      <button id="btn-abort" class="hidden px-4 bg-red-500 text-white py-3 rounded-lg font-bold text-sm hover:bg-red-600 transition-colors">
+        中断
+      </button>
+    </div>
     <p id="search-disabled-reason" class="text-xs text-center text-amber-600"></p>
     <div id="progress-container" class="hidden">
       <div class="w-full bg-gray-200 rounded-full h-2">
@@ -227,6 +233,7 @@ const base = import.meta.env.BASE_URL;
       evaluated: number;
       elapsedMs: number;
       evalMode: 'expected' | 'max';
+      aborted?: boolean;
     }
 
     // --- 楽曲セレクト初期化 ---
@@ -342,9 +349,10 @@ const base = import.meta.env.BASE_URL;
         }).join('') + (cards.length > 30 ? `<span class="text-[10px] text-gray-400">…他 ${cards.length - 30}枚</span>` : '');
       };
 
-      // 組合せ数推定: C(N, 6) × P(6, 2) (スロット1-4は順不同、センター・フレンドは順序有意)
+      // 組合せ数: センター N × フレンド N × メンバー4枚(重複可・順不同) multichoose(N, 4)
+      // = N^2 × C(N+3, 4)
       const N = currentCandidates.length;
-      const comb = N >= 6 ? binomial(N, 6) * 30 : 0;
+      const comb = N >= 1 ? N * N * multichoose(N, 4) : 0;
 
       body.innerHTML = `
         <ul class="mb-2 list-disc pl-5">${eventList}</ul>
@@ -378,6 +386,11 @@ const base = import.meta.env.BASE_URL;
       return r;
     }
 
+    // 重複ありで k 個を N 個から選ぶ場合の数 (多重組合せ) = C(N+k-1, k)
+    function multichoose(n: number, k: number): number {
+      return binomial(n + k - 1, k);
+    }
+
     // --- 探索ボタン状態 ---
     function updateSearchButton() {
       const btn = $('btn-search') as HTMLButtonElement;
@@ -387,9 +400,9 @@ const base = import.meta.env.BASE_URL;
         reason.textContent = '楽曲を選択してください';
         return;
       }
-      if (currentCandidates.length < 6) {
+      if (currentCandidates.length < 1) {
         btn.disabled = true;
-        reason.textContent = `候補が 6 枚未満です（現在 ${currentCandidates.length} 枚）`;
+        reason.textContent = '開催中イベントに金/銀特効 UR カードがありません';
         return;
       }
       btn.disabled = false;
@@ -404,46 +417,46 @@ const base = import.meta.env.BASE_URL;
       });
     }
 
-    // 6 枚の選択における全配置（センター×フレンド×残り4枚）を列挙
-    // センター/フレンド以外の4枚は順序不問なので (c, f) の組合せ 6*5 = 30 通り
-    function* arrangements(combo: Card[]): Generator<(Card | null)[]> {
-      for (let c = 0; c < 6; c++) {
-        for (let f = 0; f < 6; f++) {
-          if (c === f) continue;
-          const deck: Card[] = new Array(6);
-          deck[0] = combo[c];
-          deck[5] = combo[f];
-          let slot = 1;
-          for (let i = 0; i < 6; i++) {
-            if (i === c || i === f) continue;
-            deck[slot++] = combo[i];
-          }
-          yield deck as (Card | null)[];
-        }
+    // 重複可で N 要素から k 個を順不同（弱単調増加）に列挙
+    function* multisetIndices(N: number, k: number): Generator<number[]> {
+      if (N <= 0 || k <= 0) return;
+      const idx = new Array(k).fill(0);
+      while (true) {
+        yield idx;
+        let i = k - 1;
+        while (i >= 0 && idx[i] === N - 1) i--;
+        if (i < 0) break;
+        const v = idx[i] + 1;
+        for (let j = i; j < k; j++) idx[j] = v;
       }
     }
 
-    // 6 枚の組合せ: 再帰を使わずインデックス列挙
-    function* combinations(N: number, k: number): Generator<number[]> {
-      const idx = new Array(k);
-      for (let i = 0; i < k; i++) idx[i] = i;
-      while (true) {
-        yield idx.slice();
-        // 右端から繰り下げ
-        let i = k - 1;
-        while (i >= 0 && idx[i] === N - k + i) i--;
-        if (i < 0) break;
-        idx[i]++;
-        for (let j = i + 1; j < k; j++) idx[j] = idx[j - 1] + 1;
-      }
-    }
+    let abortRequested = false;
 
     async function runSearch() {
-      if (!selectedSong || currentCandidates.length < 6) return;
+      if (!selectedSong || currentCandidates.length < 1) return;
 
+      const candidates = currentCandidates;
+      const N = candidates.length;
+      const totalEvals = N * N * multichoose(N, 4);
+
+      // 計算量が膨大な場合は確認ダイアログ
+      if (totalEvals > 5_000_000) {
+        const estMinutes = Math.ceil(totalEvals / 300_000 / 60);
+        const ok = confirm(
+          `評価する組合せが ${totalEvals.toLocaleString()} 通りあります。\n` +
+          `計算時間は目安として ${estMinutes} 分以上かかる可能性があります。\n` +
+          `続行しますか？`,
+        );
+        if (!ok) return;
+      }
+
+      abortRequested = false;
       const btn = $('btn-search') as HTMLButtonElement;
+      const abortBtn = $('btn-abort') as HTMLButtonElement;
       btn.disabled = true;
       btn.textContent = '探索中…';
+      abortBtn.classList.remove('hidden');
       $('progress-container').classList.remove('hidden');
       $('progress-bar').style.width = '0%';
       $('progress-text').textContent = '準備中…';
@@ -459,14 +472,10 @@ const base = import.meta.env.BASE_URL;
       const rabbit = loadRabbitNotes();
       const skillLevels: (1 | 2 | 3 | 4 | 5)[] = [5, 5, 5, 5, 5, 5];
       const trained: boolean[] = [true, true, true, true, true, true];
-
-      const candidates = currentCandidates;
-      const N = candidates.length;
-      const totalCombinations = binomial(N, 6);
-      const totalEvals = totalCombinations * 30;
+      const emptyShared: number[][] = [[], [], [], [], [], []];
+      const notesCount = selectedSong.notes_count || notes.length;
 
       const TOP_K = 10;
-      // score 昇順で先頭が最小
       const top: DeckRecord[] = [];
       const pushTop = (rec: DeckRecord) => {
         if (top.length < TOP_K) {
@@ -478,71 +487,91 @@ const base = import.meta.env.BASE_URL;
         }
       };
 
+      const deck: (Card | null)[] = new Array(6).fill(null);
       let evaluated = 0;
-      let comboIndex = 0;
-      const YIELD_EVERY = 3000; // この回数ごとに yield してプログレス更新
+      const YIELD_EVERY = 3000;
       const t0 = performance.now();
+      outer:
+      for (let ci = 0; ci < N; ci++) {
+        deck[0] = candidates[ci];
+        for (let fi = 0; fi < N; fi++) {
+          deck[5] = candidates[fi];
+          for (const members of multisetIndices(N, 4)) {
+            deck[1] = candidates[members[0]];
+            deck[2] = candidates[members[1]];
+            deck[3] = candidates[members[2]];
+            deck[4] = candidates[members[3]];
 
-      for (const idx of combinations(N, 6)) {
-        const combo = idx.map(i => candidates[i]);
-        for (const deck of arrangements(combo)) {
-          const tiers = buildTiersFromDeck(deck);
-          const team = computeTeam(
-            deck, allBroachs, selectedSong, tiers, trained, undefined, [[], [], [], [], [], []], skillLevels, rabbit,
-          );
-          let score = 0;
-          const rec: DeckRecord = {
-            cardIds: deck.map(c => c?.ID ?? null),
-            score: 0,
-          };
-          if (evalMode === 'expected') {
-            const e = calcExpectedScore(team, notes, selectedSong.notes_count || notes.length, scoreOptions);
-            score = e.finalScore;
-            rec.baseScore = e.baseScore;
-            rec.scoreUpExpected = e.scoreUpExpected;
-            rec.shrinkExpected = e.shrinkExpected;
-            rec.liveEndScore = e.liveEndScore;
-            rec.finalScore = e.finalScore;
-          } else {
-            score = calcMaxScore(team, notes, scoreOptions);
-            rec.finalScore = score;
-          }
-          rec.score = score;
-          pushTop(rec);
-          evaluated++;
+            const tiers = buildTiersFromDeck(deck);
+            const team = computeTeam(
+              deck, allBroachs, selectedSong, tiers, trained, undefined, emptyShared, skillLevels, rabbit,
+            );
+            let score = 0;
+            const rec: DeckRecord = {
+              cardIds: [deck[0]!.ID!, deck[1]!.ID!, deck[2]!.ID!, deck[3]!.ID!, deck[4]!.ID!, deck[5]!.ID!],
+              score: 0,
+            };
+            if (evalMode === 'expected') {
+              const e = calcExpectedScore(team, notes, notesCount, scoreOptions);
+              score = e.finalScore;
+              rec.baseScore = e.baseScore;
+              rec.scoreUpExpected = e.scoreUpExpected;
+              rec.shrinkExpected = e.shrinkExpected;
+              rec.liveEndScore = e.liveEndScore;
+              rec.finalScore = e.finalScore;
+            } else {
+              score = calcMaxScore(team, notes, scoreOptions);
+              rec.finalScore = score;
+            }
+            rec.score = score;
+            pushTop(rec);
+            evaluated++;
 
-          if (evaluated % YIELD_EVERY === 0) {
-            const pct = Math.min(100, Math.round((evaluated / totalEvals) * 100));
-            ($('progress-bar') as HTMLElement).style.width = `${pct}%`;
-            $('progress-text').textContent = `探索中… ${pct}% (${evaluated.toLocaleString()} / ${totalEvals.toLocaleString()})`;
-            await new Promise<void>(r => setTimeout(r, 0));
+            if (evaluated % YIELD_EVERY === 0) {
+              const pct = Math.min(100, Math.round((evaluated / totalEvals) * 100));
+              ($('progress-bar') as HTMLElement).style.width = `${pct}%`;
+              const speed = evaluated / ((performance.now() - t0) / 1000);
+              const etaSec = Math.max(0, (totalEvals - evaluated) / Math.max(1, speed));
+              $('progress-text').textContent = `探索中… ${pct}% (${evaluated.toLocaleString()} / ${totalEvals.toLocaleString()}, 残り約 ${formatElapsed(etaSec * 1000)}, 暫定 1位: ${top[0] ? top[0].score.toLocaleString() : '-'})`;
+              await new Promise<void>(r => setTimeout(r, 0));
+              if (abortRequested) break outer;
+            }
           }
         }
-        comboIndex++;
       }
 
       const t1 = performance.now();
       const elapsedMs = Math.round(t1 - t0);
 
-      lastResult = {
-        best: top[0],
-        top,
-        evaluated,
-        elapsedMs,
-        evalMode,
-      };
-
-      renderResult(lastResult);
+      if (top.length === 0) {
+        alert('評価できる組合せがありませんでした');
+      } else {
+        lastResult = {
+          best: top[0],
+          top,
+          evaluated,
+          elapsedMs,
+          evalMode,
+          aborted: abortRequested,
+        };
+        renderResult(lastResult);
+      }
 
       btn.disabled = false;
       btn.textContent = '🔍 総当たり探索を開始';
+      abortBtn.classList.add('hidden');
       $('progress-container').classList.add('hidden');
+    }
+
+    function requestAbort() {
+      abortRequested = true;
     }
 
     function renderResult(result: SearchResult) {
       $('result-section').classList.remove('hidden');
       $('best-score').textContent = result.best.score.toLocaleString();
-      $('best-score-label').textContent = result.evalMode === 'expected' ? '算術期待値（最終リザルト）' : '理論最大値（全スキル発動）';
+      const modeLabel = result.evalMode === 'expected' ? '算術期待値（最終リザルト）' : '理論最大値（全スキル発動）';
+      $('best-score-label').textContent = result.aborted ? `${modeLabel} ※探索中断` : modeLabel;
       $('combo-count').textContent = result.evaluated.toLocaleString();
       $('elapsed-time').textContent = formatElapsed(result.elapsedMs);
 
@@ -705,6 +734,7 @@ const base = import.meta.env.BASE_URL;
       initSongSelect();
       updateLiveEvents();
       $('btn-search').addEventListener('click', runSearch);
+      $('btn-abort').addEventListener('click', requestAbort);
       $('btn-send-to-calc').addEventListener('click', sendToScoreCalc);
     }
 


### PR DESCRIPTION
## Summary
- Secrets ページの総当たり探索を、同一カードを複数スロットに配置可能（重複あり）な組合せ列挙に変更
- 組合せ数は `C(N,6)×30` → `N²×C(N+3,4)` (センター × フレンド × 重複可・順不同メンバー 4 枚) に拡張
- 長時間実行に耐える UX 改善: 閾値超過時の確認ダイアログ / 中断ボタン / ETA 付きプログレス表示 / 暫定 1 位スコア表示

## Test plan
- [ ] `/secrets/` で楽曲を選択し、候補数・組合せ数表示が `N²×C(N+3,4)` の式で更新されることを確認
- [ ] 候補が少ない楽曲/イベントで探索を実行し、最適編成に同じカードが複数スロットに入ることがあり得るのを確認
- [ ] 500 万件超の場合に確認ダイアログが出ること、キャンセルで探索が始まらないこと
- [ ] 探索中に「中断」ボタンで中断できること、結果には「※探索中断」が付与されること
- [ ] プログレスに残り時間・暫定 1 位スコアが表示されること
- [ ] 「この編成をスコア計算ページに送る」で正しく復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)