### PR TITLE
hotfix(build): @playform/compress の Image 圧縮を無効化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
     JavaScript: true,
     JSON: true,
     SVG: true,
-    Image: true,
+    Image: false,
     Logger: 1,
   }), svelte()],
 


### PR DESCRIPTION
## Summary
- `@playform/compress` の `Image: true` を `false` に戻す
- 画像圧縮を有効化して以降、`npm run build` に 60 分以上かかり deploy.yml が極端に遅延しているため暫定対応
- CSS / HTML / JavaScript / JSON / SVG の圧縮は引き続き有効

## Background
- #136 で `Image: true` に切り替えて以降、deploy のビルドが毎回 60〜80 分に
- 実行中の run `24757762381` は開始から 30 分以上経過してもまだ `npm run build` 段階
- 公開中画像の追加圧縮メリットに対してビルド時間コストが見合わないため、一旦戻す

## Follow-up (別PRで検討)
- 圧縮結果のキャッシュ戦略、もしくは事前に圧縮済み画像をコミットする運用に切り替える

## Test plan
- [ ] CI (build check) がグリーンになること
- [ ] deploy.yml のビルドが従来（#136 以前）の所要時間に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)