### PR TITLE
fix(score-calc): 縮小計算対象外の注記をスキル詳細パネルへ移動

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -178,7 +178,6 @@ const base = import.meta.env.BASE_URL;
           </table>
         </div>
         <p class="text-xs text-gray-400 mt-2">※ オート専用ブローチはスコア計算の対象外です</p>
-        <p id="shrink-exclusion-note" class="text-xs text-gray-400 mt-2 hidden">※ 最初の<span id="shrink-exclusion-count" class="font-medium">0</span>ノーツは縮小の計算対象外です</p>
       </details>
 
       <!-- スキル詳細 -->
@@ -202,6 +201,7 @@ const base = import.meta.env.BASE_URL;
               <span id="shrink-expected-val" class="font-medium text-orange-600"></span>
             </div>
           </div>
+          <p id="shrink-exclusion-note" class="text-xs text-gray-400 mt-2 hidden">※ 最初の<span id="shrink-exclusion-count" class="font-medium">0</span>ノーツは縮小の計算対象外です</p>
           <div id="skill-per-card-section" class="mt-4 border-t pt-3 hidden">
             <table class="w-full text-xs">
               <thead>


### PR DESCRIPTION
## Summary
- カード詳細パネルに配置していた「※ 最初の N ノーツは縮小の計算対象外です」の注記を、縮小カバー率を表示する「📊 スキル詳細」パネル内へ移動
- 縮小カバー率行（shrink-expected-row）の直下に配置し、縮小関連の情報を一箇所に集約
- `#shrink-exclusion-note` / `#shrink-exclusion-count` の ID は維持しているため `updateShrinkCoverage` の動作は不変

## Test plan
- [x] Playwright で `/score-calc/` を開き、注記がスキル詳細パネル内に表示されカード詳細パネルから消えていることを確認
- [x] `#shrink-exclusion-note` が `breakdown-section` に含まれ、`card-detail-section` に含まれないことを DOM 経由で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)