### PR TITLE
fix(score-calc): 仕様書と実装の矛盾 3 件を解消

### DIFF
--- a/docs/score_calc_spec.md
+++ b/docs/score_calc_spec.md
@@ -140,30 +140,47 @@ if (sharedBroach.targetAttribute) {
 }
 ```
 
+**UR 限定・枠数ルール**:
+
+- UR カードはブローチ枠を 2 つ有し、共有ブローチを最大 2 つまで装備できる。
+- UR カードによっては取り外しできない固有ブローチがあり、その場合は共有ブローチを 1 つしか選択できない（残り 1 枠は固有ブローチで固定）。
+- 非 UR カード（SSR 以下）は共有ブローチ枠を持たない。
+
+画面実装では `validateSharedBroachs` (`src/pages/score-calc/index.astro`) が上記ルールに従い `deckSharedBroachs[slotIndex]` を最大 0 / 1 / 2 に切り詰める。`computeTeam` (`src/lib/score/engine.ts`) は `validateSharedBroachs` 済みの入力を前提とする（engine 単体で UR ガードを行わない）。
+
 ### 3-5. センター／フレンド ボーナス
 
-センター（スロット 0）とフレンド（スロット 5）のレアリティに応じて、各カードの属性に対応する属性値にボーナス率を加算する。
+センター（スロット 0）とフレンド（スロット 5）のレアリティに応じて、各カードの属性に対応する属性値にボーナス率を加算する。**センター分とフレンド分はそれぞれ独立に floor し、その後合算する**（合算レートで 1 回 floor しない）。
 
 ```
 centerRate = getCenterSkillRate(deck[0].rarity)   // UR=10, SSR=7, 他=6
 friendRate = getCenterSkillRate(deck[5].rarity)
 
-shoutRate = (centerAttr === 'Shout' ? centerRate : 0) + (friendAttr === 'Shout' ? friendRate : 0)
-beatRate  = (centerAttr === 'Beat'  ? centerRate : 0) + (friendAttr === 'Beat'  ? friendRate : 0)
-melodyRate = (centerAttr === 'Melody' ? centerRate : 0) + (friendAttr === 'Melody' ? friendRate : 0)
+baseShout  = rawShout  + broachShoutTotal
+baseBeat   = rawBeat   + broachBeatTotal
+baseMelody = rawMelody + broachMelodyTotal
+
+centerShout  = centerAttr === 'Shout'  ? floor(baseShout  × centerRate / 100) : 0
+centerBeat   = centerAttr === 'Beat'   ? floor(baseBeat   × centerRate / 100) : 0
+centerMelody = centerAttr === 'Melody' ? floor(baseMelody × centerRate / 100) : 0
+friendShout  = friendAttr === 'Shout'  ? floor(baseShout  × friendRate / 100) : 0
+friendBeat   = friendAttr === 'Beat'   ? floor(baseBeat   × friendRate / 100) : 0
+friendMelody = friendAttr === 'Melody' ? floor(baseMelody × friendRate / 100) : 0
 ```
 
 > **外部サイトとの差分**: 外部サイトは `ct_skill` テキスト内のキーワード（「かなり」「やや」「大きく」）で判定。実装はレアリティ判定（UR は必ず「かなり(10%)」、SSR は必ず「やや(7%)」という対応関係をコードにしたもの）。結果の数値は同じ。
 
-### 3-6. チーム属性値（最終）— 切り捨て
+### 3-6. チーム属性値（最終）
+
+センター分とフレンド分を独立 floor した結果を base に加算する:
 
 ```
