### PR TITLE
feat(seo): sitemap・robots.txt・JSON-LD・パンくず対応

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import compress from '@playform/compress';
+import sitemap from '@astrojs/sitemap';
 
 import svelte from '@astrojs/svelte';
 
@@ -8,15 +9,36 @@ export default defineConfig({
   site: 'https://i7.yo4raw.com',
   output: 'static',
 
-  integrations: [compress({
-    CSS: true,
-    HTML: true,
-    JavaScript: true,
-    JSON: true,
-    SVG: true,
-    Image: false,
-    Logger: 1,
-  }), svelte()],
+  integrations: [
+    sitemap({
+      serialize(item) {
+        const url = item.url;
+        if (/\/cards\/\d+\/?$/.test(url)) {
+          return { ...item, changefreq: 'monthly', priority: 0.5 };
+        }
+        if (/\/songs\/\d+\/?$/.test(url)) {
+          return { ...item, changefreq: 'weekly', priority: 0.7 };
+        }
+        if (/\/events\/\d+\/?$/.test(url)) {
+          return { ...item, changefreq: 'weekly', priority: 0.8 };
+        }
+        if (url.replace(/\/$/, '').endsWith('yo4raw.com')) {
+          return { ...item, changefreq: 'daily', priority: 1.0 };
+        }
+        return { ...item, changefreq: 'weekly', priority: 0.6 };
+      },
+    }),
+    compress({
+      CSS: true,
+      HTML: true,
+      JavaScript: true,
+      JSON: true,
+      SVG: true,
+      Image: false,
+      Logger: 1,
+    }),
+    svelte(),
+  ],
 
   vite: {
     plugins: [tailwindcss()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "i7-card-database",
       "version": "1.0.0",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.2",
         "@astrojs/svelte": "^8.0.5",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.9",
@@ -146,6 +147,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/svelte": {
@@ -341,6 +353,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -780,6 +793,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -802,6 +816,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -824,6 +839,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -840,6 +856,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -856,6 +873,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -872,6 +890,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -888,6 +907,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -904,6 +924,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -920,6 +941,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -936,6 +958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -952,6 +975,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -968,6 +992,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -984,6 +1009,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1006,6 +1032,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1028,6 +1055,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1050,6 +1078,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1072,6 +1101,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1094,6 +1124,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1116,6 +1147,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1138,6 +1170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1160,6 +1193,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1179,6 +1213,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1198,6 +1233,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1217,6 +1253,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2311,10 +2348,18 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2738,7 +2783,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -7012,6 +7056,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -7076,6 +7154,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -7380,7 +7464,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -7468,7 +7552,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "extract-fixtures": "tsx scripts/extract-test-fixtures.ts"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/svelte": "^8.0.5",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.9",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://i7.yo4raw.com/sitemap-index.xml

--- a/src/components/cards/CardMobileCard.svelte
+++ b/src/components/cards/CardMobileCard.svelte
@@ -54,7 +54,7 @@
 <div class="rounded-lg shadow p-3 hover:shadow-md transition-shadow" style="border-top:3px solid {borderColor}; background: {bg}">
   <div class="flex gap-3 cursor-pointer" onclick={handleRowClick} role="presentation">
     <div class="flex-shrink-0">
-      <img src={thumb} alt="" class="w-12 h-auto rounded" loading="lazy" />
+      <img src={thumb} alt={card.cardname || ''} class="w-12 h-auto rounded" loading="lazy" />
     </div>
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-1 mb-1">

--- a/src/components/seo/JsonLd.astro
+++ b/src/components/seo/JsonLd.astro
@@ -1,0 +1,9 @@
+---
+interface Props {
+  data: Record<string, unknown> | Array<Record<string, unknown>>;
+}
+
+const { data } = Astro.props;
+const json = JSON.stringify(data).replace(/</g, '\\u003c');
+---
+<script type="application/ld+json" set:html={json} is:inline></script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,15 +3,23 @@ import { execSync } from 'node:child_process';
 import '../styles/global.css';
 import { SITE_NAME } from '../lib/constants.ts';
 import HeaderNav from '../components/HeaderNav.svelte';
+import JsonLd from '../components/seo/JsonLd.astro';
+
+interface Breadcrumb {
+  name: string;
+  url: string;
+}
 
 interface Props {
   title: string;
   description?: string;
   image?: string;
   ogType?: 'website' | 'article';
+  jsonLd?: Record<string, unknown> | Array<Record<string, unknown>>;
+  breadcrumbs?: Breadcrumb[];
 }
 
-const { title, description, image, ogType = 'website' } = Astro.props;
+const { title, description, image, ogType = 'website', jsonLd, breadcrumbs } = Astro.props;
 const base = import.meta.env.BASE_URL;
 
 const DEFAULT_DESCRIPTION = 'アイドリッシュセブン カードデータベース';
@@ -19,6 +27,41 @@ const desc = description ?? DEFAULT_DESCRIPTION;
 const fullTitle = `${title} | ${SITE_NAME}`;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 const ogImage = image ? new URL(image, Astro.site).toString() : undefined;
+
+const siteUrl = Astro.site!.toString();
+
+const websiteLd: Record<string, unknown> = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_NAME,
+  url: siteUrl,
+  inLanguage: 'ja',
+  description: DEFAULT_DESCRIPTION,
+};
+
+const organizationLd: Record<string, unknown> = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: SITE_NAME,
+  url: siteUrl,
+};
+
+const breadcrumbLd = breadcrumbs && breadcrumbs.length > 0
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: breadcrumbs.map((b, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: b.name,
+        item: new URL(b.url, Astro.site).toString(),
+      })),
+    }
+  : null;
+
+const extraJsonLd: Array<Record<string, unknown>> = jsonLd
+  ? Array.isArray(jsonLd) ? jsonLd : [jsonLd]
+  : [];
 
 let version = 'dev';
 try {
@@ -50,6 +93,11 @@ try {
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={desc} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
+    <!-- JSON-LD Structured Data -->
+    <JsonLd data={websiteLd} />
+    <JsonLd data={organizationLd} />
+    {breadcrumbLd && <JsonLd data={breadcrumbLd} />}
+    {extraJsonLd.map((d) => <JsonLd data={d} />)}
     <!-- Google Tag Manager -->
     <script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -65,6 +113,22 @@ try {
     <!-- End Google Tag Manager (noscript) -->
     <HeaderNav base={base} client:load />
     <main class="flex-1 max-w-7xl mx-auto px-4 py-6 w-full">
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" class="mb-4">
+          <ol class="flex flex-wrap items-center gap-1.5 text-sm text-gray-500">
+            {breadcrumbs.map((b, i) => (
+              <li class="flex items-center gap-1.5 min-w-0">
+                {i > 0 && <span aria-hidden="true" class="text-gray-300">/</span>}
+                {i === breadcrumbs.length - 1 ? (
+                  <span aria-current="page" class="text-gray-700 truncate">{b.name}</span>
+                ) : (
+                  <a href={b.url} class="hover:text-indigo-600 hover:underline">{b.name}</a>
+                )}
+              </li>
+            ))}
+          </ol>
+        </nav>
+      )}
       <slot />
     </main>
     <footer class="text-xs text-gray-400 py-3 px-4 flex items-center justify-center">

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -49,6 +49,12 @@ const base = import.meta.env.BASE_URL;
 const descParts = [card.rarity, card.attribute, card.name].filter(Boolean).join(' ');
 const ogDescription = card.groupname ? `${descParts}（${card.groupname}）` : descParts;
 
+const breadcrumbs = [
+  { name: 'ホーム', url: base },
+  { name: 'カード一覧', url: `${base}cards/` },
+  { name: card.cardname || `カード ${card.ID}`, url: `${base}cards/${card.ID}/` },
+];
+
 const infoRows = [
   { label: 'ID', value: card.ID },
   { label: 'カードID', value: card.cardID },
@@ -90,10 +96,8 @@ const otherSkills = [
   description={ogDescription}
   image={cardImageUrl(card.ID)}
   ogType="article"
+  breadcrumbs={breadcrumbs}
 >
-  <div class="mb-6">
-    <a href={`${base}cards/`} class="text-indigo-600 hover:underline text-sm">&larr; カード一覧に戻る</a>
-  </div>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
     <div class="md:col-span-1">
       <img src={cardImageUrl(card.ID)} alt={card.cardname || ''}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -39,6 +39,38 @@ interface Props {
 const { event, goldCards, silverCards, bronzeCards } = Astro.props as Props;
 const base = import.meta.env.BASE_URL;
 
+const goldNames = goldCards.map(c => c.cardname).filter(Boolean).slice(0, 3).join('・');
+const ogDescription = `${event.eventname}（${event.eventtype}）の特効カード・期間・ボーナス情報。${event.start_date}〜${event.end_date}${goldNames ? ` 金特効: ${goldNames}` : ''}`;
+const ogImageCard = goldCards[0] || silverCards[0] || bronzeCards[0];
+const ogImage = ogImageCard?.ID != null ? cardThumbUrl(ogImageCard.ID) : undefined;
+
+const breadcrumbs = [
+  { name: 'ホーム', url: base },
+  { name: 'イベント情報', url: `${base}events/` },
+  { name: event.eventname, url: `${base}events/${event.id}/` },
+];
+
+const eventLd: Record<string, unknown> = {
+  '@context': 'https://schema.org',
+  '@type': 'Event',
+  name: event.eventname,
+  description: event.comment || ogDescription,
+  startDate: `${event.start_date}T17:00:00+09:00`,
+  endDate: `${event.end_date}T17:00:00+09:00`,
+  eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
+  eventStatus: 'https://schema.org/EventScheduled',
+  location: {
+    '@type': 'VirtualLocation',
+    url: 'https://app.idolish7.com/',
+  },
+  organizer: {
+    '@type': 'Organization',
+    name: 'アイドリッシュセブン',
+  },
+  url: new URL(`${base}events/${event.id}/`, Astro.site).toString(),
+  ...(ogImage ? { image: new URL(ogImage, Astro.site).toString() } : {}),
+};
+
 interface TierView {
   key: 'gold' | 'silver' | 'bronze';
   label: string;
@@ -76,10 +108,15 @@ const tiers: TierView[] = [
 ];
 ---
 
-<BaseLayout title={event.eventname}>
-  <a href={`${base}events/`} class="text-sm text-indigo-600 hover:underline">← イベント一覧へ戻る</a>
-
-  <div class="mt-2 mb-6">
+<BaseLayout
+  title={event.eventname}
+  description={ogDescription}
+  image={ogImage}
+  ogType="article"
+  breadcrumbs={breadcrumbs}
+  jsonLd={eventLd}
+>
+  <div class="mb-6">
     <div class="flex items-center gap-3 flex-wrap">
       <h1 class="text-2xl font-bold">{event.eventname}</h1>
       <EventStatusBadge
@@ -127,7 +164,7 @@ const tiers: TierView[] = [
               >
                 <img
                   src={cardThumbUrl(card.ID!)}
-                  alt=""
+                  alt={card.cardname || ''}
                   class="w-12 h-auto rounded flex-shrink-0"
                   loading="lazy"
                 />

--- a/src/pages/songs/[id].astro
+++ b/src/pages/songs/[id].astro
@@ -19,6 +19,22 @@ const base = import.meta.env.BASE_URL;
 const basePart = [song.artist, song.category].filter(Boolean).join(' / ');
 const ogDescription = song.song_type ? `${basePart}（${song.song_type}）` : basePart;
 
+const breadcrumbs = [
+  { name: 'ホーム', url: base },
+  { name: '楽曲一覧', url: `${base}songs/` },
+  { name: song.song_name || `楽曲 ${song.id}`, url: `${base}songs/${song.id}/` },
+];
+
+const musicLd: Record<string, unknown> = {
+  '@context': 'https://schema.org',
+  '@type': 'MusicComposition',
+  name: song.song_name,
+  ...(song.artist ? { composer: { '@type': 'MusicGroup', name: song.artist } } : {}),
+  ...(song.category ? { inAlbum: { '@type': 'MusicAlbum', name: song.category } } : {}),
+  image: new URL(songImageUrl(song.id), Astro.site).toString(),
+  url: new URL(`${base}songs/${song.id}/`, Astro.site).toString(),
+};
+
 // 属性比率の円グラフ用
 const sr = song.shout_ratio || 0;
 const br = song.beat_ratio || 0;
@@ -47,11 +63,9 @@ const infoRows = [
   description={ogDescription}
   image={songImageUrl(song.id)}
   ogType="article"
+  breadcrumbs={breadcrumbs}
+  jsonLd={musicLd}
 >
-  <div class="mb-6">
-    <a href={`${base}songs/`} class="text-indigo-600 hover:underline text-sm">&larr; 楽曲一覧に戻る</a>
-  </div>
-
   <!-- 基本情報 -->
   <div class="bg-white rounded-lg shadow p-6 mb-6">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary

- `@astrojs/sitemap` を導入。`/cards/[id]` `/songs/[id]` `/events/[id]` を含む全 2799 ページを sitemap-0.xml に出力（カード 2708 / 楽曲 7 / イベント 72 + 静的ページ）。changefreq/priority を種別ごとにカスタマイズ
- `public/robots.txt` を新規作成し sitemap-index.xml を案内
- 共通 `JsonLd.astro` コンポーネント追加。`BaseLayout` から WebSite / Organization を全ページに、`breadcrumbs` プロパティから BreadcrumbList JSON-LD + nav UI を自動レンダリング
- 楽曲詳細に MusicComposition、イベント詳細に Event の JSON-LD を追加
- イベント詳細に動的 description / og:image（特効カードを優先表示）を追加
- 詳細ページの「← 一覧に戻る」リンクをパンくず UI に置換
- `CardMobileCard.svelte` と `events/[id]` の `alt=""` をカード名に修正

## Test plan

- [x] `npm run typecheck` 0 errors / 0 warnings
- [x] `npm run test:unit` 119 passed
- [x] `npm run build` 成功（2799 ページ、約 7 分）
- [x] `dist/sitemap-index.xml` `dist/sitemap-0.xml` `dist/robots.txt` の生成と URL 数を確認
- [x] dev サーバー上でカード/楽曲/イベント詳細の JSON-LD 内容と breadcrumb UI を Chrome DevTools で確認
- [ ] デプロイ後 Google Search Console で sitemap を送信
- [ ] Rich Results Test (https://search.google.com/test/rich-results) で各 schema の検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)