### PR TITLE
docs(claude): commit 前にリリースノートを更新するルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,4 +183,5 @@ Tailwind CSS v4 integrated via `@tailwindcss/vite` plugin (not the legacy `@astr
 1. `docker compose up preview` でローカルプレビューサーバーを Docker 上に起動する
 2. Playwright MCP でプレビューサーバー（`http://localhost:4321/`）にアクセスし、変更箇所の画面表示を確認する
 3. スクリーンショットを `tmp/` ディレクトリに保存し、ユーザーに提示して問題がないか確認を取る
-4. ユーザーの確認が取れたら 対応ないように応じたブランチを作成して`git commit` → `git push` とPRの作成を行い、CIの結果を待たずリリースまで行う。リリースに伴うworkflowを待つ必要はない。
+4. `git` に `commit` する前に必ずリリースノートを更新する
+5. ユーザーの確認が取れたら 対応ないように応じたブランチを作成して`git commit` → `git push` とPRの作成を行い、CIの結果を待たずリリースまで行う。リリースに伴うworkflowを待つ必要はない。


### PR DESCRIPTION
## Summary
- `CLAUDE.md` の Workflow セクションに「\`git\` に \`commit\` する前に必ずリリースノートを更新する」という手順を追加

## Test plan
- [x] CLAUDE.md のレンダリング確認（番号リストが 5 項目になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)