### PR TITLE
ci: 自動取得 PR をマージ・リリースまで自動化

### DIFF
--- a/.github/workflows/fetch-event-db.yml
+++ b/.github/workflows/fetch-event-db.yml
@@ -53,6 +53,7 @@ jobs:
           echo "size=$SIZE" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           add-paths: public/events/events.csv
@@ -68,3 +69,27 @@ jobs:
             - **Destination**: `public/events/events.csv`
             - **Rows**: ${{ steps.fetch.outputs.rows }}
             - **Size**: ${{ steps.fetch.outputs.size }} bytes
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch
+
+      - name: Bump tag and trigger release/deploy
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -e -o pipefail
+          git fetch --tags origin
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest: $LATEST  ->  New: $NEW_TAG"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin main
+          git tag "$NEW_TAG" origin/main
+          git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-gap-cards.yml
+++ b/.github/workflows/fetch-gap-cards.yml
@@ -92,6 +92,7 @@ jobs:
           echo "new_ids=${NEW_IDS}" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: cpr
         if: steps.fetch.outputs.downloaded != '0'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -110,3 +111,27 @@ jobs:
             - **New card IDs**: ${{ steps.fetch.outputs.new_ids }}
 
             > Scans descending from the highest existing ID to 1, fetching any missing IDs. Batch limited to 500 per run.
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch
+
+      - name: Bump tag and trigger release/deploy
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -e -o pipefail
+          git fetch --tags origin
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest: $LATEST  ->  New: $NEW_TAG"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin main
+          git tag "$NEW_TAG" origin/main
+          git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -100,6 +100,7 @@ jobs:
           echo "new_ids=${NEW_IDS}" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: cpr
         if: steps.fetch.outputs.downloaded != '0'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -117,3 +118,27 @@ jobs:
             - **Gaps checked**: ${{ steps.fetch.outputs.gap_count }}
             - **New images**: ${{ steps.fetch.outputs.new_ids }}
             - **Count**: ${{ steps.fetch.outputs.downloaded }}
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch
+
+      - name: Bump tag and trigger release/deploy
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -e -o pipefail
+          git fetch --tags origin
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest: $LATEST  ->  New: $NEW_TAG"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin main
+          git tag "$NEW_TAG" origin/main
+          git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-new-th-cards.yml
+++ b/.github/workflows/fetch-new-th-cards.yml
@@ -112,6 +112,7 @@ jobs:
           echo "missing_count=$MISSING_COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: cpr
         if: steps.fetch.outputs.downloaded != '0'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -129,3 +130,27 @@ jobs:
             - **New thumbnail IDs**: ${{ steps.fetch.outputs.new_ids }}
 
             > Thumbnails are stored in `public/assets/th_cards/` and sourced from `cards/th/{id}.png`.
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch
+
+      - name: Bump tag and trigger release/deploy
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -e -o pipefail
+          git fetch --tags origin
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest: $LATEST  ->  New: $NEW_TAG"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin main
+          git tag "$NEW_TAG" origin/main
+          git push origin "$NEW_TAG"


### PR DESCRIPTION
## Summary
- `fetch-new-cards.yml` / `fetch-new-th-cards.yml` / `fetch-gap-cards.yml` / `fetch-event-db.yml` の PR 作成直後に auto-merge とタグ発行ステップを追加
- `gh pr merge <n> --squash --delete-branch` で `GITHUB_TOKEN` 経由のマージ
- `RELEASE_PAT` を使って `origin/main` の先端に patch +1 したタグを push し、既存の `release.yml` / `deploy.yml` を発火させる
  - `GITHUB_TOKEN` で push した tag は他 workflow を起動しない GitHub 仕様のため PAT を使用

## Test plan
- [ ] マージ後、`fetch-event-db.yml` を Actions から `workflow_dispatch` で手動実行し、PR 作成 → squash merge → `v1.7.x+1` タグ push → `Create Release` 発火 → `Deploy to Cloudflare Workers` 発火 → 本番反映まで一気通貫で走ることを確認
- [ ] 差分無しのケースで PR/マージ/タグが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)