### PR TITLE
feat(score-calc): スキル詳細パネルに「スキル最大発動数」列を追加

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -5,7 +5,7 @@
   import type { Song } from '../lib/data/fetchSongsJson';
   import type { FixedBroach } from '../lib/data/fetchFixedBroachsJson';
   import type { ComputedTeam, SimulationResult, ScoreOptions, FlatNote } from '../lib/score/types';
-  import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, calcExpectedScore, calcCardSkillExpected, calcCardSkillMax, runSimulation, flattenNotes, getCenterSkillRate, computeShrinkExclusion, computeGroupSizes } from '../lib/score/engine';
+  import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, calcExpectedScore, calcCardSkillExpected, calcCardSkillMax, calcCardSkillMaxActivations, runSimulation, flattenNotes, getCenterSkillRate, computeShrinkExclusion, computeGroupSizes } from '../lib/score/engine';
   import { resolveDeckBroachs } from '../lib/score/broachResolver';
   import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER, TRAIN_BONUS, SCOREUP_ASSIST_RATE } from '../lib/score/constants';
   import { EVENT_BONUS_TIERS, EVENT_BONUS_MULTIPLIER, BONUS_LABEL, BONUS_CLASS, ALL_SELECT_CLASSES } from '../lib/data/eventBonusTiers';
@@ -707,13 +707,16 @@
       const rows: string[] = [];
       let totalExp = 0;
       let totalMax = 0;
+      let totalActivations = 0;
       for (const i of DISPLAY_ORDER) {
         const card = deck[i];
         if (!card) continue;
         const exp = calcCardSkillExpected(team, notes, notesCount, i, options);
         const max = calcCardSkillMax(team, notes, notesCount, i, options);
+        const activations = calcCardSkillMaxActivations(team, notes, notesCount, i);
         totalExp += exp;
         totalMax += max;
+        totalActivations += activations;
         const slotCls = i === 0 ? 'text-indigo-600 font-bold' : i === 5 ? 'text-amber-600 font-bold' : 'text-gray-500';
         rows.push(`<tr class="border-t">
           <td class="py-1 px-1 text-[10px] ${slotCls}">${SLOT_LABELS[i]}</td>
@@ -723,6 +726,7 @@
           </td>
           <td class="py-1 px-1">${card.ap_skill_type || '-'}</td>
           <td class="py-1 px-1 text-right">${exp > 0 ? exp.toLocaleString() : '-'}</td>
+          <td class="py-1 px-1 text-right">${activations > 0 ? activations.toLocaleString() : '-'}</td>
           <td class="py-1 px-1 text-right">${max > 0 ? max.toLocaleString() : '-'}</td>
         </tr>`);
       }
@@ -735,6 +739,7 @@
       _q('skill-per-card-foot').innerHTML = `<tr class="border-t-2 border-gray-300 font-bold">
         <td colspan="3" class="py-1 px-1 text-right text-gray-700">合計</td>
         <td class="py-1 px-1 text-right">${totalExp.toLocaleString()}</td>
+        <td class="py-1 px-1 text-right">${totalActivations.toLocaleString()}</td>
         <td class="py-1 px-1 text-right">${totalMax.toLocaleString()}</td>
       </tr>`;
     }
@@ -1360,7 +1365,7 @@
       <section id="score-breakdown" class="hidden">
         <div class="space-y-1">
           <div id="shrink-coverage-row" class="flex justify-between text-sm hidden">
-            <span class="text-gray-500">縮小カバー率（100%発動時）</span>
+            <span class="text-gray-500">縮小カバー率（最大発動時）</span>
             <span id="shrink-coverage-val" class="font-medium text-orange-600"></span>
           </div>
           <div id="shrink-expected-row" class="flex justify-between text-sm hidden">
@@ -1382,13 +1387,14 @@
                 <th class="text-left py-1 px-1">カード名</th>
                 <th class="text-left py-1 px-1">スキル</th>
                 <th class="text-right py-1 px-1">スキル期待値</th>
+                <th class="text-right py-1 px-1">スキル最大発動回数</th>
                 <th class="text-right py-1 px-1">スキル論理最高値</th>
               </tr>
             </thead>
             <tbody id="skill-per-card-body"></tbody>
             <tfoot id="skill-per-card-foot"></tfoot>
           </table>
-          <p class="text-xs text-gray-400 mt-2">※ 複数の判定縮小スキルが共存する場合、max rate 合成は考慮しないためカード単独寄与の目安です</p>
+          <p class="text-xs text-gray-400 mt-2">※ 複数の判定縮小スキルが共存する場合、値は按分されます</p>
         </div>
       </section>
       <p id="breakdown-placeholder" class="text-xs text-gray-400 text-center py-6">楽曲とカードを設定するとスキル詳細が表示されます</p>

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -514,6 +514,34 @@ export function calcCardSkillExpected(
   return Math.floor(eligibleBaseScore * (skill.rate - 1.0) * coverageRate);
 }
 
