### PR TITLE
feat(songs): ID allowlist で楽曲表示を絞り込む静的フィルタを追加

### DIFF
--- a/src/data/allowed-songs.json
+++ b/src/data/allowed-songs.json
@@ -1,0 +1,4 @@
+{
+  "note": "表示を許可する楽曲 ID のリスト。空配列の場合は制限なし (全件表示)。ID は /songs/ の URL (/songs/{id}/) や tests/fixtures/songs.json から確認できる。",
+  "allowedIds": [62, 144, 50, 48, 145, 60, 117]
+}

--- a/src/lib/data/fetchSongsJson.ts
+++ b/src/lib/data/fetchSongsJson.ts
@@ -1,4 +1,5 @@
 import { SPREADSHEET_ID, extractCellValue, fetchSheetRaw, type GVizCell } from './gviz.ts';
+import allowedSongsConfig from '../../data/allowed-songs.json';
 
 export interface SongNoteGroup {
   shout_white: number; //shout属性値 * 0.025
@@ -127,6 +128,20 @@ function convertRow(cells: (GVizCell | null)[]): Song {
  */
 export function filterValidSongs(songs: Song[]): Song[] {
   return songs.filter(s => s.category && s.artist && s.notes_count);
+}
+
+const ALLOWED_SONG_IDS: ReadonlySet<number> | null =
+  Array.isArray(allowedSongsConfig.allowedIds) && allowedSongsConfig.allowedIds.length > 0
+    ? new Set(allowedSongsConfig.allowedIds as number[])
+    : null;
+
+/**
+ * `src/data/allowed-songs.json` の allowedIds に含まれる楽曲のみに絞り込む。
+ * allowedIds が空の場合は制限なし（全件通過）。
+ */
+export function filterAllowedSongs(songs: Song[]): Song[] {
+  if (ALLOWED_SONG_IDS === null) return songs;
+  return songs.filter(s => s.id != null && ALLOWED_SONG_IDS.has(s.id));
 }
 
 /**

--- a/src/pages/decks/index.astro
+++ b/src/pages/decks/index.astro
@@ -1,14 +1,14 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
-import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson.ts';
 import { CARD_THUMB_BASE_URL } from '../../lib/constants';
 
 const [allCards, allSongsRaw] = await Promise.all([
   fetchCardsJson(),
   fetchSongsJson(),
 ]);
-const allSongs = filterValidSongs(allSongsRaw);
+const allSongs = filterAllowedSongs(filterValidSongs(allSongsRaw));
 const base = import.meta.env.BASE_URL;
 ---
 

--- a/src/pages/hidden/secrets/index.astro
+++ b/src/pages/hidden/secrets/index.astro
@@ -1,11 +1,11 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
-import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
-import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
-import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
-import { CARD_THUMB_BASE_URL } from '../../lib/constants';
-import { ATTR_TEXT_CLASS } from '../../lib/ui';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { fetchCardsJson } from '../../../lib/data/fetchCardsJson.ts';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../../lib/data/fetchSongsJson.ts';
+import { fetchFixedBroachsJson } from '../../../lib/data/fetchFixedBroachsJson.ts';
+import { fetchEventsCsv } from '../../../lib/data/fetchEventsCsv.ts';
+import { CARD_THUMB_BASE_URL } from '../../../lib/constants';
+import { ATTR_TEXT_CLASS } from '../../../lib/ui';
 
 const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchCardsJson(),
@@ -14,7 +14,7 @@ const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchEventsCsv(),
 ]);
 
-const allSongs = filterValidSongs(allSongsRaw);
+const allSongs = filterAllowedSongs(filterValidSongs(allSongsRaw));
 
 const eventsForBonus = allEvents.map(e => ({
   id: e.id,
@@ -182,20 +182,20 @@ const base = import.meta.env.BASE_URL;
   </script>
 
   <script>
-    import type { Card } from '../../lib/data/fetchCardsJson';
-    import { getApSkillLevel } from '../../lib/data/fetchCardsJson';
-    import { formatSkillEffect } from '../../lib/score/skillFormatter';
-    import type { Song } from '../../lib/data/fetchSongsJson';
-    import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
-    import type { ScoreOptions } from '../../lib/score/types';
-    import { normalizeAttribute } from '../../lib/score/types';
-    import { computeTeam, calcMaxScore, calcExpectedScore, flattenNotes } from '../../lib/score/engine';
-    import { buildLiveTierMap, isEventLive, BONUS_LABEL, BONUS_CLASS } from '../../lib/data/eventBonusTiers';
-    import type { EventBonusTier, EventForBonus } from '../../lib/data/eventBonusTiers';
-    import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constants';
-    import { STORAGE_KEYS, loadJson, saveJson } from '../../lib/storage';
-    import { cardThumbUrl } from '../../lib/ui';
-    import { loadRabbitNotes } from '../../lib/data/rabbitNote';
+    import type { Card } from '../../../lib/data/fetchCardsJson';
+    import { getApSkillLevel } from '../../../lib/data/fetchCardsJson';
+    import { formatSkillEffect } from '../../../lib/score/skillFormatter';
+    import type { Song } from '../../../lib/data/fetchSongsJson';
+    import type { FixedBroach } from '../../../lib/data/fetchFixedBroachsJson';
+    import type { ScoreOptions } from '../../../lib/score/types';
+    import { normalizeAttribute } from '../../../lib/score/types';
+    import { computeTeam, calcMaxScore, calcExpectedScore, flattenNotes } from '../../../lib/score/engine';
+    import { buildLiveTierMap, isEventLive, BONUS_LABEL, BONUS_CLASS } from '../../../lib/data/eventBonusTiers';
+    import type { EventBonusTier, EventForBonus } from '../../../lib/data/eventBonusTiers';
+    import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../../lib/constants';
+    import { STORAGE_KEYS, loadJson, saveJson } from '../../../lib/storage';
+    import { cardThumbUrl } from '../../../lib/ui';
+    import { loadRabbitNotes } from '../../../lib/data/rabbitNote';
 
     interface LiveEvent extends EventForBonus {
       eventname: string;
@@ -741,17 +741,17 @@ const base = import.meta.env.BASE_URL;
     init();
 
     // クライアントサイドデータリフレッシュ
-    import { refreshData } from '../../lib/data/clientRefresh';
-    import { fetchCardsJson } from '../../lib/data/fetchCardsJson';
-    import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson';
-    import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson';
+    import { refreshData } from '../../../lib/data/clientRefresh';
+    import { fetchCardsJson } from '../../../lib/data/fetchCardsJson';
+    import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../../lib/data/fetchSongsJson';
+    import { fetchFixedBroachsJson } from '../../../lib/data/fetchFixedBroachsJson';
 
     refreshData('cards', fetchCardsJson, (fresh) => {
       allCards = fresh as Card[];
       updateLiveEvents();
     });
 
-    refreshData('songs', async () => filterValidSongs(await fetchSongsJson()), (fresh) => {
+    refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
       allSongs = fresh as Song[];
       initSongSelect();
     });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,16 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../lib/data/fetchCardsJson.ts';
-import { fetchSongsJson } from '../lib/data/fetchSongsJson.ts';
+import { fetchSongsJson, filterAllowedSongs } from '../lib/data/fetchSongsJson.ts';
 import { fetchEventsCsv } from '../lib/data/fetchEventsCsv.ts';
 import { RARITIES, RARITY_BADGE_CLASSES, SITE_NAME } from '../lib/constants.ts';
 
-const [cards, songs, events] = await Promise.all([
+const [cards, songsRaw, events] = await Promise.all([
   fetchCardsJson(),
   fetchSongsJson(),
   fetchEventsCsv(),
 ]);
+const songs = filterAllowedSongs(songsRaw);
 
 const rarityCounts: Record<string, number> = {};
 for (const card of cards as Array<{ rarity?: string }>) {

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
-import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
 import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
 import { CARD_THUMB_BASE_URL } from '../../lib/constants';
@@ -14,7 +14,7 @@ const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchEventsCsv(),
 ]);
 
-const allSongs = filterValidSongs(allSongsRaw);
+const allSongs = filterAllowedSongs(filterValidSongs(allSongsRaw));
 
 const eventsForBonus = allEvents.map(e => ({
   id: e.id,
@@ -1576,7 +1576,7 @@ const base = import.meta.env.BASE_URL;
     // クライアントサイドデータリフレッシュ
     import { refreshData } from '../../lib/data/clientRefresh';
     import { fetchCardsJson } from '../../lib/data/fetchCardsJson';
-    import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson';
+    import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson';
     import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson';
 
     refreshData('cards', fetchCardsJson, (fresh) => {
@@ -1586,7 +1586,7 @@ const base = import.meta.env.BASE_URL;
       recalculate();
     });
 
-    refreshData('songs', async () => filterValidSongs(await fetchSongsJson()), (fresh) => {
+    refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
       allSongs = fresh as Song[];
       if (selectedSong) {
         selectedSong = allSongs.find(s => s.id === selectedSong!.id) || null;

--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -1,12 +1,12 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson.ts';
 import { ATTR_BADGE_BG } from '../../lib/constants';
 import { attrDonutSvg } from '../../lib/donutChart';
 import { songImageUrl, starsText } from '../../lib/ui';
 
 export async function getStaticPaths() {
-  const allSongs = filterValidSongs(await fetchSongsJson());
+  const allSongs = filterAllowedSongs(filterValidSongs(await fetchSongsJson()));
   return allSongs.map((song: any) => ({
     params: { id: String(song.id) },
     props: { song },

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -1,8 +1,8 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson.ts';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson.ts';
 
-const allSongs = filterValidSongs(await fetchSongsJson());
+const allSongs = filterAllowedSongs(filterValidSongs(await fetchSongsJson()));
 const categories = [...new Set(allSongs.map((s: any) => s.category))].sort() as string[];
 const base = import.meta.env.BASE_URL;
 ---
@@ -351,8 +351,8 @@ const base = import.meta.env.BASE_URL;
 
     // クライアントサイドデータリフレッシュ
     import { refreshData } from '../../lib/data/clientRefresh';
-    import { fetchSongsJson, filterValidSongs } from '../../lib/data/fetchSongsJson';
-    refreshData('songs', async () => filterValidSongs(await fetchSongsJson()), (fresh) => {
+    import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson';
+    refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
       allSongs = fresh as Song[];
       applyFilters();
     });


### PR DESCRIPTION
## Summary

- `src/data/allowed-songs.json` を **git 管理の許可 ID リスト** として導入し、人手で楽曲 ID を入力・版管理できるようにした
- `fetchSongsJson.ts` に `filterAllowedSongs()` を追加し、songs 一覧・詳細・score-calc・secrets・decks・home の全参照経路に合成
- 許可外 ID は `getStaticPaths` から除外されるため、**詳細ページも含めサイト全体で 404 / 非表示** になる
- `allowedIds` が空配列のときは制限なし（全件表示）で既定挙動を維持

## 運用方法

`src/data/allowed-songs.json` の `allowedIds` 配列に表示したい楽曲 ID を列挙してコミットする:

\`\`\`json
{
  "note": "表示を許可する楽曲ID。空配列の場合は全件表示 (制限なし)。",
  "allowedIds": [62, 144]
}
\`\`\`

- ID は `/songs/{id}/` の URL や `tests/fixtures/songs.json` から確認可能
- 全件公開に戻したい場合は `[]` に戻す

## Test plan

- [x] `docker compose up preview` でビルド + プレビュー起動
- [x] `allowedIds` に複数 ID を設定し、`/songs/` で該当曲のみ表示されることを確認
- [x] 許可 ID の詳細ページ (`/songs/62/` 等) が HTTP 200 を返すことを確認
- [x] 許可外 ID (`/songs/1/`, `/songs/99999/`) が HTTP 404 を返すことを確認
- [x] `dist/songs/` に許可 ID 分のディレクトリのみ生成されていることを確認
- [x] クライアント側の `refreshData()` 経路でも許可外 ID が混入しないことを確認

## Other changes

- secrets ページを `hidden/` 配下へ移動 (stagedされていた rename を同梱)

🤖 Generated with [Claude Code](https://claude.com/claude-code)