### PR TITLE
chore(build): @playform/compress の Image 圧縮を有効化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
       JavaScript: true,
       JSON: true,
       SVG: true,
-      Image: false,
+      Image: true,
       Logger: 1,
     }),
   ],


### PR DESCRIPTION
## Summary
- `@playform/compress` の `Image` オプションを `false` → `true` に変更
- カード / サムネイル / 楽曲ジャケット等の静的画像もビルド時に圧縮

## 注意
- 画像枚数が多い（カード約 2,700 枚）ため、ビルド時間が増える可能性あり
- CI / デプロイ時間への影響は本 PR のタグ push 時に検証

## Test plan
- [ ] CI (build, Lighthouse) グリーン
- [ ] Cloudflare Workers デプロイ成功
- [ ] 本番で画像表示に崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)