+/**
+ * 単一カードのスキル最大発動数（理論上の上限発動回数）。
+ * - スコアアップ / タイマー: floor( (タイマーなら songDuration、通常なら notesCount) / count )
+ * - 判定縮小: floor( eligibleCount / count )
+ * 発動確率 per は考慮せず、カウント条件を満たし得る最大回数を返す。
+ */
+export function calcCardSkillMaxActivations(
+  team: ComputedTeam,
+  notes: FlatNote[],
+  notesCount: number,
+  slotIndex: number,
+): number {
+  const dc = team.cards.find(c => c.slotIndex === slotIndex);
+  if (!dc || !dc.skill || dc.skill.count <= 0) return 0;
+  const skill = dc.skill;
+
+  if (!skill.isShrink) {
+    const denom = skill.isTimer ? team.songDuration : notesCount;
+    if (denom <= 0) return 0;
+    return Math.floor(denom / skill.count);
+  }
+
+  const excludedCount = notes.filter(n => n.excluded).length;
+  const eligibleCount = notesCount - excludedCount;
+  if (eligibleCount <= 0) return 0;
+  return Math.floor(eligibleCount / skill.count);
+}
+
 /** 単一カードのスキル論理最高値（100% 発動・当該カードのみが縮小スキルを持つ想定）。 */
 export function calcCardSkillMax(
   team: ComputedTeam,

--- a/tests/unit/score/engine.test.ts
+++ b/tests/unit/score/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import type { Card } from '../../../src/lib/data/fetchCardsJson';
 import {
+  calcCardSkillMaxActivations,
   calcExpectedScore,
   calcMaxScore,
   calcMinScore,
@@ -665,6 +666,52 @@ describe('Binary Vampire (ID60) × Re:vale六枚デッキ (センター=ID1500 /
         grandTotal += sw + sc + bw + bc + mw + mc;
       }
       expect(grandTotal).toBe(1876289);
+    });
+  });
+});
+
+describe('calcCardSkillMaxActivations (単一カードのスキル最大発動数)', () => {
+  const notesCount = monsterGenerationSong.notes_count!;
+
+  it('スキル非所持カード(10th 環: BAD→Perfect)は 0 を返す', () => {
+    const team = computeTeam(centerDeck, [], monsterGenerationSong);
+    const notes = flattenNotes(monsterGenerationSong, FLATTEN_SEED);
+    expect(calcCardSkillMaxActivations(team, notes, notesCount, 0)).toBe(0);
+  });
+
+  it('空スロット(カード未配置)は 0 を返す', () => {
+    const team = computeTeam(centerDeck, [], monsterGenerationSong);
+    const notes = flattenNotes(monsterGenerationSong, FLATTEN_SEED);
+    expect(calcCardSkillMaxActivations(team, notes, notesCount, 3)).toBe(0);
+  });
+
+  it('タイマー(JokerFlag2 環 / count=16秒): floor(songDuration 104 / 16) = 6 回', () => {
+    const team = computeTeam(jokerFlag2Deck, [], monsterGenerationSong);
+    const notes = flattenNotes(monsterGenerationSong, FLATTEN_SEED);
+    expect(calcCardSkillMaxActivations(team, notes, notesCount, 0)).toBe(6);
+  });
+
+  it('スコアアップコンボ(屋外フェス2 壮五 / count=16ノート): floor(428 / 16) = 26 回', () => {
+    const team = computeTeam(outdoorFes2Deck, [], monsterGenerationSong);
+    const notes = flattenNotes(monsterGenerationSong, FLATTEN_SEED);
+    expect(calcCardSkillMaxActivations(team, notes, notesCount, 0)).toBe(26);
+  });
+
+  describe('判定縮小 2 枚構成(ID1952 フレンド count=20 / ID3597 メンバー1 count=23)', () => {
+    const team = computeTeam(threeCardDeck, tenthTamakiBroachs, monsterGenerationSong);
+    const exclusion = computeShrinkExclusion(team, computeGroupSizes(monsterGenerationSong));
+    const notes = flattenNotes(monsterGenerationSong, FLATTEN_SEED, exclusion);
+
+    it('フレンド(ID1952): floor(eligibleCount 407 / 20) = 20 回', () => {
+      expect(calcCardSkillMaxActivations(team, notes, notesCount, 5)).toBe(20);
+    });
+
+    it('メンバー1(ID3597): floor(eligibleCount 407 / 23) = 17 回', () => {
+      expect(calcCardSkillMaxActivations(team, notes, notesCount, 1)).toBe(17);
+    });
+
+    it('センター(10th 環: スキル非所持)は 0', () => {
+      expect(calcCardSkillMaxActivations(team, notes, notesCount, 0)).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- スコア計算画面のスキル詳細パネルに **スキル最大発動数** 列を追加（「スキル期待値」と「スキル論理最高値」の間）。
- `calcCardSkillMaxActivations` を `src/lib/score/engine.ts` に追加。per (発動確率) は考慮せず、カウント条件を満たし得る理論上限を返す:
  - スコアアップ / タイマー: `floor( (タイマーなら songDuration, 通常なら notesCount) / count )`
  - 判定縮小: `floor( eligibleCount / count )`
- Vitest に 6 ケース追加（スコアアップコンボ / タイマー / 判定縮小 2 枚 / スキル非所持 / 空スロット）。全 80 テスト pass。

## Screenshot
`tmp/skill-detail-panel.png` にローカル確認のスクリーンショット。Binary Vampire + 判定縮小 2 枚 + 10th 環（スキル非所持）構成で、列順・`-` 表示・合計行が期待通り表示されることを確認済み。

## Test plan
- [x] `npm run test:unit` で 80 tests 全 pass
- [x] `npm run build` がエラーなし
- [x] ホストで `npx serve dist -l 4321` を起動し Playwright で /score-calc/ のスキル詳細パネル表示を確認
- [ ] Cloudflare Workers デプロイ後に本番画面で列表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)