### PR TITLE
feat(seo): 楽曲・カード詳細ページに OGP / Twitter Card を追加

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,10 +6,19 @@ import HeaderNav from '../components/HeaderNav.svelte';
 
 interface Props {
   title: string;
+  description?: string;
+  image?: string;
+  ogType?: 'website' | 'article';
 }
 
-const { title } = Astro.props;
+const { title, description, image, ogType = 'website' } = Astro.props;
 const base = import.meta.env.BASE_URL;
+
+const DEFAULT_DESCRIPTION = 'アイドリッシュセブン カードデータベース';
+const desc = description ?? DEFAULT_DESCRIPTION;
+const fullTitle = `${title} | ${SITE_NAME}`;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
+const ogImage = image ? new URL(image, Astro.site).toString() : undefined;
 
 let version = 'dev';
 try {
@@ -24,9 +33,23 @@ try {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="アイドリッシュセブン カードデータベース" />
+    <meta name="description" content={desc} />
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
-    <title>{title} | {SITE_NAME}</title>
+    <link rel="canonical" href={canonicalUrl} />
+    <title>{fullTitle}</title>
+    <!-- OGP -->
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={desc} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:site_name" content={SITE_NAME} />
+    <meta property="og:locale" content="ja_JP" />
+    {ogImage && <meta property="og:image" content={ogImage} />}
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content={ogImage ? 'summary_large_image' : 'summary'} />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={desc} />
+    {ogImage && <meta name="twitter:image" content={ogImage} />}
     <!-- Google Tag Manager -->
     <script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -46,6 +46,9 @@ export async function getStaticPaths() {
 const { card, broachs, relatedEvents } = Astro.props;
 const base = import.meta.env.BASE_URL;
 
+const descParts = [card.rarity, card.attribute, card.name].filter(Boolean).join(' ');
+const ogDescription = card.groupname ? `${descParts}（${card.groupname}）` : descParts;
+
 const infoRows = [
   { label: 'ID', value: card.ID },
   { label: 'カードID', value: card.cardID },
@@ -82,7 +85,12 @@ const otherSkills = [
 ].filter(r => r.value != null && r.value !== '');
 ---
 
-<BaseLayout title={card.cardname || 'カード詳細'}>
+<BaseLayout
+  title={card.cardname || 'カード詳細'}
+  description={ogDescription}
+  image={cardImageUrl(card.ID)}
+  ogType="article"
+>
   <div class="mb-6">
     <a href={`${base}cards/`} class="text-indigo-600 hover:underline text-sm">&larr; カード一覧に戻る</a>
   </div>

--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -16,6 +16,9 @@ export async function getStaticPaths() {
 const { song } = Astro.props;
 const base = import.meta.env.BASE_URL;
 
+const basePart = [song.artist, song.category].filter(Boolean).join(' / ');
+const ogDescription = song.song_type ? `${basePart}（${song.song_type}）` : basePart;
+
 // 属性比率の円グラフ用
 const sr = song.shout_ratio || 0;
 const br = song.beat_ratio || 0;
@@ -39,7 +42,12 @@ const infoRows = [
 ].filter(r => r.value != null && r.value !== '');
 ---
 
-<BaseLayout title={song.song_name || '楽曲詳細'}>
+<BaseLayout
+  title={song.song_name || '楽曲詳細'}
+  description={ogDescription}
+  image={songImageUrl(song.id)}
+  ogType="article"
+>
   <div class="mb-6">
     <a href={`${base}songs/`} class="text-indigo-600 hover:underline text-sm">&larr; 楽曲一覧に戻る</a>
   </div>

--- a/tests/card-detail.test.ts
+++ b/tests/card-detail.test.ts
@@ -38,6 +38,20 @@ test.describe('カード詳細ページ', () => {
     expect(count).toBeGreaterThanOrEqual(2);
   });
 
+  test('OGP / Twitter Card メタタグが出力される', async ({ page }) => {
+    const id = await getFirstCardId(page);
+    await page.goto(`${BASE}/cards/${id}/`);
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'article');
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', /^https:\/\/.+\/cards\/.+/);
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /^https:\/\/.+\/assets\/cards\/.+\.png$/);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', /^https:\/\/.+\/cards\/.+/);
+  });
+
   test('ステータスセクションにドーナツチャートが表示される', async ({ page }) => {
     const id = await getFirstCardId(page);
     await page.goto(`${BASE}/cards/${id}/`);

--- a/tests/song-detail.test.ts
+++ b/tests/song-detail.test.ts
@@ -33,6 +33,20 @@ test.describe('楽曲詳細ページ', () => {
     await expect(page.getByText('アーティスト').first()).toBeVisible();
   });
 
+  test('OGP / Twitter Card メタタグが出力される', async ({ page }) => {
+    const href = await getFirstSongHref(page);
+    await page.goto(href!);
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'article');
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', /^https:\/\/.+\/songs\/.+/);
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute('content', /^https:\/\/.+\/assets\/songs\/.+\.png$/);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', /.+/);
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', /^https:\/\/.+\/songs\/.+/);
+  });
+
   test('属性比率チャートが表示される', async ({ page }) => {
     const href = await getFirstSongHref(page);
     await page.goto(href!);


### PR DESCRIPTION
## Summary
- `BaseLayout.astro` に `description` / `image` / `ogType` の任意 props を追加し、`Astro.site` を基に `og:*` / `twitter:*` / `link[rel=canonical]` を絶対URLで出力
- 楽曲詳細 (`src/pages/songs/[id].astro`) に `song.artist / song.category（song_type）` を description、ジャケット画像を og:image、`ogType="article"` で渡す
- カード詳細 (`src/pages/cards/[id].astro`) に `\${rarity} \${attribute} \${name}（\${groupname}）` を description、カード画像を og:image、`ogType="article"` で渡す
- 他ページは基本 OGP (website / 既存 description) のみで副次的にカバー

## 動作確認

| ページ | og:title | og:image | og:type | twitter:card |
|--------|----------|----------|---------|--------------|
| /songs/48/ | Period Color \| i7マネ部屋(β) | https://i7.yo4raw.com/assets/songs/48.png | article | summary_large_image |
| /cards/1001/ | Marie Mariage \| i7マネ部屋(β) | https://i7.yo4raw.com/assets/cards/1001.png | article | summary_large_image |
| / | ホーム \| i7マネ部屋(β) | (無) | website | summary |

`og:url` / `og:image` は `Astro.site` (`https://i7.yo4raw.com`) で絶対URLに解決されることを `npm run dev` で確認済み。

## Test plan
- [x] `npm run dev` で songs/cards/home の head を curl 検証 (OGP/Twitter/canonical が想定通り出力)
- [x] 画像アセット (`/assets/songs/48.png`, `/assets/cards/1001.png`) が 200 OK
- [ ] Playwright E2E (`song-detail.test.ts` / `card-detail.test.ts` に OGP アサーション追加済み、CI で自動実行)
- [ ] 本番ビルド (`npm run build`) での動的ルート全件生成は CI に委ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)