### PR TITLE
feat(score-calc): デッキ合計に1ノーツあたりの得点を追記

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -903,6 +903,17 @@ const base = import.meta.env.BASE_URL;
       const assistMelody = scoreUpAssistEnabled ? Math.floor(teamMelody * (1 + SCOREUP_ASSIST_RATE)) - teamMelody : 0;
       const assistPct = Math.round(SCOREUP_ASSIST_RATE * 100);
 
+      const deckShout  = teamShout  + assistShout;
+      const deckBeat   = teamBeat   + assistBeat;
+      const deckMelody = teamMelody + assistMelody;
+
+      const noteShoutWhite  = Math.floor(deckShout  * NOTE_RATE.white);
+      const noteBeatWhite   = Math.floor(deckBeat   * NOTE_RATE.white);
+      const noteMelodyWhite = Math.floor(deckMelody * NOTE_RATE.white);
+      const noteShoutColor  = Math.floor(deckShout  * NOTE_RATE.color);
+      const noteBeatColor   = Math.floor(deckBeat   * NOTE_RATE.color);
+      const noteMelodyColor = Math.floor(deckMelody * NOTE_RATE.color);
+
       $('card-detail-foot').innerHTML = `<tr class="border-t-2 border-gray-300 font-bold text-xs">
         <td colspan="4" class="py-1 px-1 text-right text-gray-700">単純属性値計</td>
         <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${totalShout.toLocaleString()}</td>
@@ -942,9 +953,23 @@ const base = import.meta.env.BASE_URL;
         <td colspan="2"></td>
       </tr>` : ''}<tr class="border-t-2 border-gray-300 font-bold text-xs">
         <td colspan="4" class="py-1 px-1 text-right text-gray-700">デッキ合計</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${(teamShout + assistShout).toLocaleString()}</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${(teamBeat + assistBeat).toLocaleString()}</td>
-        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${(teamMelody + assistMelody).toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${deckShout.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${deckBeat.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${deckMelody.toLocaleString()}</td>
+        <td colspan="3"></td>
+        <td colspan="2"></td>
+      </tr><tr class="text-xs text-gray-500">
+        <td colspan="4" class="py-0.5 px-1 text-right">1ノーツ得点 / ⚪</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${noteShoutWhite.toLocaleString()}</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${noteBeatWhite.toLocaleString()}</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${noteMelodyWhite.toLocaleString()}</td>
+        <td colspan="3"></td>
+        <td colspan="2"></td>
+      </tr><tr class="text-xs text-gray-500">
+        <td colspan="4" class="py-0.5 px-1 text-right">1ノーツ得点 / 🔵🔴</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${noteShoutColor.toLocaleString()}</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${noteBeatColor.toLocaleString()}</td>
+        <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${noteMelodyColor.toLocaleString()}</td>
         <td colspan="3"></td>
         <td colspan="2"></td>
       </tr>`;


### PR DESCRIPTION
## Summary
- カード詳細パネルの「デッキ合計」行の下に、各属性ごとの **1ノーツあたりの基礎得点** を 2 行追加（白ノーツ ⚪ は `floor(デッキ合計 × 2.5%)`、色ノーツ 🔵🔴 は `floor(デッキ合計 × 3%)`）。
- デッキ合計値と 1ノーツ得点値をそれぞれ専用変数 (`deckShout/Beat/Melody`, `noteXxxWhite/Color`) に切り出して意図を明示。
- ⚪ / 🔵🔴 はノーツ種別マーカーであり属性色とは独立。LIGHT_MULTIPLIER は未適用の基礎単価。

## Test plan
- [x] 5枚同カードで計算 → 暗算と一致（例: Melody 36,433 → ⚪ 910 / 🔵🔴 1,092）
- [x] ScoreUPアシスト ON/OFF とも `(team + assist)` に追従
- [ ] 既存 Playwright / Vitest がグリーン（CI にて確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)