### PR TITLE
chore(ci): cloudflare/wrangler-action を v3.15.0 にピン止め

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` の `cloudflare/wrangler-action` を `@v3` → `@v3.15.0` にピン止め
- floating major tag ではなく特定パッチ版を明示的に指定する運用に変更

## Test plan
- [ ] タグ push で `deploy.yml` がグリーンになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)