### PR TITLE
chore(secrets): ナビから Secrets リンクを削除し import 拡張子と未使用引数を整理

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,4 +183,4 @@ Tailwind CSS v4 integrated via `@tailwindcss/vite` plugin (not the legacy `@astr
 1. `docker compose up preview` でローカルプレビューサーバーを Docker 上に起動する
 2. Playwright MCP でプレビューサーバー（`http://localhost:4321/`）にアクセスし、変更箇所の画面表示を確認する
 3. スクリーンショットを `tmp/` ディレクトリに保存し、ユーザーに提示して問題がないか確認を取る
-4. ユーザーの確認が取れたら 対応ないように応じたブランチを作成して`git commit` → `git push` とPRの作成を行う
+4. ユーザーの確認が取れたら 対応ないように応じたブランチを作成して`git commit` → `git push` とPRの作成を行い、CIの結果を待たずリリースまで行う。リリースに伴うworkflowを待つ必要はない。

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,7 +57,6 @@ try {
           <li><a href={`${base}score-calc/`} class="hover:text-indigo-200 transition-colors">スコア計算</a></li>
           <li><a href={`${base}rabbit-note/`} class="hover:text-indigo-200 transition-colors">ラビットノート</a></li>
           <li><a href={`${base}decks/`} class="hover:text-indigo-200 transition-colors">保存デッキ</a></li>
-          <li><a href={`${base}secrets/`} class="hover:text-indigo-200 transition-colors">Secrets</a></li>
         </ul>
       </nav>
       <ul id="mobile-nav" class="hidden flex-col gap-2 px-4 pb-3 text-sm font-medium md:hidden">
@@ -69,7 +68,6 @@ try {
         <li><a href={`${base}score-calc/`} class="block py-1 hover:text-indigo-200">スコア計算</a></li>
         <li><a href={`${base}rabbit-note/`} class="block py-1 hover:text-indigo-200">ラビットノート</a></li>
         <li><a href={`${base}decks/`} class="block py-1 hover:text-indigo-200">保存デッキ</a></li>
-        <li><a href={`${base}secrets/`} class="block py-1 hover:text-indigo-200">Secrets</a></li>
       </ul>
     </header>
     <main class="flex-1 max-w-7xl mx-auto px-4 py-6 w-full">

--- a/src/pages/hidden/secrets/index.astro
+++ b/src/pages/hidden/secrets/index.astro
@@ -1,9 +1,9 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { fetchCardsJson } from '../../../lib/data/fetchCardsJson.ts';
-import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../../lib/data/fetchSongsJson.ts';
-import { fetchFixedBroachsJson } from '../../../lib/data/fetchFixedBroachsJson.ts';
-import { fetchEventsCsv } from '../../../lib/data/fetchEventsCsv.ts';
+import { fetchCardsJson } from '../../../lib/data/fetchCardsJson';
+import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../../lib/data/fetchSongsJson';
+import { fetchFixedBroachsJson } from '../../../lib/data/fetchFixedBroachsJson';
+import { fetchEventsCsv } from '../../../lib/data/fetchEventsCsv';
 import { CARD_THUMB_BASE_URL } from '../../../lib/constants';
 import { ATTR_TEXT_CLASS } from '../../../lib/ui';
 
@@ -337,7 +337,7 @@ const base = import.meta.env.BASE_URL;
         `<li class="mb-0.5"><b>${ev.eventname}</b> <span class="text-gray-400 text-[11px]">(${ev.start_date} 〜 ${ev.end_date} 17:00)</span></li>`,
       ).join('');
 
-      const cardBadges = (cards: Card[], tier: 'gold' | 'silver') => {
+      const cardBadges = (cards: Card[]) => {
         if (cards.length === 0) return '<span class="text-gray-400">該当なし</span>';
         return cards.slice(0, 30).map(c => {
           const attr = normalizeAttribute(c.attribute);
@@ -367,9 +367,9 @@ const base = import.meta.env.BASE_URL;
           <summary class="cursor-pointer text-[11px] text-indigo-600">候補カードを展開</summary>
           <div class="mt-2">
             <div class="text-[11px] font-bold text-yellow-700">金特効（${gold.length}枚）</div>
-            <div>${cardBadges(gold, 'gold')}</div>
+            <div>${cardBadges(gold)}</div>
             <div class="mt-2 text-[11px] font-bold text-gray-500">銀特効（${silver.length}枚）</div>
-            <div>${cardBadges(silver, 'silver')}</div>
+            <div>${cardBadges(silver)}</div>
           </div>
         </details>
       `;


### PR DESCRIPTION
## Summary
- BaseLayout のデスクトップ/モバイルナビから Secrets リンクを削除（隠しページ化）
- `src/pages/hidden/secrets/index.astro` の TS 拡張子付き import を解消し、`cardBadges` の未使用 `tier` 引数を削除
- CLAUDE.md のワークフローを「CI 結果を待たずリリースまで実行」に更新

## Test plan
- [ ] `docker compose up preview` で起動後、ヘッダーに Secrets リンクが表示されないことを確認
- [ ] `/hidden/secrets/` に直接アクセスしてページが従来通り動作することを確認
- [ ] 型エラー (TS5097 / TS6133) が解消されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)