-teamShout  = floor((rawShout  + broachShoutTotal)  × (100 + shoutRate)  / 100)
-teamBeat   = floor((rawBeat   + broachBeatTotal)   × (100 + beatRate)   / 100)
-teamMelody = floor((rawMelody + broachMelodyTotal) × (100 + melodyRate) / 100)
+teamShout  = baseShout  + centerShout  + friendShout
+teamBeat   = baseBeat   + centerBeat   + friendBeat
+teamMelody = baseMelody + centerMelody + friendMelody
 ```
 
-`broachXxxTotal` はスロット 0〜5（フレンド枠を含む全枠）の有効ブローチ値の合計（§3-3 / §3-4 の条件を満たすもの）。
+`baseXxx = rawXxx + broachXxxTotal`。`broachXxxTotal` はスロット 0〜5（フレンド枠を含む全枠）の有効ブローチ値の合計（§3-3 / §3-4 の条件を満たすもの）。
 
 ### 3-7. スコアアップアシスト適用済み属性値
 

--- a/docs/shrink-skill-spec.md
+++ b/docs/shrink-skill-spec.md
@@ -18,8 +18,8 @@
 | `isShrink` | true | — |
 | `isTimer` | 縮小タイマー型の場合のみ true | false |
 
-**縮小倍率**: 仕様上はカードデータの `rate`（スキルレベル別に変化し得る）を縮小倍率として使う。
-現行実装は `rate` を参照せず `SHRINK_MULTIPLIER = 1.6` 固定のみを使う（§7-4 参照）。
+**縮小倍率**: カードデータの `rate`（`CardSkill.rate`、スキルレベル依存）を参照する。
+過去は `SHRINK_MULTIPLIER = 1.6` 固定だったが、2026-04-20 の `fix/shrink-skill-spec-compliance` で `skill.rate` 参照に統一（§7-4 解消済み）。
 
 ## 1. 縮小追加スコアの基本式（仕様）
 

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -177,23 +177,26 @@ export function computeTeam(
     });
   }
 
-  // センター/フレンドのセンタースキルボーナス
-  let shoutRate = 0, beatRate = 0, melodyRate = 0;
+  // センター/フレンドのセンタースキルボーナス（docs/score_calc_spec.md §3-5 / §3-6 準拠）
+  // センター分とフレンド分はそれぞれ独立に floor する（合算 floor ではない）
   const centerAttr = deck[0] ? normalizeAttribute(deck[0].attribute) : null;
   const friendAttr = deck[5] ? normalizeAttribute(deck[5].attribute) : null;
   const centerRate = deck[0] ? getCenterSkillRate(deck[0].rarity) : 0;
   const friendRate = deck[5] ? getCenterSkillRate(deck[5].rarity) : 0;
 
-  if (centerAttr === 'Shout') shoutRate += centerRate;
-  if (centerAttr === 'Beat') beatRate += centerRate;
-  if (centerAttr === 'Melody') melodyRate += centerRate;
-  if (friendAttr === 'Shout') shoutRate += friendRate;
-  if (friendAttr === 'Beat') beatRate += friendRate;
-  if (friendAttr === 'Melody') melodyRate += friendRate;
+  const baseShout = rawShout + broachShoutTotal;
+  const baseBeat = rawBeat + broachBeatTotal;
+  const baseMelody = rawMelody + broachMelodyTotal;
+  const centerShout  = centerAttr === 'Shout'  ? Math.floor(baseShout  * centerRate / 100) : 0;
+  const centerBeat   = centerAttr === 'Beat'   ? Math.floor(baseBeat   * centerRate / 100) : 0;
+  const centerMelody = centerAttr === 'Melody' ? Math.floor(baseMelody * centerRate / 100) : 0;
+  const friendShout  = friendAttr === 'Shout'  ? Math.floor(baseShout  * friendRate / 100) : 0;
+  const friendBeat   = friendAttr === 'Beat'   ? Math.floor(baseBeat   * friendRate / 100) : 0;
+  const friendMelody = friendAttr === 'Melody' ? Math.floor(baseMelody * friendRate / 100) : 0;
 
-  const teamShout = Math.floor((rawShout + broachShoutTotal) * (100 + shoutRate) / 100);
-  const teamBeat = Math.floor((rawBeat + broachBeatTotal) * (100 + beatRate) / 100);
-  const teamMelody = Math.floor((rawMelody + broachMelodyTotal) * (100 + melodyRate) / 100);
+  const teamShout  = baseShout  + centerShout  + friendShout;
+  const teamBeat   = baseBeat   + centerBeat   + friendBeat;
+  const teamMelody = baseMelody + centerMelody + friendMelody;
 
   return {
     Shout: teamShout,


### PR DESCRIPTION
## Summary

`docs/` 配下の仕様書と `src/lib/score/engine.ts` / `src/pages/score-calc/index.astro` を突合して検出した 4 件の矛盾のうち、ユーザー判断により 3 件を是正（1 件は現状実装どおりで修正不要）。

## 変更点

### ① center/friend floor を個別 floor 方式に統一

- **問題**: 仕様書 §3-6 と engine は `floor((raw+broach) × (100+center+friend) / 100)` の合算 floor、一方で画面カード詳細フッター (`index.astro:881-892`) は center / friend を別々に floor。センター・フレンド同属性・低レートケースで 1 点差の可能性。
- **方針**: ユーザー判断で**個別 floor を仕様化**。engine と仕様書を画面実装に合わせる。
- **変更**: `computeTeam` (`src/lib/score/engine.ts:180-196`) を個別 floor に書き換え。`docs/score_calc_spec.md` §3-5 / §3-6 も数式を更新。

### ② shrink-skill-spec.md §0 stale 記述更新

- **問題**: §0 が「現行実装は `rate` を参照せず `SHRINK_MULTIPLIER=1.6` 固定」と記載するも、同ファイル §7-4 で既に解消済み、`engine.ts:34` は `sl.rate` 参照。
- **変更**: §0 を「`CardSkill.rate` を参照（§7-4 解消済み）」の最新状態に書き換え。

### ③ UR 共有ブローチ枠ルールを仕様書に明記

- **問題**: 「共有ブローチは UR 限定」「UR 枠 2 個、固有ブローチ保持時は 1 個」のゲーム仕様が spec に記載なし。`computeTeam` は `validateSharedBroachs` 済みの前提で動作。
- **変更**: `docs/score_calc_spec.md` §3-4 に UR 枠数ルールと、engine は `validateSharedBroachs` 済みの入力を前提とする旨を明記。

### 現状維持（今回は変更せず）

- shrink-offset-input の offset 値がカード別スキル期待値/論理最高値に反映されない挙動は**意図どおり**。offset は縮小カバー率表示のみに使用し、スキル計算には影響させない方針。

## Test plan

- [x] `npm run test:unit` で既存 62 テストが通過
- [x] `docker compose up preview` でプレビュー起動し、UR×2 同属性センター+フレンド構成でカード詳細「デッキ合計」が正しく計算されること
- [x] engine の `team.Shout/Beat/Melody` が画面「デッキ合計」と必ず一致（個別 floor に統一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)