### PR TITLE
feat(score-calc): スコア分布ヒストグラム細分化＋スキル種別寄与分布の並置表示

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -856,6 +856,23 @@
 
       _q('histogram-container').innerHTML = renderHistogramSvg(result.scores, result.minScore, result.maxScore, result.mean);
 
+      const renderContributionHistogram = (values: number[], containerId: string, label: string, color: string) => {
+        if (values.length === 0) {
+          _q(containerId).innerHTML = '<span class="text-gray-400 text-xs">データなし</span>';
+          return;
+        }
+        let min = Infinity, max = -Infinity, sum = 0;
+        for (const v of values) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+          sum += v;
+        }
+        const mean = sum / values.length;
+        _q(containerId).innerHTML = renderHistogramSvg(values, min, max, mean, { xAxisLabel: label, barColor: color });
+      };
+      renderContributionHistogram(result.shrinkScores, 'histogram-shrink', '縮小スキル寄与', '#10b981');
+      renderContributionHistogram(result.scoreUpScores, 'histogram-scoreup', 'スコアアップ寄与', '#6366f1');
+
       const expected = calcExpectedScore(team, notes, selectedSong.notes_count || notes.length, scoreOptions);
       _q('expected-score').classList.remove('hidden');
       _q('exp-base').textContent = expected.baseScore.toLocaleString();
@@ -1455,6 +1472,16 @@
           </tbody>
         </table>
         <div id="histogram-container" class="mt-4"></div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <div>
+            <div class="text-xs text-gray-600 mb-1">縮小スキル寄与量の分布</div>
+            <div id="histogram-shrink"></div>
+          </div>
+          <div>
+            <div class="text-xs text-gray-600 mb-1">スコアアップスキル寄与量の分布</div>
+            <div id="histogram-scoreup"></div>
+          </div>
+        </div>
       </section>
       <p id="mc-placeholder" class="text-xs text-gray-400 text-center py-6">計算を実行するとシミュレーション結果が表示されます</p>
     </section>

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -576,6 +576,8 @@ interface RunOnceResult {
   score: number;
   activations: number[];
   contributions: number[];
+  shrinkScore: number;
+  scoreUpScore: number;
 }
 
 /** MC 1回分の実行 */
@@ -584,6 +586,8 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
   const cardCount = team.cards.length;
   const activations = new Array<number>(cardCount).fill(0);
   const contributions = new Array<number>(cardCount).fill(0);
+  let shrinkScore = 0;
+  let scoreUpScore = 0;
   const assist = options?.scoreUpAssist ?? false;
 
   // 期待縮小時間 (§2-2 按分用): 試行間で変わらない固定係数
@@ -615,6 +619,7 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
         if (noteIndex >= 0) {
           timerBonus[noteIndex] += skill.value;
           contributions[c] += skill.value;
+          scoreUpScore += skill.value;
         }
       }
     }
@@ -653,6 +658,7 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
           } else {
             scoreUpSum += skill.value;
             contributions[c] += skill.value;
+            scoreUpScore += skill.value;
           }
         }
       }
@@ -681,10 +687,11 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
           contributions[c] += shrinkExtra * (expectedShrinkTimes[c] / totalExpectedShrinkTime);
         }
       }
+      shrinkScore += shrinkExtra;
     }
   }
 
-  return { score: applyFinalBonus(totalScore, team, options), activations, contributions };
+  return { score: applyFinalBonus(totalScore, team, options), activations, contributions, shrinkScore, scoreUpScore };
 }
 
 /** MC シミュレーション実行（チャンク分割） */
