### PR TITLE
chore(ci): deploy.yml の actions/setup-node を v4 → v6 に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` の `actions/setup-node` を `v4` → `v6` に更新
- `actions/checkout` は既に `v6`、`cloudflare/wrangler-action` は最新メジャーが `v3` のため据え置き

## Test plan
- [ ] タグ push で `deploy.yml` がグリーンになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)