### PR TITLE
fix(score-calc): カード詳細パネルの集計行を整理し SCOREUPアシスト込みで合計表示

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -877,26 +877,21 @@ const base = import.meta.env.BASE_URL;
       const centerAttr = centerCard ? normalizeAttribute(centerCard.attribute) : null;
       const friendAttr = friendCard ? normalizeAttribute(friendCard.attribute) : null;
 
-      let shoutRate = 0, beatRate = 0, melodyRate = 0;
-      if (centerAttr === 'Shout') shoutRate += centerRate;
-      if (centerAttr === 'Beat') beatRate += centerRate;
-      if (centerAttr === 'Melody') melodyRate += centerRate;
-      if (friendAttr === 'Shout') shoutRate += friendRate;
-      if (friendAttr === 'Beat') beatRate += friendRate;
-      if (friendAttr === 'Melody') melodyRate += friendRate;
-
       const baseShout = totalShout + totalBS;
       const baseBeat = totalBeat + totalBB;
       const baseMelody = totalMelody + totalBM;
-      const csShout = Math.floor(baseShout * (100 + shoutRate) / 100) - baseShout;
-      const csBeat = Math.floor(baseBeat * (100 + beatRate) / 100) - baseBeat;
-      const csMelody = Math.floor(baseMelody * (100 + melodyRate) / 100) - baseMelody;
+      const centerShout = centerAttr === 'Shout' ? Math.floor(baseShout * centerRate / 100) : 0;
+      const centerBeat = centerAttr === 'Beat' ? Math.floor(baseBeat * centerRate / 100) : 0;
+      const centerMelody = centerAttr === 'Melody' ? Math.floor(baseMelody * centerRate / 100) : 0;
+      const friendShout = friendAttr === 'Shout' ? Math.floor(baseShout * friendRate / 100) : 0;
+      const friendBeat = friendAttr === 'Beat' ? Math.floor(baseBeat * friendRate / 100) : 0;
+      const friendMelody = friendAttr === 'Melody' ? Math.floor(baseMelody * friendRate / 100) : 0;
+      const csShout = centerShout + friendShout;
+      const csBeat = centerBeat + friendBeat;
+      const csMelody = centerMelody + friendMelody;
 
-      const hasCenter = shoutRate > 0 || beatRate > 0 || melodyRate > 0;
-      const centerSkillLabels: string[] = [];
-      if (centerCard && centerRate > 0) centerSkillLabels.push(`自分+${centerRate}%`);
-      if (friendCard && friendRate > 0) centerSkillLabels.push(`フレンド+${friendRate}%`);
-      const centerSkillLabel = centerSkillLabels.join(' / ');
+      const hasCenter = !!centerCard && centerRate > 0;
+      const hasFriend = !!friendCard && friendRate > 0;
 
       const scoreUpAssistEnabled = ($('opt-scoreup-assist') as HTMLInputElement | null)?.checked ?? false;
       const teamShout = baseShout + csShout;
