### PR TITLE
refactor(score-calc): 1ノーツあたりスコアのラベルを単位先頭表記に変更

### DIFF
--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -960,14 +960,14 @@ const base = import.meta.env.BASE_URL;
         <td colspan="3"></td>
         <td colspan="2"></td>
       </tr><tr class="text-xs text-gray-500">
-        <td colspan="4" class="py-0.5 px-1 text-right">1ノーツ/⚪</td>
+        <td colspan="4" class="py-0.5 px-1 text-right">⚪🟢/1ノーツ</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${noteShoutWhite.toLocaleString()}</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${noteBeatWhite.toLocaleString()}</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${noteMelodyWhite.toLocaleString()}</td>
         <td colspan="3"></td>
         <td colspan="2"></td>
       </tr><tr class="text-xs text-gray-500">
-        <td colspan="4" class="py-0.5 px-1 text-right">1ノーツ/🔵🔴</td>
+        <td colspan="4" class="py-0.5 px-1 text-right">🔵🔴/1ノーツ</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Shout}">${noteShoutColor.toLocaleString()}</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Beat}">${noteBeatColor.toLocaleString()}</td>
         <td class="py-0.5 px-1 text-right ${ATTR_TEXT_CLASS.Melody}">${noteMelodyColor.toLocaleString()}</td>


### PR DESCRIPTION
## Summary
- スコア計算ページの詳細テーブルで、1ノーツあたりスコア行のラベルを「1ノーツ/⚪」「1ノーツ/🔵🔴」から「⚪🟢/1ノーツ」「🔵🔴/1ノーツ」に変更
- 単位（属性アイコン）を先頭に置くことで、列値との視覚的対応を改善

## Test plan
- [ ] score-calc ページで詳細テーブル内のラベルが新表記になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)