### PR TITLE
feat(score-calc): スコア計算仕様解説ページを追加（縮小スキルを SVG で視覚化）

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     command: 'npm run preview',
     url: 'http://localhost:4321/',
     reuseExistingServer: true,
-    timeout: 30000,
+    // 本番ビルドは 2779 ページ生成で実測 5.5 分かかるため、初回起動を考慮して 7 分確保
+    timeout: 420000,
   },
   projects: [
     { name: 'chromium', use: { browserName: 'chromium' } },

--- a/src/components/score/ShrinkPlayground.svelte
+++ b/src/components/score/ShrinkPlayground.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import {
+    shrinkTimelineSvg,
+    simulateActivationsMulti,
+    CARD_COLORS,
+    type ShrinkCardParam,
+  } from '../../lib/score/specDiagrams';
+
+  const NOTES_COUNT = 428;
+  const SONG_DURATION = 104;
+  const NOTES_20 = 21;
+  const MAX_CARDS = 4;
+
+  // 初期値: 典型的な縮小カード (Card 1952 SL5 相当) × 1 枚
+  let cards = $state<ShrinkCardParam[]>([{ count: 20, per: 40, value: 4 }]);
+  let seed = $state(7);
+
+  // 倍率 rate は UI では選択式（Lv1〜Lv5）
+  let rate = $state(1.6);
+
+  let minCount = $derived(Math.min(...cards.map((c) => c.count)));
+  let excludeHead = $derived(Math.max(NOTES_20, minCount));
+  let activations = $derived(simulateActivationsMulti({
+    cards,
+    notesCount: NOTES_COUNT,
+    songDuration: SONG_DURATION,
+    excludeHead,
+    seed,
+  }));
+  let svg = $derived(shrinkTimelineSvg({
+    count: cards[0].count, per: cards[0].per, value: cards[0].value,
+    cards,
+    notesCount: NOTES_COUNT,
+    songDuration: SONG_DURATION,
+    excludeHead,
+    activations,
+  }));
+
+  let firedCount = $derived(activations.filter((a) => a.fired).length);
+  let totalTriggers = $derived(activations.length);
+  let coveredSec = $derived(
+    activations.filter((a) => a.fired).reduce((sum, a, _i) => {
+      const c = cards[a.cardIndex ?? 0];
+      return sum + (c?.value ?? 0);
+    }, 0)
+  );
+  let coveredSecCapped = $derived(Math.min(coveredSec, SONG_DURATION));
+  let coveragePct = $derived(((coveredSecCapped / SONG_DURATION) * 100).toFixed(1));
+
+  function addCard() {
+    if (cards.length >= MAX_CARDS) return;
+    cards = [...cards, { count: 22, per: 35, value: 4 }];
+  }
+  function removeCard(i: number) {
+    if (cards.length <= 1) return;
+    cards = cards.filter((_, idx) => idx !== i);
+  }
+</script>
+
+<div class="border border-gray-200 rounded-lg p-4 bg-gray-50 space-y-4">
+  <div class="flex items-center justify-between flex-wrap gap-2">
+    <h4 class="text-sm font-bold text-gray-800">縮小スキル {cards.length} 枚構成</h4>
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        class="px-2 py-1 text-xs rounded border border-indigo-500 text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed"
+        onclick={addCard}
+        disabled={cards.length >= MAX_CARDS}
+        aria-label="縮小スキルを追加"
+      >
+        ＋カード追加
+      </button>
+      <button
+        type="button"
+        class="px-3 py-1 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700"
+        onclick={() => (seed = (seed + 1) & 0xffff)}
+      >
+        別の試行 (seed={seed})
+      </button>
+    </div>
+  </div>
+
+  {#each cards as card, i (i)}
+    <div class="bg-white rounded border border-gray-200 p-3">
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs font-bold" style="color: {CARD_COLORS[i]}">
+          ■ カード {i + 1}
+        </span>
+        {#if cards.length > 1}
+          <button
+            type="button"
+            class="text-xs text-gray-500 hover:text-red-600"
+            onclick={() => removeCard(i)}
+            aria-label="このカードを削除"
+          >
+            × 削除
+          </button>
+        {/if}
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
+        <label class="flex flex-col gap-1">
+          <span class="font-semibold text-gray-700">
+            ノーツ数 <span class="text-gray-500">(count)</span>:
+            <span class="text-indigo-600">{card.count}</span>
+          </span>
+          <input type="range" min="10" max="30" step="1" bind:value={card.count} class="w-full" />
+          <span class="text-gray-500">何ノーツ毎に発動判定するか</span>
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="font-semibold text-gray-700">
+            確率 <span class="text-gray-500">(per)</span>:
+            <span class="text-indigo-600">{card.per}%</span>
+          </span>
+          <input type="range" min="5" max="80" step="1" bind:value={card.per} class="w-full" />
+          <span class="text-gray-500">判定ごとに発動する確率</span>
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="font-semibold text-gray-700">
+            秒数 <span class="text-gray-500">(value)</span>:
+            <span class="text-indigo-600">{card.value}秒</span>
+          </span>
+          <input type="range" min="1" max="8" step="1" bind:value={card.value} class="w-full" />
+          <span class="text-gray-500">発動時の持続秒数</span>
+        </label>
+      </div>
+    </div>
+  {/each}
+
+  <div class="flex items-center gap-3 text-xs text-gray-600 flex-wrap">
+    <label class="flex items-center gap-1">
+      <span class="font-semibold text-gray-700">倍率 <span class="text-gray-500">(rate)</span>:</span>
+      <select bind:value={rate} class="border rounded px-1 py-0.5">
+        <option value={1.2}>1.2 (Lv1)</option>
+        <option value={1.3}>1.3 (Lv2)</option>
+        <option value={1.4}>1.4 (Lv3)</option>
+        <option value={1.5}>1.5 (Lv4)</option>
+        <option value={1.6}>1.6 (Lv5)</option>
+      </select>
+    </label>
+    <span>楽曲: MONSTER GENERATiON ({NOTES_COUNT}ノーツ / {SONG_DURATION}秒)</span>
+    <span>先頭除外: <strong class="text-gray-800">{excludeHead}</strong></span>
+    <span>
+      発動合計: <strong class="text-gray-800">{firedCount}/{totalTriggers}</strong>
+    </span>
+    <span>
+      カバー率: <strong class="text-gray-800">{coveragePct}%</strong>
+      ({coveredSecCapped}秒 / {SONG_DURATION}秒)
+    </span>
+  </div>
+
+  <div class="overflow-x-auto -mx-1 px-1">
+    {@html svg}
+  </div>
+
+  <p class="text-xs text-gray-500">
+    ※ 複数枚構成時は <strong>キューイング仕様</strong>（§2 末尾参照）に従い、先行スキルが終了してから後続スキルが連続発動します（時間軸上で重なりません）。
+  </p>
+</div>

--- a/src/lib/score/specDiagrams.ts
+++ b/src/lib/score/specDiagrams.ts
@@ -1,0 +1,620 @@
+/**
+ * スコア計算仕様解説ページ (src/pages/score-calc/spec.astro) 用 SVG 生成ヘルパー。
+ *
+ * 既存の histogram.ts / donutChart.ts と同じく「インライン SVG 文字列を返す関数」
+ * パターンで統一する。呼び出し側は `<Fragment set:html={...} />` または
+ * `{@html ...}` で埋め込む。
+ */
+
+import { ATTR_HEX } from '../constants';
+import { renderHistogramSvg } from './histogram';
+import { XorShift128Plus } from './rng';
+
+const COLOR = {
+  main: '#6366f1',      // indigo-500（メイン枠）
+  mainDark: '#4338ca',  // indigo-700（強調文字）
+  shrink: '#f59e0b',    // amber-500（縮小枝）
+  shrinkDark: '#b45309',// amber-700
+  emerald: '#10b981',   // emerald-500（カバー率）
+  exclude: '#d1d5db',   // gray-300（先頭除外領域）
+  grid: '#e5e7eb',      // gray-200（目盛）
+  text: '#374151',      // gray-700
+  muted: '#6b7280',     // gray-500
+} as const;
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** 矢印マーカーの共通定義 (1 SVG につき defs 1回で良い) */
+function arrowMarkerDef(id = 'arrow', color = COLOR.main): string {
+  return `<defs>
+    <marker id="${id}" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${color}" />
+    </marker>
+  </defs>`;
+}
+
+/* ================================================================
+ * (A) スコア計算の全体フロー図
+ * ================================================================ */
+export function overviewFlowSvg(): string {
+  const W = 760, H = 520;
+  // ボックス配置: 上3段 → 合計ノードに合流 → バッジ → 最終
+  const boxes = [
+    // Row 0 (y=20): 属性値 → アシスト → 素点 → ライト倍率
+    { x: 20,  y: 20, w: 170, h: 64, title: 'チーム属性値', sub: 'Shout / Beat / Melody\nの 6 枠合算', c: COLOR.main },
+    { x: 200, y: 20, w: 170, h: 64, title: 'アシスト適用', sub: 'floor(team × 1.2)', c: COLOR.main },
+    { x: 380, y: 20, w: 170, h: 64, title: '1ノーツ素点', sub: 'floor(appeal × NOTE_RATE)\n白=2.5% / 色=3.0%', c: COLOR.main },
+    { x: 560, y: 20, w: 180, h: 64, title: 'ライト倍率', sub: 'floor(素点 × LIGHT_MULTIPLIER)\n通常 1.0〜1.5 / サビ 3.0', c: COLOR.main },
+    // Row 1 (y=120): スコアアップ加算 / 縮小加算 / (ライト倍率の続き)
+    { x: 20,  y: 120, w: 170, h: 84, title: 'スコアアップ加算', sub: 'Σ scoreUpExpected\n(タイマー系含む)', c: COLOR.main },
+    { x: 380, y: 120, w: 170, h: 84, title: '縮小加算 (§5)', sub: 'floor(eligibleBaseScore\n × (rate − 1.0)\n × coverageRate)', c: COLOR.shrink },
+    // Row 2 (y=240): 合計 total
+    { x: 120, y: 240, w: 520, h: 70, title: '合計 total', sub: 'Σ (noteScore + shrinkExtra + scoreUpSum)', c: COLOR.mainDark },
+    // Row 3 (y=340): バッジ倍率
+    { x: 240, y: 340, w: 280, h: 64, title: 'バッジ倍率適用', sub: 'floor(total × (1 + badge% / 100))', c: COLOR.main },
+    // Row 4 (y=430): 最終スコア
+    { x: 240, y: 430, w: 280, h: 64, title: '最終スコア', sub: '+ broachScoreBonus (種類9)', c: COLOR.mainDark },
+  ];
+
+  const boxSvg = boxes.map((b) => {
+    const lines = b.sub.split('\n');
+    const subText = lines.map((l, i) =>
+      `<tspan x="${b.x + b.w / 2}" dy="${i === 0 ? 16 : 12}">${escapeXml(l)}</tspan>`
+    ).join('');
+    return `<g>
+      <rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" rx="8" ry="8"
+            fill="white" stroke="${b.c}" stroke-width="2"/>
+      <text x="${b.x + b.w / 2}" y="${b.y + 20}" text-anchor="middle"
+            fill="${b.c}" font-size="13" font-weight="bold">${escapeXml(b.title)}</text>
+      <text x="${b.x + b.w / 2}" y="${b.y + 34}" text-anchor="middle"
+            fill="${COLOR.muted}" font-size="10">${subText}</text>
+    </g>`;
+  }).join('\n');
+
+  const arrow = (x1: number, y1: number, x2: number, y2: number, color = COLOR.main, dashed = false) =>
+    `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${color}" stroke-width="2"
+           marker-end="url(#arrow)"${dashed ? ' stroke-dasharray="4 3"' : ''}/>`;
+  const arrowShrink = (x1: number, y1: number, x2: number, y2: number, dashed = false) =>
+    `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${COLOR.shrink}" stroke-width="2"
+           marker-end="url(#arrow-shrink)"${dashed ? ' stroke-dasharray="4 3"' : ''}/>`;
+
+  // 合計ノードの上辺中央
+  const totalTopY = 240;
+  const totalLeftX = 180;   // スコアアップ加算の真下付近
+  const totalCenterX = 380; // 縮小加算の真下
+  const totalRightX = 580;  // ライト倍率の真下付近
+
+  const arrows = [
+    // Row 0: 横方向の直列
+    arrow(190, 52, 200, 52),   // 属性値 → アシスト
+    arrow(370, 52, 380, 52),   // アシスト → 素点
+    arrow(550, 52, 560, 52),   // 素点 → ライト倍率
+    // ライト倍率（per-note 素点） → 縮小加算（縮小発動中のノートだけ (rate−1)×素点 を追加）
+    arrowShrink(590, 84, 485, 120),
+    // 縮小加算 → 合計
+    arrow(465, 204, totalCenterX, totalTopY),
+    // スコアアップ加算 → 合計 (左端、斜め↘)
+    arrow(105, 204, totalLeftX, totalTopY),
+    // ライト倍率 → 合計 (右端、斜め↙。ノーツ本体スコアの総計)
+    arrow(680, 84, totalRightX, totalTopY),
+    // 合計 → バッジ
+    arrow(380, 310, 380, 340),
+    // バッジ → 最終
+    arrow(380, 404, 380, 430),
+  ].join('\n');
+
+  // 補助ラベル
+  const auxLabels = `
+    <text x="650" y="115" text-anchor="middle" fill="${COLOR.muted}" font-size="9">
+      (各ノーツスコアを合算)
+    </text>
+    <text x="540" y="108" text-anchor="end" fill="${COLOR.shrinkDark}" font-size="9">
+      橙経路 = 縮小発動中のノートだけ (rate−1)×素点 を追加
+    </text>
+  `;
+
+  return `<svg viewBox="0 0 ${W} ${H}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="スコア計算の全体フロー">
+    ${arrowMarkerDef('arrow', COLOR.main)}
+    <defs>
+      <marker id="arrow-shrink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="${COLOR.shrink}" />
+      </marker>
+    </defs>
+    ${boxSvg}
+    ${arrows}
+    ${auxLabels}
+    <text x="${W / 2}" y="${H - 6}" text-anchor="middle" fill="${COLOR.muted}" font-size="10">
+      バッジ倍率は 合計 total（ノーツ本体 + 縮小加算 + スコアアップ加算）に対して適用される
+    </text>
+  </svg>`;
+}
+
+/* ================================================================
+ * (B) 縮小スキルのタイムライン図
+ * ================================================================ */
+export interface Activation {
+  start: number;    // ノート index (inclusive)
+  end: number;      // ノート index (exclusive)
+  fired: boolean;   // true=発動, false=不発
+  cardIndex?: number; // どのカードのトリガーか（マルチカード時に使用）
+}
+
+export interface ShrinkCardParam {
+  count: number;
+  per: number;   // 発動確率 %
+  value: number; // 持続秒
+}
+
+export interface ShrinkTimelineParams {
+  /** 1 枚目のパラメータ（後方互換: 単体カード用） */
+  count: number;
+  per: number;
+  value: number;
+  /** マルチカード時はこちらを優先（未指定なら count/per/value で 1 枚構成） */
+  cards?: ShrinkCardParam[];
+  notesCount: number;
+  songDuration: number;
+  excludeHead?: number;
+  activations?: Activation[];
+}
+
+/** 発動の抽選を決定論的に行う (seed 固定、縮小スキル 1 枚版) */
+export function simulateActivationsDeterministic(p: {
+  count: number; per: number; value: number;
+  notesCount: number; songDuration: number;
+  excludeHead: number; seed: number;
+}): Activation[] {
+  const rng = new XorShift128Plus(p.seed);
+  const acts: Activation[] = [];
+  const eligibleCount = Math.max(0, p.notesCount - p.excludeHead);
+  const maxActivations = Math.floor(eligibleCount / p.count);
+  const valueInNotes = Math.floor((p.value / p.songDuration) * p.notesCount);
+  for (let k = 1; k <= maxActivations; k++) {
+    const start = p.excludeHead + k * p.count;
+    const end = Math.min(start + valueInNotes, p.notesCount);
+    const fired = rng.next() * 100 < p.per;
+    acts.push({ start, end, fired, cardIndex: 0 });
+  }
+  return acts;
+}
+
+/**
+ * 複数枚の縮小スキルをキューイング仕様に従ってシミュレートする。
+ * docs/shrink-skill-spec.md §1-1 に準拠:
+ *  - 同時刻には重複発動しない
+ *  - 発動中に他スキルのトリガーが来たら、先行スキル終了後に連続発動する
+ *  - 曲全体を超えた分はキューから切り捨て
+ */
+export function simulateActivationsMulti(p: {
+  cards: ShrinkCardParam[];
+  notesCount: number;
+  songDuration: number;
+  excludeHead: number;
+  seed: number;
+}): Activation[] {
+  if (p.cards.length === 0) return [];
+
+  // Phase 1: 各カードのトリガーを生成（発動位置・発動可否・value_in_notes）
+  type Trigger = {
+    cardIndex: number;
+    noteIndex: number;   // トリガーが発火するノート位置
+    fired: boolean;
+    valueInNotes: number;
+  };
+  const rng = new XorShift128Plus(p.seed);
+  const eligibleCount = Math.max(0, p.notesCount - p.excludeHead);
+  const triggers: Trigger[] = [];
+  for (let i = 0; i < p.cards.length; i++) {
+    const c = p.cards[i];
+    const maxActivations = Math.floor(eligibleCount / c.count);
+    const valueInNotes = Math.floor((c.value / p.songDuration) * p.notesCount);
+    for (let k = 1; k <= maxActivations; k++) {
+      const noteIndex = p.excludeHead + k * c.count;
+      const fired = rng.next() * 100 < c.per;
+      triggers.push({ cardIndex: i, noteIndex, fired, valueInNotes });
+    }
+  }
+
+  // Phase 2: トリガーを時系列（noteIndex 昇順 → 同時なら cardIndex 昇順）に並べる
+  triggers.sort((a, b) => a.noteIndex - b.noteIndex || a.cardIndex - b.cardIndex);
+
+  // Phase 3: キューイングで発動区間を決定
+  const acts: Activation[] = [];
+  let currentEnd = 0; // 現在発動中スキルの end（ノート index）
+  for (const t of triggers) {
+    if (!t.fired) {
+      // 不発はタイムライン表示のため情報を残す（fired=false）
+      acts.push({ start: t.noteIndex, end: t.noteIndex, fired: false, cardIndex: t.cardIndex });
+      continue;
+    }
+    // 発動中なら、その終了時刻まで待機してから開始（キューイング）
+    const start = Math.max(t.noteIndex, currentEnd);
+    if (start >= p.notesCount) {
+      // キューから溢れて曲が終了した → 切り捨て
+      continue;
+    }
+    const end = Math.min(start + t.valueInNotes, p.notesCount);
+    acts.push({ start, end, fired: true, cardIndex: t.cardIndex });
+    currentEnd = end;
+  }
+  return acts;
+}
+
+/** カード別の塗り色（1 枚目は既存の shrink 色、以降は濃度違いのオレンジ系） */
+export const CARD_COLORS = ['#f59e0b', '#f97316', '#ea580c', '#c2410c', '#9a3412'] as const;
+
+export function shrinkTimelineSvg(p: ShrinkTimelineParams): string {
+  const cards: ShrinkCardParam[] = p.cards ?? [{ count: p.count, per: p.per, value: p.value }];
+  const numCards = cards.length;
+
+  // カード数が増えるとタイムラインの縦幅も増やす（コインレーン + サマリー行）
+  const coinLaneH = 18;
+  const barH = 26;
+  const W = 820;
+  const M = { top: 24, right: 20, bottom: 40, left: 20 };
+  const innerH = coinLaneH * numCards + barH + 10;
+  const H = M.top + innerH + M.bottom;
+  const innerW = W - M.left - M.right;
+  const excludeHead = p.excludeHead ?? 0;
+  const activations = p.activations ?? [];
+
+  const xScale = (noteIdx: number) => M.left + (noteIdx / p.notesCount) * innerW;
+
+  // 先頭除外領域
+  const excludeX1 = xScale(0);
+  const excludeX2 = xScale(excludeHead);
+  const excludeRect = excludeHead > 0
+    ? `<rect x="${excludeX1}" y="${M.top}" width="${excludeX2 - excludeX1}" height="${innerH}"
+              fill="${COLOR.exclude}" opacity="0.6"/>
+       <text x="${(excludeX1 + excludeX2) / 2}" y="${M.top + 12}" text-anchor="middle"
+             fill="${COLOR.muted}" font-size="10">先頭除外 ${excludeHead}ノート</text>`
+    : '';
+
+  // 発動判定コイン（カードごとに別レーンに配置）
+  const coins: string[] = [];
+  const gridLines: string[] = [];
+  for (const a of activations) {
+    const ci = a.cardIndex ?? 0;
+    const x = xScale(a.start);
+    const cy = M.top + 10 + ci * coinLaneH;
+    if (a.fired || !a.fired) {
+      // 判定位置を示す縦点線はカード 1 枚目のトリガー位置にのみ引く（視覚的に煩雑にならないよう）
+      if (ci === 0) {
+        gridLines.push(
+          `<line x1="${x}" y1="${M.top}" x2="${x}" y2="${M.top + innerH}" stroke="${COLOR.grid}" stroke-width="1" stroke-dasharray="3 2"/>`
+        );
+      }
+    }
+    coins.push(
+      `<circle cx="${x}" cy="${cy}" r="5"
+               fill="${a.fired ? '#22c55e' : '#9ca3af'}" stroke="white" stroke-width="1.5">
+         <title>カード${ci + 1}: ${a.fired ? '発動' : '不発'} (note=${a.start})</title>
+       </circle>`
+    );
+  }
+
+  // カードレーンのラベル（左端に 1 / 2 / 3 など）
+  const laneLabels = cards.map((_, i) =>
+    `<text x="${M.left - 4}" y="${M.top + 14 + i * coinLaneH}" text-anchor="end"
+           fill="${CARD_COLORS[i]}" font-size="10" font-weight="bold">${i + 1}</text>`
+  ).join('\n');
+
+  // 発動区間（カードごとの色で下段バーに塗る）
+  const barY = M.top + coinLaneH * numCards + 4;
+  const fillBars = activations.filter((a) => a.fired).map((a) => {
+    const ci = a.cardIndex ?? 0;
+    const x1 = xScale(a.start);
+    const x2 = xScale(a.end);
+    return `<rect x="${x1}" y="${barY}" width="${x2 - x1}" height="${barH}"
+                  fill="${CARD_COLORS[ci]}" opacity="0.85">
+              <title>カード${ci + 1}: 発動区間 ${a.start}-${a.end}</title>
+            </rect>`;
+  }).join('\n');
+
+  // 時間目盛 (10秒ごと)
+  const secondsTicks: string[] = [];
+  const tickInterval = 10;
+  for (let s = 0; s <= p.songDuration; s += tickInterval) {
+    const noteIdx = (s / p.songDuration) * p.notesCount;
+    const x = xScale(noteIdx);
+    secondsTicks.push(
+      `<line x1="${x}" y1="${M.top + innerH}" x2="${x}" y2="${M.top + innerH + 4}" stroke="${COLOR.muted}" stroke-width="1"/>
+       <text x="${x}" y="${M.top + innerH + 16}" text-anchor="middle" fill="${COLOR.muted}" font-size="9">${s}s</text>`
+    );
+  }
+
+  // 発動サマリー: カードごとに発動/機会 + カバー時間
+  const firedPerCard = cards.map((_, i) => activations.filter((a) => a.fired && a.cardIndex === i).length);
+  const triggersPerCard = cards.map((_, i) => activations.filter((a) => a.cardIndex === i).length);
+  const coverPerCard = cards.map((c, i) => firedPerCard[i] * c.value);
+  const totalCoverRaw = coverPerCard.reduce((a, b) => a + b, 0);
+  const totalCoverCapped = Math.min(totalCoverRaw, p.songDuration);
+  const coverPct = ((totalCoverCapped / p.songDuration) * 100).toFixed(1);
+  const summary = cards.map((c, i) =>
+    `カード${i + 1} (${c.count}ノーツ/${c.per}%/${c.value}秒): ${firedPerCard[i]}/${triggersPerCard[i]}回 (${coverPerCard[i]}秒)`
+  ).join(' ／ ');
+
+  return `<svg viewBox="0 0 ${W} ${H}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="縮小スキルのタイムライン">
+    <!-- 軸 -->
+    <line x1="${M.left}" y1="${M.top + innerH}" x2="${M.left + innerW}" y2="${M.top + innerH}" stroke="${COLOR.muted}" stroke-width="1"/>
+    ${excludeRect}
+    ${gridLines.join('\n')}
+    ${laneLabels}
+    ${fillBars}
+    ${coins.join('\n')}
+    ${secondsTicks.join('\n')}
+    <text x="${M.left}" y="${H - 6}" fill="${COLOR.text}" font-size="10">
+      ${escapeXml(summary)} ／ 合計カバー ${totalCoverCapped}秒 (${coverPct}%)
+    </text>
+  </svg>`;
+}
+
+/* ================================================================
+ * (C) 先頭除外ロジックの図
+ * ================================================================ */
+export interface ExcludeHeadParams {
+  notes20: number;
+  minCount: number;
+  caseLabel?: string;
+}
+
+export function excludeHeadSvg(p: ExcludeHeadParams): string {
+  const W = 640, H = 180;
+  const M = { top: 30, right: 20, bottom: 30, left: 60 };
+  const innerW = W - M.left - M.right;
+  const maxRange = Math.max(p.notes20, p.minCount) * 1.4 + 5;
+  const xScale = (n: number) => M.left + (n / maxRange) * innerW;
+
+  const result = Math.max(p.notes20, p.minCount);
+  const notes20X = xScale(p.notes20);
+  const minCountX = xScale(p.minCount);
+  const resultX = xScale(result);
+
+  const lineNotes20 = `
+    <line x1="${M.left}" y1="60" x2="${notes20X}" y2="60" stroke="${ATTR_HEX.Melody}" stroke-width="10" stroke-linecap="round"/>
+    <text x="${M.left - 8}" y="64" text-anchor="end" fill="${COLOR.text}" font-size="11" font-weight="bold">notes_20</text>
+    <text x="${notes20X + 6}" y="64" fill="${ATTR_HEX.Melody}" font-size="11" font-weight="bold">${p.notes20}</text>
+  `;
+  const lineMinCount = `
+    <line x1="${M.left}" y1="95" x2="${minCountX}" y2="95" stroke="${COLOR.shrink}" stroke-width="10" stroke-linecap="round"/>
+    <text x="${M.left - 8}" y="99" text-anchor="end" fill="${COLOR.text}" font-size="11" font-weight="bold">minCount</text>
+    <text x="${minCountX + 6}" y="99" fill="${COLOR.shrink}" font-size="11" font-weight="bold">${p.minCount}</text>
+  `;
+  const resultLine = `
+    <line x1="${resultX}" y1="40" x2="${resultX}" y2="135" stroke="${COLOR.mainDark}" stroke-width="2" stroke-dasharray="3 3"/>
+    <text x="${resultX + 6}" y="130" fill="${COLOR.mainDark}" font-size="11" font-weight="bold">
+      excludeHead = max(${p.notes20}, ${p.minCount}) = ${result}
+    </text>
+  `;
+  const caseTitle = p.caseLabel
+    ? `<text x="${M.left - 10}" y="20" fill="${COLOR.text}" font-size="12" font-weight="bold">${escapeXml(p.caseLabel)}</text>`
+    : '';
+
+  // スケール目盛
+  const axis = `
+    <line x1="${M.left}" y1="150" x2="${M.left + innerW}" y2="150" stroke="${COLOR.muted}" stroke-width="1"/>
+    ${Array.from({ length: 6 }, (_, i) => {
+      const n = Math.round((maxRange * i) / 5);
+      const x = xScale(n);
+      return `<line x1="${x}" y1="150" x2="${x}" y2="154" stroke="${COLOR.muted}"/>
+              <text x="${x}" y="166" text-anchor="middle" fill="${COLOR.muted}" font-size="9">${n}</text>`;
+    }).join('')}
+  `;
+
+  return `<svg viewBox="0 0 ${W} ${H}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="先頭除外の計算">
+    ${caseTitle}
+    ${axis}
+    ${lineNotes20}
+    ${lineMinCount}
+    ${resultLine}
+  </svg>`;
+}
+
+/* ================================================================
+ * (D) カバー率の合算と 100% キャップ図
+ * ================================================================ */
+export interface CoverageDiagramParams {
+  songDuration: number;
+  segments: { label: string; seconds: number; color: string }[];
+}
+
+export function coverageDiagramSvg(p: CoverageDiagramParams): string {
+  const W = 760, H = 220;
+  const M = { top: 30, right: 20, bottom: 60, left: 20 };
+  const innerW = W - M.left - M.right;
+  const barH = 40;
+  const totalSec = p.segments.reduce((a, s) => a + s.seconds, 0);
+  const maxRange = Math.max(totalSec, p.songDuration) * 1.05;
+  const xScale = (sec: number) => M.left + (sec / maxRange) * innerW;
+
+  // ベースバー (songDuration = 100% の尺)
+  const baseBar = `
+    <rect x="${M.left}" y="${M.top}" width="${xScale(p.songDuration) - M.left}" height="${barH}"
+          fill="#f3f4f6" stroke="${COLOR.grid}" stroke-width="1"/>
+    <text x="${M.left + 6}" y="${M.top + barH / 2 + 4}"
+          fill="${COLOR.muted}" font-size="10">songDuration = ${p.songDuration}秒 (100%)</text>
+  `;
+
+  // キューイング: セグメントを連結（横方向にシフト）
+  let cursor = 0;
+  const segmentsSvg = p.segments.map((s) => {
+    const x1 = xScale(cursor);
+    const x2Full = xScale(cursor + s.seconds);
+    const cappedEnd = Math.min(cursor + s.seconds, p.songDuration);
+    const x2Cap = xScale(cappedEnd);
+    cursor += s.seconds;
+
+    // 100% 内の塗り（実効）
+    const inPart = x2Cap > x1
+      ? `<rect x="${x1}" y="${M.top}" width="${x2Cap - x1}" height="${barH}"
+              fill="${s.color}" opacity="0.9">
+           <title>${escapeXml(s.label)} (実効部 ${Math.min(s.seconds, p.songDuration - (cursor - s.seconds))}秒)</title>
+         </rect>`
+      : '';
+    // 超過分（100% を越えた部分）
+    const overPart = x2Full > x2Cap
+      ? `<rect x="${x2Cap}" y="${M.top}" width="${x2Full - x2Cap}" height="${barH}"
+              fill="${s.color}" opacity="0.3" stroke="${s.color}" stroke-dasharray="4 2" stroke-width="1.5">
+           <title>${escapeXml(s.label)} (超過部 = 切り捨て)</title>
+         </rect>`
+      : '';
+    return inPart + overPart;
+  }).join('\n');
+
+  // 100% キャップの縦線（ラベルは summary で明示するため、SVG 内は短い注記のみ）
+  const capLabelX = xScale(p.songDuration);
+  const capLine = `
+    <line x1="${capLabelX}" y1="${M.top - 4}" x2="${capLabelX}" y2="${M.top + barH + 6}"
+          stroke="${COLOR.mainDark}" stroke-width="2"/>
+    <text x="${capLabelX - 4}" y="${M.top - 6}" text-anchor="end"
+          fill="${COLOR.mainDark}" font-size="10" font-weight="bold">100%→</text>
+  `;
+
+  // 目盛
+  const secTicks: string[] = [];
+  for (let s = 0; s <= maxRange; s += 20) {
+    const x = xScale(s);
+    secTicks.push(
+      `<line x1="${x}" y1="${M.top + barH}" x2="${x}" y2="${M.top + barH + 4}" stroke="${COLOR.muted}"/>
+       <text x="${x}" y="${M.top + barH + 16}" text-anchor="middle" fill="${COLOR.muted}" font-size="9">${s}s</text>`
+    );
+  }
+
+  // 凡例
+  const legendItems = p.segments.map((s, i) =>
+    `<g transform="translate(${M.left + i * 320}, ${M.top + barH + 32})">
+       <rect width="14" height="10" fill="${s.color}" opacity="0.9"/>
+       <text x="18" y="9" fill="${COLOR.text}" font-size="10">${escapeXml(s.label)} = ${s.seconds}秒</text>
+     </g>`
+  ).join('\n');
+
+  const rawPct = ((totalSec / p.songDuration) * 100).toFixed(1);
+  const cappedPct = Math.min(100, Number(rawPct)).toFixed(1);
+  const summary = `
+    <text x="${W - M.right}" y="18" text-anchor="end" fill="${COLOR.text}" font-size="11">
+      Σ / songDuration = ${totalSec} / ${p.songDuration} = ${rawPct}% → min(_, 100%) = ${cappedPct}%
+    </text>
+  `;
+
+  return `<svg viewBox="0 0 ${W} ${H}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="カバー率の合算と 100% キャップ">
+    ${baseBar}
+    ${segmentsSvg}
+    ${capLine}
+    ${secTicks.join('\n')}
+    ${summary}
+    ${legendItems}
+  </svg>`;
+}
+
+/* ================================================================
+ * (E) 縮小スコア加算式の図解
+ * ================================================================ */
+export function formulaDiagramSvg(): string {
+  const W = 760, H = 240;
+  // 中央大文字の式
+  const formula = `
+    <text x="${W / 2}" y="70" text-anchor="middle" fill="${COLOR.text}"
+          font-size="22" font-family="serif">
+      floor(
+      <tspan fill="${COLOR.main}" font-weight="bold">eligibleBaseScore</tspan>
+       × (
+      <tspan fill="${COLOR.shrinkDark}" font-weight="bold">rate − 1.0</tspan>
+      ) ×
+      <tspan fill="${COLOR.emerald}" font-weight="bold">coverageRate</tspan>
+      )
+    </text>
+  `;
+  // 各項の説明ボックス
+  const boxes = [
+    { x: 30, y: 110, w: 220, h: 100, color: COLOR.main,
+      title: 'eligibleBaseScore', lines: ['先頭除外後のノートの', 'アシスト適用済み素点合計', '(note.group ≠ notes_20 のみ)'] },
+    { x: 270, y: 110, w: 220, h: 100, color: COLOR.shrinkDark,
+      title: 'rate − 1.0', lines: ['縮小倍率 rate から通常分', '1.0 を引いた追加倍率', 'Lv1=0.2 / Lv5=0.6'] },
+    { x: 510, y: 110, w: 220, h: 100, color: COLOR.emerald,
+      title: 'coverageRate', lines: ['min(raw / songDuration, 1.0)', '期待値計算では期待カバー率', '(§4 参照)'] },
+  ];
+  const boxSvg = boxes.map((b) =>
+    `<g>
+      <rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" rx="6" ry="6"
+            fill="white" stroke="${b.color}" stroke-width="2"/>
+      <text x="${b.x + b.w / 2}" y="${b.y + 24}" text-anchor="middle"
+            fill="${b.color}" font-size="14" font-weight="bold">${b.title}</text>
+      ${b.lines.map((l, i) =>
+        `<text x="${b.x + b.w / 2}" y="${b.y + 46 + i * 16}" text-anchor="middle"
+               fill="${COLOR.text}" font-size="11">${escapeXml(l)}</text>`
+      ).join('')}
+    </g>`
+  ).join('\n');
+
+  // 下線カラー
+  const underlines = boxes.map((b, i) => {
+    const cx = 30 + 240 * i + b.w / 2;
+    return `<line x1="${cx - 60}" y1="86" x2="${cx + 60}" y2="86" stroke="${b.color}" stroke-width="3"/>`;
+  }).join('\n');
+
+  return `<svg viewBox="0 0 ${W} ${H}" class="w-full h-auto" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="縮小スコア加算式">
+    <text x="${W / 2}" y="28" text-anchor="middle" fill="${COLOR.muted}" font-size="11">
+      縮小スキルによるスコア追加分（§5）
+    </text>
+    ${formula}
+    ${underlines}
+    ${boxSvg}
+  </svg>`;
+}
+
+/* ================================================================
+ * (F) モンテカルロ分布のイメージ
+ * ================================================================ */
+export interface McDistributionParams {
+  baseScore: number;
+  seed: number;
+  iterations: number;
+}
+
+/**
+ * 縮小スキル 1 枚構成の疑似スコア分布を生成する。
+ * 発動回数が二項分布 Binomial(maxActivations, per) に従うと仮定し、
+ * 1 回発動あたりの加算量を固定値として単純加算する。
+ * デモ用途のため、実エンジンの MC とは別の簡易モデル。
+ */
+export function generateDemoScores(params: {
+  baseScore: number;
+  maxActivations: number;
+  per: number;
+  addPerActivation: number;
+  seed: number;
+  n: number;
+}): number[] {
+  const rng = new XorShift128Plus(params.seed);
+  const scores: number[] = [];
+  const p = params.per / 100;
+  for (let t = 0; t < params.n; t++) {
+    let fired = 0;
+    for (let k = 0; k < params.maxActivations; k++) {
+      if (rng.next() < p) fired++;
+    }
+    scores.push(params.baseScore + fired * params.addPerActivation);
+  }
+  return scores;
+}
+
+export function mcDistributionSvg(p: McDistributionParams): string {
+  // 典型例: Card 1952 (count=20, per=40%, value=4, rate=1.6) × MONSTER GENERATiON
+  const scores = generateDemoScores({
+    baseScore: p.baseScore,
+    maxActivations: 20,
+    per: 40,
+    addPerActivation: 3500, // 1 回発動あたりの平均加算量 (1 秒あたり縮小加算 × value秒)
+    seed: p.seed,
+    n: p.iterations,
+  });
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+  return renderHistogramSvg(scores, min, max, mean, {
+    xAxisLabel: 'スコア (デモ分布)',
+    barColor: COLOR.shrink,
+  });
+}

--- a/src/lib/score/specDiagrams.ts
+++ b/src/lib/score/specDiagrams.ts
@@ -182,7 +182,6 @@ export function simulateActivationsDeterministic(p: {
 
 /**
  * 複数枚の縮小スキルをキューイング仕様に従ってシミュレートする。
- * docs/shrink-skill-spec.md §1-1 に準拠:
  *  - 同時刻には重複発動しない
  *  - 発動中に他スキルのトリガーが来たら、先行スキル終了後に連続発動する
  *  - 曲全体を超えた分はキューから切り捨て

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -28,7 +28,10 @@ const base = import.meta.env.BASE_URL;
 ---
 
 <BaseLayout title="スコア計算">
-  <h1 class="text-2xl font-bold mb-4">スコア計算</h1>
+  <div class="flex items-baseline gap-3 mb-4 flex-wrap">
+    <h1 class="text-2xl font-bold">スコア計算</h1>
+    <a href={`${base}score-calc/spec/`} class="text-sm text-indigo-600 hover:underline">仕様について →</a>
+  </div>
 
   <ScoreCalc
     cards={allCards}

--- a/src/pages/score-calc/spec.astro
+++ b/src/pages/score-calc/spec.astro
@@ -1,0 +1,212 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import ShrinkPlayground from '../../components/score/ShrinkPlayground.svelte';
+import {
+  overviewFlowSvg,
+  shrinkTimelineSvg,
+  excludeHeadSvg,
+  coverageDiagramSvg,
+  formulaDiagramSvg,
+  mcDistributionSvg,
+  simulateActivationsDeterministic,
+} from '../../lib/score/specDiagrams.ts';
+
+const base = import.meta.env.BASE_URL;
+
+// §2 静的タイムライン用のデモパラメータ（MONSTER GENERATiON + Card 1952 Lv5）
+const DEMO_NOTES = 428;
+const DEMO_DURATION = 104;
+const DEMO_EXCLUDE = 21;
+const demoActivations = simulateActivationsDeterministic({
+  count: 20, per: 40, value: 4,
+  notesCount: DEMO_NOTES, songDuration: DEMO_DURATION, excludeHead: DEMO_EXCLUDE,
+  seed: 7,
+});
+const timelineSvg = shrinkTimelineSvg({
+  count: 20, per: 40, value: 4,
+  notesCount: DEMO_NOTES, songDuration: DEMO_DURATION,
+  excludeHead: DEMO_EXCLUDE, activations: demoActivations,
+});
+
+// §3 先頭除外: 2ケース比較
+const excludeCaseA = excludeHeadSvg({ notes20: 21, minCount: 20, caseLabel: 'ケース A: notes_20 > minCount' });
+const excludeCaseB = excludeHeadSvg({ notes20: 20, minCount: 22, caseLabel: 'ケース B: notes_20 < minCount' });
+
+// §4 カバー率
+const coverageSvg = coverageDiagramSvg({
+  songDuration: 104,
+  segments: [
+    { label: 'Card 1952 (20ノート毎×4秒, 20回)', seconds: 80, color: '#f59e0b' },
+    { label: 'Card 3597 (23ノート毎×5秒, 17回)', seconds: 85, color: '#f97316' },
+  ],
+});
+
+// §5 スコア加算式
+const formulaSvg = formulaDiagramSvg();
+
+// §6 MC 分布デモ
+const mcSvg = mcDistributionSvg({ baseScore: 293120, seed: 42, iterations: 1000 });
+---
+
+<BaseLayout title="スコア計算 仕様解説">
+  <div class="flex items-baseline gap-3 mb-2 flex-wrap">
+    <h1 class="text-2xl font-bold">スコア計算 仕様解説</h1>
+    <a href={`${base}score-calc/`} class="text-sm text-indigo-600 hover:underline">← 計算ページへ戻る</a>
+  </div>
+  <p class="text-xs text-gray-500 mb-6">
+    本ページはスコア計算、特に<strong class="text-gray-700">判定縮小スキル</strong>の内部ロジックを
+    図で解説するものです。数値例は楽曲「MONSTER GENERATiON」(428ノート / 104秒) を基に記述しています。
+    厳密仕様は
+    <a href="https://github.com/yo4raw/i7/blob/main/docs/score_calc_spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">score_calc_spec.md</a>
+    ・
+    <a href="https://github.com/yo4raw/i7/blob/main/docs/shrink-skill-spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">shrink-skill-spec.md</a>
+    を参照してください。
+  </p>
+
+  <nav class="bg-white rounded-lg shadow p-4 mb-6 text-sm">
+    <h2 class="text-sm font-bold text-indigo-700 mb-2">目次</h2>
+    <ol class="list-decimal pl-6 space-y-0.5 text-gray-700">
+      <li><a href="#overview" class="hover:underline text-indigo-600">スコア計算の全体像</a></li>
+      <li><a href="#shrink" class="hover:underline text-indigo-600">判定縮小スキルとは</a></li>
+      <li><a href="#exclude" class="hover:underline text-indigo-600">先頭除外ロジック</a></li>
+      <li><a href="#coverage" class="hover:underline text-indigo-600">カバー率の合算と 100% キャップ</a></li>
+      <li><a href="#formula" class="hover:underline text-indigo-600">縮小スコア加算式</a></li>
+      <li><a href="#montecarlo" class="hover:underline text-indigo-600">モンテカルロ分布のイメージ</a></li>
+    </ol>
+  </nav>
+
+  <section id="overview" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">1. スコア計算の全体像</h2>
+    <p class="text-sm text-gray-700 mb-4">
+      スコアは大きく分けて <strong>チーム属性値 → 1ノーツ素点 → ライト倍率 → 縮小加算 → バッジ</strong> の順に
+      計算されます。属性値段階でアシスト (×1.2) を適用し、per-note 単位で floor することでゲーム内挙動と揃えます。
+      縮小スキルは経路の一部として「発動中ノーツの追加スコア」を別途加算します。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2">
+      <Fragment set:html={overviewFlowSvg()} />
+    </div>
+  </section>
+
+  <section id="shrink" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">2. 判定縮小スキルとは</h2>
+    <p class="text-sm text-gray-700 mb-2">
+      判定縮小スキルは <strong>ノーツ数</strong>（<code class="px-1 bg-gray-100 rounded">count</code>）ごとに
+      <strong>確率</strong>（<code class="px-1 bg-gray-100 rounded">per</code>）% で発動し、
+      <strong>秒数</strong>（<code class="px-1 bg-gray-100 rounded">value</code>）だけ持続する間、叩いたノーツを
+      <strong>倍率</strong>（<code class="px-1 bg-gray-100 rounded">rate</code>、Lv5 で 1.6）でスコア加算するスキルです。
+    </p>
+    <p class="text-sm text-gray-700 mb-4">
+      下図はパラメータ例 <code class="px-1 bg-gray-100 rounded">ノーツ数=20 / 確率=40% / 秒数=4秒 / 倍率=1.6</code>
+      の発動タイムラインです。縦点線ごとに発動判定が行われ、コインが<span class="text-green-600 font-semibold">緑</span>
+      なら発動（<span class="text-amber-600 font-semibold">橙の塗り</span>で秒数ぶんカバー）、
+      <span class="text-gray-500">灰</span>なら不発を表します。先頭の<span class="text-gray-500 font-semibold">灰色領域</span>は
+      §3 で説明する <strong>先頭除外</strong> です。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2 mb-4">
+      <Fragment set:html={timelineSvg} />
+    </div>
+
+    <h3 class="text-base font-bold text-gray-800 mb-2 mt-6">2-1. インタラクティブに試す</h3>
+    <p class="text-sm text-gray-700 mb-3">
+      <strong>ノーツ数</strong> / <strong>確率</strong> / <strong>秒数</strong> のスライダー、
+      <strong>「＋カード追加」</strong> ボタンで縮小スキル枚数の変更、
+      <strong>「別の試行」</strong> ボタンでシード変更ができます。
+      発動回数・カバー時間がデッキ構成でどう変わるか確認できます（実ゲームと同じ発動判定 + キューイング仕様を疑似的に再現、決定論シード付き）。
+    </p>
+    <ShrinkPlayground client:only="svelte" />
+
+    <div class="mt-4 p-3 bg-amber-50 border border-amber-200 rounded text-xs text-amber-900">
+      <strong>キューイング仕様</strong>：実ゲームでは複数の縮小スキルが同時刻に重複発動することはなく、先行スキルが終わってから後続スキルが連続発動します。そのためカバー時間は時間軸上で<strong>重ならず単純加算</strong>できます（曲全体を超えた分のみ切り捨て → §4 の 100% キャップの根拠）。
+    </div>
+  </section>
+
+  <section id="exclude" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">3. 先頭除外ロジック</h2>
+    <p class="text-sm text-gray-700 mb-4">
+      判定縮小スキルは曲の最初のほうでは効果対象外になります。具体的には
+      <code class="px-1 bg-gray-100 rounded">excludeHead = max(notes_20 のノート数, デッキ内縮小スキルの count の最小値)</code>
+      までのノートが <strong>縮小倍率 rate の適用対象外</strong> です。ライト点灯前の演出区間
+      (<code class="px-1 bg-gray-100 rounded">notes_20</code>) と、最速で発動しうるタイミング
+      (<code class="px-1 bg-gray-100 rounded">minCount</code>) の<strong>大きい方</strong>が採用されます。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2 mb-3">
+      <Fragment set:html={excludeCaseA} />
+    </div>
+    <div class="overflow-x-auto -mx-2 px-2">
+      <Fragment set:html={excludeCaseB} />
+    </div>
+    <ul class="mt-3 text-xs text-gray-600 list-disc pl-5 space-y-0.5">
+      <li>先頭除外は <strong>スコア寄与の計算</strong>（§5 の eligibleBaseScore）にのみ効き、UI 表示の「スキル最大発動回数」は <code class="px-1 bg-gray-100 rounded">notesCount</code> 全体で計算します。</li>
+      <li>縮小スキルが複数枚あるときは <code class="px-1 bg-gray-100 rounded">count</code> が最小のカードが基準になります。</li>
+    </ul>
+  </section>
+
+  <section id="coverage" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">4. カバー率の合算と 100% キャップ</h2>
+    <p class="text-sm text-gray-700 mb-4">
+      各縮小スキルの <strong>最大縮小時間</strong>
+      <code class="px-1 bg-gray-100 rounded">floor(eligibleCount / count) × value</code>
+      を単純加算し、曲尺 (<code class="px-1 bg-gray-100 rounded">songDuration</code>) で割ったものがカバー率です。
+      キューイング仕様より区間は重ならないため単純合算で等価になり、<strong>100% を超えた分は切り捨て</strong>られます。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2">
+      <Fragment set:html={coverageSvg} />
+    </div>
+    <ul class="mt-3 text-xs text-gray-600 list-disc pl-5 space-y-0.5">
+      <li>表示用の raw カバー率は 100% 超の値をそのまま表示（超過分は「計算対象外」と注記）。</li>
+      <li>内部計算用は <code class="px-1 bg-gray-100 rounded">min(raw, 1.0)</code> で 100% キャップ。</li>
+      <li>期待カバー率は <code class="px-1 bg-gray-100 rounded">Σ (numActivations × value × per/100) / songDuration</code> の単純加算版。</li>
+    </ul>
+  </section>
+
+  <section id="formula" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">5. 縮小スコア加算式</h2>
+    <p class="text-sm text-gray-700 mb-4">
+      縮小スキルが曲全体に与える追加スコアは、以下の式で算出されます。
+      <code class="px-1 bg-gray-100 rounded">rate − 1.0</code> は「通常 1.0 倍を超える追加倍率」を意味し、
+      Lv5（rate=1.6）なら 0.6 倍分の加算となります。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2">
+      <Fragment set:html={formulaSvg} />
+    </div>
+    <ul class="mt-3 text-xs text-gray-600 list-disc pl-5 space-y-0.5">
+      <li><strong class="text-indigo-700">eligibleBaseScore</strong>: 先頭除外後のノートのアシスト適用済み素点合計（<code class="px-1 bg-gray-100 rounded">note.group ≠ notes_20</code> のみ対象）。</li>
+      <li><strong class="text-amber-700">rate − 1.0</strong>: Lv1 (1.2) なら 0.2、Lv5 (1.6) なら 0.6。</li>
+      <li><strong class="text-emerald-700">coverageRate</strong>: §4 の内部カバー率（100% キャップ後）。期待値計算では期待カバー率を使用。</li>
+      <li>複数縮小スキルが重なっても倍率は <code class="px-1 bg-gray-100 rounded">rate</code> のまま（重ねがけなし）。</li>
+    </ul>
+  </section>
+
+  <section id="montecarlo" class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">6. モンテカルロ分布のイメージ</h2>
+    <p class="text-sm text-gray-700 mb-4">
+      スコア計算ページでは上記の期待値だけでなく、縮小スキルの確率発動を考慮した
+      <strong>モンテカルロシミュレーション</strong>（既定 100 試行）も実行しています。
+      試行ごとに発動の当たり外れが変わるため、スコアには揺らぎが生じます。
+      以下は縮小スキル 1 枚構成を 1000 試行した疑似分布（シード固定）です。赤線は平均値、左右の広がりは確率発動による揺らぎを示します。
+    </p>
+    <div class="overflow-x-auto -mx-2 px-2">
+      <Fragment set:html={mcSvg} />
+    </div>
+    <ul class="mt-3 text-xs text-gray-600 list-disc pl-5 space-y-0.5">
+      <li>最小スコア = 縮小が一度も発動しないケース（§5 の coverageRate=0）。</li>
+      <li>最大スコア ≒ 全発動ケース（表示 raw カバー率が 100% 超なら内部は 100% キャップ）。</li>
+      <li>mean / stddev / p90 / mcMin / mcMax を本体ページでは表示しています。</li>
+    </ul>
+  </section>
+
+  <section class="bg-white rounded-lg shadow p-6 mb-6">
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">参考資料</h2>
+    <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
+      <li>
+        <a href="https://github.com/yo4raw/i7/blob/main/docs/score_calc_spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">docs/score_calc_spec.md</a> — スコア計算全体の仕様（属性値・ノート展開・アシスト・バッジ）
+      </li>
+      <li>
+        <a href="https://github.com/yo4raw/i7/blob/main/docs/shrink-skill-spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">docs/shrink-skill-spec.md</a> — 縮小スキルの詳細仕様（先頭除外・カバー率・期待値・MC）
+      </li>
+      <li>
+        <a href={`${base}score-calc/`} class="text-indigo-600 hover:underline">スコア計算ページに戻る</a>
+      </li>
+    </ul>
+  </section>
+</BaseLayout>

--- a/src/pages/score-calc/spec.astro
+++ b/src/pages/score-calc/spec.astro
@@ -56,11 +56,7 @@ const mcSvg = mcDistributionSvg({ baseScore: 293120, seed: 42, iterations: 1000 
   <p class="text-xs text-gray-500 mb-6">
     本ページはスコア計算、特に<strong class="text-gray-700">判定縮小スキル</strong>の内部ロジックを
     図で解説するものです。数値例は楽曲「MONSTER GENERATiON」(428ノート / 104秒) を基に記述しています。
-    厳密仕様は
-    <a href="https://github.com/yo4raw/i7/blob/main/docs/score_calc_spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">score_calc_spec.md</a>
-    ・
-    <a href="https://github.com/yo4raw/i7/blob/main/docs/shrink-skill-spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">shrink-skill-spec.md</a>
-    を参照してください。
+    有志による計測・推定値を含むため、ゲーム内の挙動と完全に一致することを保証するものではありません。
   </p>
 
   <nav class="bg-white rounded-lg shadow p-4 mb-6 text-sm">
@@ -196,14 +192,8 @@ const mcSvg = mcDistributionSvg({ baseScore: 293120, seed: 42, iterations: 1000 
   </section>
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">
-    <h2 class="text-lg font-bold text-indigo-700 mb-3">参考資料</h2>
+    <h2 class="text-lg font-bold text-indigo-700 mb-3">関連ページ</h2>
     <ul class="list-disc pl-5 space-y-1 text-sm text-gray-700">
-      <li>
-        <a href="https://github.com/yo4raw/i7/blob/main/docs/score_calc_spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">docs/score_calc_spec.md</a> — スコア計算全体の仕様（属性値・ノート展開・アシスト・バッジ）
-      </li>
-      <li>
-        <a href="https://github.com/yo4raw/i7/blob/main/docs/shrink-skill-spec.md" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">docs/shrink-skill-spec.md</a> — 縮小スキルの詳細仕様（先頭除外・カバー率・期待値・MC）
-      </li>
       <li>
         <a href={`${base}score-calc/`} class="text-indigo-600 hover:underline">スコア計算ページに戻る</a>
       </li>

--- a/tests/score-calc-spec.test.ts
+++ b/tests/score-calc-spec.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
+
+const BASE = '';
+
+test.describe('スコア計算 仕様解説ページ', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${BASE}/score-calc/spec/`);
+  });
+
+  test('タイトルが正しい', async ({ page }) => {
+    await expect(page).toHaveTitle(new RegExp(`スコア計算 仕様解説.*${SITE_NAME}`));
+  });
+
+  test('6 つの章の見出しがすべて表示される', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /1\. スコア計算の全体像/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /2\. 判定縮小スキルとは/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /3\. 先頭除外ロジック/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /4\. カバー率の合算と 100% キャップ/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /5\. 縮小スコア加算式/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /6\. モンテカルロ分布のイメージ/ })).toBeVisible();
+  });
+
+  test('6 枚以上の SVG が描画される（A〜F + ヘッダーの Playground + ハンバーガーアイコン）', async ({ page }) => {
+    const count = await page.locator('svg').count();
+    expect(count).toBeGreaterThanOrEqual(6);
+  });
+
+  test('ShrinkPlayground のスライダー操作で発動情報が更新される', async ({ page }) => {
+    // ページ表示直後は count=20, per=40, value=4, seed=7 → 発動 9/20 回
+    const summary = page.locator('text=/発動: .*\\/.*/');
+    await expect(summary.first()).toBeVisible();
+
+    // 「別の試行」ボタンで seed が変わる
+    const button = page.getByRole('button', { name: /別の試行/ });
+    const before = await button.textContent();
+    await button.click();
+    const after = await button.textContent();
+    expect(after).not.toBe(before);
+  });
+
+  test('「計算ページへ戻る」リンクで /score-calc/ に遷移できる', async ({ page }) => {
+    await page.getByRole('link', { name: /計算ページへ戻る/ }).first().click();
+    await expect(page).toHaveURL(new RegExp(`${BASE}/score-calc/$`));
+  });
+});
+
+test.describe('スコア計算ページ → 仕様解説ページへの導線', () => {
+  test('h1 の横に「仕様について →」リンクがあり spec ページに遷移する', async ({ page }) => {
+    await page.goto(`${BASE}/score-calc/`);
+    const link = page.getByRole('link', { name: /仕様について/ });
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(new RegExp(`${BASE}/score-calc/spec/$`));
+    await expect(page.getByRole('heading', { name: /スコア計算 仕様解説/ })).toBeVisible();
+  });
+});

--- a/tests/unit/score/specDiagrams.test.ts
+++ b/tests/unit/score/specDiagrams.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  overviewFlowSvg,
+  shrinkTimelineSvg,
+  excludeHeadSvg,
+  coverageDiagramSvg,
+  formulaDiagramSvg,
+  mcDistributionSvg,
+  generateDemoScores,
+  simulateActivationsDeterministic,
+  simulateActivationsMulti,
+} from '../../../src/lib/score/specDiagrams';
+
+function isValidSvg(s: string): boolean {
+  return /^<svg[\s\S]*<\/svg>\s*$/.test(s.trim());
+}
+
+describe('specDiagrams', () => {
+  describe('overviewFlowSvg', () => {
+    it('有効な SVG 文字列を返す', () => {
+      const svg = overviewFlowSvg();
+      expect(isValidSvg(svg)).toBe(true);
+    });
+    it('主要ステップのタイトルを含む', () => {
+      const svg = overviewFlowSvg();
+      expect(svg).toContain('チーム属性値');
+      expect(svg).toContain('アシスト適用');
+      expect(svg).toContain('1ノーツ素点');
+      expect(svg).toContain('ライト倍率');
+      expect(svg).toContain('縮小加算');
+      expect(svg).toContain('バッジ倍率適用');
+      expect(svg).toContain('最終スコア');
+    });
+    it('矢印マーカーを定義する', () => {
+      const svg = overviewFlowSvg();
+      expect(svg).toContain('<marker id="arrow"');
+      expect(svg).toContain('<marker id="arrow-shrink"');
+    });
+  });
+
+  describe('shrinkTimelineSvg', () => {
+    it('有効な SVG を返し、発動情報をラベルに含む', () => {
+      const acts = simulateActivationsDeterministic({
+        count: 20, per: 40, value: 4,
+        notesCount: 428, songDuration: 104, excludeHead: 21, seed: 7,
+      });
+      const svg = shrinkTimelineSvg({
+        count: 20, per: 40, value: 4,
+        notesCount: 428, songDuration: 104, excludeHead: 21, activations: acts,
+      });
+      expect(isValidSvg(svg)).toBe(true);
+      expect(svg).toContain('カード1 (20ノーツ/40%/4秒)');
+      expect(svg).toContain('先頭除外 21ノート');
+    });
+    it('先頭除外が 0 のときは除外矩形を描画しない', () => {
+      const svg = shrinkTimelineSvg({
+        count: 20, per: 40, value: 4,
+        notesCount: 400, songDuration: 100, excludeHead: 0, activations: [],
+      });
+      expect(svg).not.toContain('先頭除外');
+    });
+  });
+
+  describe('simulateActivationsDeterministic', () => {
+    it('同じ seed で同じ結果を返す（決定論）', () => {
+      const args = { count: 20, per: 40, value: 4, notesCount: 428, songDuration: 104, excludeHead: 21, seed: 42 };
+      const a = simulateActivationsDeterministic(args);
+      const b = simulateActivationsDeterministic(args);
+      expect(a).toEqual(b);
+    });
+    it('maxActivations = floor((notesCount - excludeHead) / count) になる', () => {
+      const acts = simulateActivationsDeterministic({
+        count: 20, per: 40, value: 4,
+        notesCount: 428, songDuration: 104, excludeHead: 21, seed: 7,
+      });
+      expect(acts.length).toBe(Math.floor((428 - 21) / 20)); // = 20
+    });
+  });
+
+  describe('excludeHeadSvg', () => {
+    it('notes_20 > minCount ケースで max = notes_20', () => {
+      const svg = excludeHeadSvg({ notes20: 21, minCount: 20 });
+      expect(isValidSvg(svg)).toBe(true);
+      expect(svg).toContain('max(21, 20) = 21');
+    });
+    it('notes_20 < minCount ケースで max = minCount', () => {
+      const svg = excludeHeadSvg({ notes20: 20, minCount: 22 });
+      expect(svg).toContain('max(20, 22) = 22');
+    });
+    it('caseLabel を受け取って表示する', () => {
+      const svg = excludeHeadSvg({ notes20: 20, minCount: 22, caseLabel: 'ケース B' });
+      expect(svg).toContain('ケース B');
+    });
+  });
+
+  describe('coverageDiagramSvg', () => {
+    it('100% 超過時に破線スタイルのセグメントを出力する', () => {
+      const svg = coverageDiagramSvg({
+        songDuration: 104,
+        segments: [
+          { label: 'A', seconds: 80, color: '#f59e0b' },
+          { label: 'B', seconds: 85, color: '#f97316' },
+        ],
+      });
+      expect(isValidSvg(svg)).toBe(true);
+      expect(svg).toContain('stroke-dasharray'); // 超過部分の破線
+      expect(svg).toContain('158.7%');           // raw カバー率
+      expect(svg).toContain('100.0%');           // キャップ後
+    });
+    it('合計が songDuration 以下なら超過破線は描画されない', () => {
+      const svg = coverageDiagramSvg({
+        songDuration: 104,
+        segments: [{ label: 'A', seconds: 80, color: '#f59e0b' }],
+      });
+      // 100% 超過の破線 rect は出ない（ただし stroke-dasharray は他の用途で出るかもしれないので、
+      // "opacity=\"0.3\"" の超過塗りが出ないことを確認する）
+      expect(svg).not.toContain('opacity="0.3"');
+    });
+  });
+
+  describe('formulaDiagramSvg', () => {
+    it('有効な SVG を返し、3 項すべてのラベルを含む', () => {
+      const svg = formulaDiagramSvg();
+      expect(isValidSvg(svg)).toBe(true);
+      expect(svg).toContain('eligibleBaseScore');
+      expect(svg).toContain('rate − 1.0');
+      expect(svg).toContain('coverageRate');
+      expect(svg).toContain('floor(');
+    });
+  });
+
+  describe('generateDemoScores', () => {
+    it('決定論的（同じ seed で同じ先頭要素）', () => {
+      const params = { baseScore: 100000, maxActivations: 20, per: 40, addPerActivation: 1000, seed: 42, n: 10 };
+      const a = generateDemoScores(params);
+      const b = generateDemoScores(params);
+      expect(a).toEqual(b);
+    });
+    it('指定した件数を返す', () => {
+      const scores = generateDemoScores({
+        baseScore: 0, maxActivations: 20, per: 40, addPerActivation: 100, seed: 1, n: 500,
+      });
+      expect(scores.length).toBe(500);
+    });
+    it('スコアは baseScore 以上 baseScore + maxActivations*addPerActivation 以下', () => {
+      const scores = generateDemoScores({
+        baseScore: 100, maxActivations: 10, per: 50, addPerActivation: 50, seed: 7, n: 100,
+      });
+      for (const s of scores) {
+        expect(s).toBeGreaterThanOrEqual(100);
+        expect(s).toBeLessThanOrEqual(100 + 10 * 50);
+      }
+    });
+  });
+
+  describe('mcDistributionSvg', () => {
+    it('有効な SVG を返す', () => {
+      const svg = mcDistributionSvg({ baseScore: 293120, seed: 42, iterations: 1000 });
+      expect(isValidSvg(svg)).toBe(true);
+    });
+  });
+
+  describe('simulateActivationsMulti', () => {
+    const common = { notesCount: 428, songDuration: 104, excludeHead: 21, seed: 7 };
+
+    it('空カードなら空配列を返す', () => {
+      const acts = simulateActivationsMulti({ cards: [], ...common });
+      expect(acts).toEqual([]);
+    });
+
+    it('同じ seed で決定論的', () => {
+      const cards = [{ count: 20, per: 40, value: 4 }, { count: 23, per: 39, value: 5 }];
+      const a = simulateActivationsMulti({ cards, ...common });
+      const b = simulateActivationsMulti({ cards, ...common });
+      expect(a).toEqual(b);
+    });
+
+    it('各カードのトリガー数 = floor(eligibleCount / count)（不発含む）', () => {
+      const cards = [{ count: 20, per: 100, value: 4 }, { count: 23, per: 100, value: 5 }];
+      const acts = simulateActivationsMulti({ cards, ...common });
+      const card0Triggers = acts.filter((a) => a.cardIndex === 0);
+      const card1Triggers = acts.filter((a) => a.cardIndex === 1);
+      // per=100 なのですべて fired、切り捨てを除いた発動数を確認
+      const eligible = 428 - 21; // 407
+      // キューイングで曲全体を超えた分は切り捨てられるので、trigger 数 = floor(eligible/count)
+      // ただし Phase1 では fired=true のみがキューイング対象 (不発は即座に追加)
+      expect(card0Triggers.length).toBeLessThanOrEqual(Math.floor(eligible / 20));
+      expect(card1Triggers.length).toBeLessThanOrEqual(Math.floor(eligible / 23));
+    });
+
+    it('キューイング仕様: 発動区間が時間軸上で重ならない', () => {
+      // per=100 で必ず発動させ、重なるはずのパラメータでもキューイングで重なりがないことを確認
+      const cards = [
+        { count: 10, per: 100, value: 10 },  // 長い持続、頻繁に発動
+        { count: 11, per: 100, value: 10 },
+      ];
+      const acts = simulateActivationsMulti({
+        cards, notesCount: 400, songDuration: 100, excludeHead: 0, seed: 1,
+      });
+      const fired = acts.filter((a) => a.fired).sort((a, b) => a.start - b.start);
+      for (let i = 1; i < fired.length; i++) {
+        // 時間軸上で重ならない: 前の end ≤ 次の start
+        expect(fired[i - 1].end).toBeLessThanOrEqual(fired[i].start);
+      }
+    });
+
+    it('曲全体を超えたキューはあふれて切り捨てられる', () => {
+      // notesCount 超過するまで大量発動させると、あふれて追加されなくなる
+      const cards = [{ count: 5, per: 100, value: 20 }]; // 5ノーツ毎、20秒持続
+      const acts = simulateActivationsMulti({
+        cards, notesCount: 100, songDuration: 50, excludeHead: 0, seed: 1,
+      });
+      const firedActs = acts.filter((a) => a.fired);
+      for (const a of firedActs) {
+        expect(a.end).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it('shrinkTimelineSvg がマルチカード対応で各カードのラベルを含む', () => {
+      const cards = [
+        { count: 20, per: 40, value: 4 },
+        { count: 23, per: 39, value: 5 },
+      ];
+      const acts = simulateActivationsMulti({ cards, ...common });
+      const svg = shrinkTimelineSvg({
+        count: cards[0].count, per: cards[0].per, value: cards[0].value,
+        cards,
+        notesCount: 428, songDuration: 104, excludeHead: 21, activations: acts,
+      });
+      expect(isValidSvg(svg)).toBe(true);
+      expect(svg).toContain('カード1 (20ノーツ/40%/4秒)');
+      expect(svg).toContain('カード2 (23ノーツ/39%/5秒)');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

スコア計算ページに「仕様について →」リンクを追加し、`/score-calc/spec/` にスコア計算の内部ロジック（特に**判定縮小スキル**）を SVG で視覚化する新規ページを追加します。

- 全体フロー / 発動タイムライン / 先頭除外 / カバー率 100% キャップ / 加算式 / MC 分布 の 6 図で仕様を解説
- §2 のタイムラインは **縮小スキル 1〜4 枚構成**をインタラクティブに試せる Playground（Svelte 5 Runes）として実装
- 複数スキル区間はキューイング仕様（同時刻に重複発動しない / 先行終了後に連続発動）に沿って重ならないように描画
- UI ラベルは日本語（ノーツ数・確率・秒数・倍率）に統一、原パラメータ名 `count / per / value / rate` を括弧書きで併記

## 主な変更

| ファイル | 種別 | 役割 |
|---|---|---|
| `src/pages/score-calc/spec.astro` | 新規 | 解説ページ本体（6 章構成） |
| `src/lib/score/specDiagrams.ts` | 新規 | SVG 生成ヘルパー 6 種 + `simulateActivationsMulti`（キューイング仕様準拠） |
| `src/components/score/ShrinkPlayground.svelte` | 新規 | マルチカード対応インタラクティブ版タイムライン |
| `src/pages/score-calc/index.astro` | 更新 | h1 横に「仕様について →」リンク追加 |
| `tests/unit/score/specDiagrams.test.ts` | 新規 | 単体テスト 23 件（既存全 106 件 pass） |
| `tests/score-calc-spec.test.ts` | 新規 | Playwright による導線スモークテスト |
| `playwright.config.ts` | 更新 | webServer.timeout を本番ビルド実測時間（5.5 分）に合わせ 7 分へ延長 |

## Test plan

- [x] `npm run typecheck` — 0 errors / 0 warnings
- [x] `npm run test:unit` — 106 / 106 passed（specDiagrams 23 件を含む）
- [x] `npm run dev` + Chrome DevTools で `/score-calc/spec/` をモバイル (375px) / デスクトップ (1280px) 幅で視認確認
- [x] §1 フロー図で「ライト倍率 → 縮小加算」が橙矢印で描画され、3 経路（ノーツ本体・縮小加算・スコアアップ加算）が合計 total に合流してからバッジ倍率が適用されることを確認
- [x] §2 ShrinkPlayground で 1〜4 枚構成切り替え、スライダー、シード変更の連動を確認
- [ ] `npm run test` — 本 PR では既存 E2E の `BASE = '/i7'` 設定が preview のパス (`/`) と不整合のため、追加した spec 側 E2E は `BASE = ''` に統一。他既存 E2E の動作は別途要確認