@@ -908,7 +903,7 @@ const base = import.meta.env.BASE_URL;
       const assistPct = Math.round(SCOREUP_ASSIST_RATE * 100);
 
       $('card-detail-foot').innerHTML = `<tr class="border-t-2 border-gray-300 font-bold text-xs">
-        <td colspan="4" class="py-1 px-1 text-right text-gray-700">合計</td>
+        <td colspan="4" class="py-1 px-1 text-right text-gray-700">単純属性値計</td>
         <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${totalShout.toLocaleString()}</td>
         <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${totalBeat.toLocaleString()}</td>
         <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${totalMelody.toLocaleString()}</td>
@@ -916,25 +911,39 @@ const base = import.meta.env.BASE_URL;
         <td class="py-1 px-1 text-right">${totalBB || '-'}</td>
         <td class="py-1 px-1 text-right">${totalBM || '-'}</td>
         <td colspan="2"></td>
-      </tr>${hasCenter ? `<tr class="font-bold text-xs text-purple-600">
-        <td colspan="4" class="py-1 px-1 text-right">センター/フレンドボーナス (${centerSkillLabel})</td>
-        <td class="py-1 px-1 text-right">${csShout > 0 ? `+${csShout.toLocaleString()}` : '-'}</td>
-        <td class="py-1 px-1 text-right">${csBeat > 0 ? `+${csBeat.toLocaleString()}` : '-'}</td>
-        <td class="py-1 px-1 text-right">${csMelody > 0 ? `+${csMelody.toLocaleString()}` : '-'}</td>
+      </tr>${(totalBS + totalBB + totalBM) > 0 ? `<tr class="font-bold text-xs text-indigo-600">
+        <td colspan="4" class="py-1 px-1 text-right">ブローチ</td>
+        <td class="py-1 px-1 text-right">${totalBS > 0 ? `+${totalBS.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${totalBB > 0 ? `+${totalBB.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${totalBM > 0 ? `+${totalBM.toLocaleString()}` : '-'}</td>
         <td colspan="3"></td>
         <td colspan="2"></td>
-      </tr>` : ''}${scoreUpAssistEnabled ? `<tr class="font-bold text-xs text-emerald-600">
-        <td colspan="4" class="py-1 px-1 text-right">SCOREUPアシスト (+${assistPct}%)</td>
+      </tr>` : ''}${hasCenter ? `<tr class="font-bold text-xs text-purple-600">
+        <td colspan="4" class="py-1 px-1 text-right">センターSkill (+${centerRate}%)</td>
+        <td class="py-1 px-1 text-right">${centerShout > 0 ? `+${centerShout.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${centerBeat > 0 ? `+${centerBeat.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${centerMelody > 0 ? `+${centerMelody.toLocaleString()}` : '-'}</td>
+        <td colspan="3"></td>
+        <td colspan="2"></td>
+      </tr>` : ''}${hasFriend ? `<tr class="font-bold text-xs text-purple-600">
+        <td colspan="4" class="py-1 px-1 text-right">FセンターSkill (+${friendRate}%)</td>
+        <td class="py-1 px-1 text-right">${friendShout > 0 ? `+${friendShout.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${friendBeat > 0 ? `+${friendBeat.toLocaleString()}` : '-'}</td>
+        <td class="py-1 px-1 text-right">${friendMelody > 0 ? `+${friendMelody.toLocaleString()}` : '-'}</td>
+        <td colspan="3"></td>
+        <td colspan="2"></td>
+      </tr>` : ''}${scoreUpAssistEnabled ? `<tr class="border-t-2 border-gray-300 font-bold text-xs text-emerald-600">
+        <td colspan="4" class="py-1 px-1 text-right">ScoreUPアシスト (+${assistPct}%)</td>
         <td class="py-1 px-1 text-right">${assistShout > 0 ? `+${assistShout.toLocaleString()}` : '-'}</td>
         <td class="py-1 px-1 text-right">${assistBeat > 0 ? `+${assistBeat.toLocaleString()}` : '-'}</td>
         <td class="py-1 px-1 text-right">${assistMelody > 0 ? `+${assistMelody.toLocaleString()}` : '-'}</td>
         <td colspan="3"></td>
         <td colspan="2"></td>
       </tr>` : ''}<tr class="border-t-2 border-gray-300 font-bold text-xs">
-        <td colspan="4" class="py-1 px-1 text-right text-gray-700">チームアピール合計</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${teamShout.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${teamBeat.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${teamMelody.toLocaleString()}</td>
+        <td colspan="4" class="py-1 px-1 text-right text-gray-700">デッキ合計</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${(teamShout + assistShout).toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${(teamBeat + assistBeat).toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${(teamMelody + assistMelody).toLocaleString()}</td>
         <td colspan="3"></td>
         <td colspan="2"></td>
       </tr>`;


### PR DESCRIPTION
## Summary

スコア計算画面のカード詳細パネル下部の集計行を整理しました。

- **デッキ合計**（旧「チームアピール合計」）に SCOREUPアシスト 増分を含めるよう修正。これまでは 合計 + センター/フレンドボーナスまでしか反映されていませんでした。
- **センターボーナスとフレンドボーナスを別々の行**に分離。自分のセンタースキル効果とフレンドのセンタースキル効果を個別に把握できるようにし、それぞれ `floor(base × rate/100)` で独立計算します。
- 合計とセンター/フレンドの間に **ブローチ行** を追加。右側のブローチS/B/M列の合計と同じ値を、属性値カラムに表示します。
- 合計行のラベルを整理（「単純属性値計」「ブローチ」「センターSkill」「FセンターSkill」「ScoreUPアシスト」「デッキ合計」）。

### 検算例（UR×6、ALL750 装着、センター Shout、フレンド Melody、+10%、SCOREUPアシスト ON）

| 行 | Shout | Beat | Melody |
|---|---:|---:|---:|
| 単純属性値計 | 31,175 | 31,429 | 31,140 |
| ブローチ | +4,500 | +4,500 | +4,500 |
| センターSkill (+10%) | +3,567 | - | - |
| FセンターSkill (+10%) | - | - | +3,564 |
| ScoreUPアシスト (+20%) | +7,848 | +7,185 | +7,840 |
| デッキ合計 | 47,090 | 43,114 | 47,044 |

SCOREUPアシストは `floor((単純属性値計 + ブローチ + センター + フレンド) × 1.2)` からの増分として、仕様書 `docs/score_calc_spec.md §3-7` と一致します。

## Test plan

- [ ] スコア計算画面でデッキを組み、カード詳細パネル末尾の集計行が下記の順で表示されること
  - 単純属性値計 → (ブローチ) → (センターSkill) → (FセンターSkill) → (ScoreUPアシスト) → デッキ合計
- [ ] 各ボーナス行はボーナスが存在する場合のみ表示されること
- [ ] ScoreUPアシスト ON 時、デッキ合計 = 単純属性値計 + ブローチ + センター + フレンド + ScoreUPアシスト 増分 になること
- [ ] ScoreUPアシスト OFF 時、デッキ合計 = 単純属性値計 + ブローチ + センター + フレンド になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)