@@ -701,6 +708,8 @@ export async function runSimulation(
 
   const rng = new XorShift128Plus(seed ?? Date.now());
   const scores: number[] = [];
+  const shrinkScores: number[] = [];
+  const scoreUpScores: number[] = [];
   const cardCount = team.cards.length;
   const totalActivations = new Array<number>(cardCount).fill(0);
   const totalContributions = new Array<number>(cardCount).fill(0);
@@ -710,6 +719,8 @@ export async function runSimulation(
     for (let j = i; j < end; j++) {
       const result = runOnce(team, notes, rng, options);
       scores.push(result.score);
+      shrinkScores.push(result.shrinkScore);
+      scoreUpScores.push(result.scoreUpScore);
       for (let c = 0; c < cardCount; c++) {
         totalActivations[c] += result.activations[c];
         totalContributions[c] += result.contributions[c];
@@ -760,6 +771,8 @@ export async function runSimulation(
     mcMin: sorted[0],
     mcMax: sorted[sorted.length - 1],
     cardStats,
+    shrinkScores,
+    scoreUpScores,
   };
 }
 

--- a/src/lib/score/histogram.ts
+++ b/src/lib/score/histogram.ts
@@ -9,17 +9,20 @@ const CHART_HEIGHT = 200;
 const MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
 const INNER_WIDTH = CHART_WIDTH - MARGIN.left - MARGIN.right;
 const INNER_HEIGHT = CHART_HEIGHT - MARGIN.top - MARGIN.bottom;
-const BIN_COUNT = 25;
+const BIN_COUNT = 75;
 
 export function renderHistogramSvg(
   scores: number[],
   minScore: number,
   maxScore: number,
   mean: number,
+  options?: { xAxisLabel?: string; barColor?: string },
 ): string {
   if (scores.length === 0 || maxScore <= minScore) {
     return '<span class="text-gray-400 text-xs">データなし</span>';
   }
+  const xAxisLabel = options?.xAxisLabel ?? 'スコア';
+  const barColor = options?.barColor ?? '#6366f1';
 
   const range = maxScore - minScore;
   const binWidth = range / BIN_COUNT;
@@ -46,7 +49,7 @@ export function renderHistogramSvg(
     const y = MARGIN.top + INNER_HEIGHT - barH;
     const binStart = Math.round(minScore + i * binWidth);
     const binEnd = Math.round(minScore + (i + 1) * binWidth);
-    return `<rect x="${x}" y="${y}" width="${barW - 1}" height="${barH}" fill="#6366f1" opacity="0.8">
+    return `<rect x="${x}" y="${y}" width="${barW - 1}" height="${barH}" fill="${barColor}" opacity="0.8">
       <title>${binStart.toLocaleString()}〜${binEnd.toLocaleString()}: ${count}回</title>
     </rect>`;
   }).join('\n    ');
@@ -78,7 +81,7 @@ export function renderHistogramSvg(
     <line x1="${MARGIN.left}" y1="${MARGIN.top}" x2="${MARGIN.left}" y2="${MARGIN.top + INNER_HEIGHT}" stroke="#d1d5db" stroke-width="1"/>`;
 
   // 軸ラベル
-  const axisLabels = `<text x="${CHART_WIDTH / 2}" y="${CHART_HEIGHT - 2}" text-anchor="middle" fill="#6b7280" font-size="10">スコア</text>
+  const axisLabels = `<text x="${CHART_WIDTH / 2}" y="${CHART_HEIGHT - 2}" text-anchor="middle" fill="#6b7280" font-size="10">${xAxisLabel}</text>
     <text x="12" y="${CHART_HEIGHT / 2}" text-anchor="middle" fill="#6b7280" font-size="10" transform="rotate(-90 12 ${CHART_HEIGHT / 2})">度数</text>`;
 
   return `<svg viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg">

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -78,6 +78,8 @@ export interface SimulationResult {
   mcMin: number;
   mcMax: number;
   cardStats: CardSkillStats[];
+  shrinkScores: number[];
+  scoreUpScores: number[];
 }
 
 export interface ScoreOptions {


### PR DESCRIPTION
## Summary
- 総スコアヒストグラムのビン数を `25 → 75` に引き上げ、分布の粒度を細かく表示
- `SimulationResult` に per-trial の縮小スキル寄与 / スコアアップスキル寄与を追加
- `ScoreCalc.svelte` に**縮小スキル寄与量の分布**（緑）と**スコアアップスキル寄与量の分布**（紺）を並置した2枚のヒストグラムを追加し、合計3枚表示

これにより「総スコアのばらつき」に加え、「どちらのスキル種別がどれくらい/どの程度安定してスコアに寄与しているか」が視覚的に比較できる。

## Test plan
- [ ] `npm run test:unit` が通る（既存 83 テスト）
- [ ] `/score-calc/` でシミュレーション実行後、ヒストグラムが3枚表示される
- [ ] 総スコア分布（紺）のバーが細かく（75本）描画される
- [ ] 縮小スキル寄与分布（緑）/スコアアップ寄与分布（紺）がそれぞれ独立 x 軸で描画される
- [ ] 縮小スキル無しデッキ/スコアアップスキル無しデッキで該当側が「データなし」になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)