### PR TITLE
feat(cards): カード詳細の表示形式を step-on-dream に揃える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,14 @@ Tailwind CSS v4 integrated via `@tailwindcss/vite` plugin (not the legacy `@astr
 - **Context7**: Astro・Tailwind CSS・Svelte 等のライブラリやフレームワークに関する作業では、必ず Context7 で最新の公式ドキュメントを参照してから実装する
 - **Serena**: コードベースのシンボル解析・ナビゲーション・リファクタリングには Serena を使用する。ファイル全体を読む前に `get_symbols_overview` や `find_symbol` で必要な箇所を特定し、効率的に作業する
 
+## カード表示参考
+
+カードの表示で判断が難しい場合は
+`https://i7.yo4raw.com/cards/{id}/`
+が　
+`https://i7.step-on-dream.net/card.php?ID={id}`
+に該当するので参考にする
+
 ## Workflow
 
 作業完了後は以下を自動で行うこと:

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -64,11 +64,19 @@ const infoRows = [
   { label: 'ストーリー', value: card.story },
 ].filter(r => r.value != null && r.value !== '');
 
+const trainCount = Number(card.sp_time) || 0;
+const trainStep = Number(card.sp_value) || 0;
+const trainTotal = trainCount * trainStep;
+const hasTraining = trainCount > 0 && trainStep > 0;
+
 const stats = [
   { label: 'Shout', min: card.shout_min || 0, max: card.shout_max || 0, color: ATTR_HEX.Shout },
   { label: 'Beat', min: card.beat_min || 0, max: card.beat_max || 0, color: ATTR_HEX.Beat },
   { label: 'Melody', min: card.melody_min || 0, max: card.melody_max || 0, color: ATTR_HEX.Melody },
-];
+].map(s => ({
+  ...s,
+  untrained: hasTraining && s.label === card.attribute ? s.max - trainTotal : null,
+}));
 
 const apSkillLevels = [];
 if (card.ap_skill_name) {
@@ -85,8 +93,6 @@ if (card.ap_skill_name) {
 
 const otherSkills = [
   { label: 'センタースキル', value: card.ct_skill },
-  { label: 'SPスキル時間', value: card.sp_time },
-  { label: 'SPスキル値', value: card.sp_value },
   { label: 'コメント', value: card.comment },
 ].filter(r => r.value != null && r.value !== '');
 ---
@@ -154,10 +160,23 @@ const otherSkills = [
                       <span class="w-2 h-2 rounded-full flex-shrink-0" style={`background:${s.color}`}></span>
                       <span class="font-medium text-sm w-16">{s.label}</span>
                       <span class="text-sm text-gray-500 w-10 text-right">{pct}%</span>
-                      <span class="text-sm text-right flex-1">{s.min.toLocaleString()} ~ {s.max.toLocaleString()}</span>
+                      <span class="text-sm text-right flex-1">
+                        {s.min.toLocaleString()} / {s.max.toLocaleString()}
+                        {s.untrained != null && (
+                          <span class="text-xs text-gray-500 ml-1">（未特訓 {s.untrained.toLocaleString()}）</span>
+                        )}
+                      </span>
                     </div>
                   );
                 })}
+                {hasTraining && (
+                  <div class="flex items-center gap-3">
+                    <span class="w-2 h-2 flex-shrink-0"></span>
+                    <span class="font-medium text-sm w-16">特訓</span>
+                    <span class="text-sm text-gray-500 w-10 text-right"></span>
+                    <span class="text-sm text-right flex-1">{trainCount}回 / +{trainTotal.toLocaleString()}</span>
+                  </div>
+                )}
               </div>
             </div>
           </section>
@@ -193,23 +212,13 @@ const otherSkills = [
         {card.ap_skill_req && <p><strong>発動条件:</strong> {card.ap_skill_req}</p>}
       </div>
       {apSkillLevels.length > 0 && (
-        <div class="overflow-x-auto">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="bg-gray-50 text-left">
-                <th class="px-3 py-2 w-16">Lv</th>
-                <th class="px-3 py-2">効果</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100">
-              {apSkillLevels.map(lv => (
-                <tr>
-                  <td class="px-3 py-2">Lv{lv.lv}</td>
-                  <td class="px-3 py-2">{formatSkillEffect(card.ap_skill_type, card.ap_skill_req, { count: lv.count, per: lv.per, value: lv.value, rate: lv.rate })}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div class="text-sm space-y-1">
+          {apSkillLevels.map(lv => (
+            <div>
+              <span class="font-medium text-gray-600">【Lv{lv.lv}】</span>
+              {formatSkillEffect(card.ap_skill_type, card.ap_skill_req, { count: lv.count, per: lv.per, value: lv.value, rate: lv.rate })}
+            </div>
+          ))}
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary

- カード詳細ページのステータス値とAPスキル効果を `i7.step-on-dream.net/card.php?ID={id}` の表記に揃える
- 「特訓回数と段階上昇値」を新規表示（自属性の未特訓値も併記）
- 既存の誤ラベル「SPスキル時間 / SPスキル値」を削除（実体は特訓回数・段階上昇値）

## 変更詳細

### ステータス
- 区切りを `~` → `/`
- 自属性のみ末尾に `（未特訓 max - sp_time × sp_value）` を併記
- ステータス内に `特訓 N回 / +合計上昇値` 行を追加

### APスキル
- Lv1〜Lv5 の表形式 → `【LvN】効果` の改行リスト形式

### Before / After (Card 3700)

**Before**: `Beat 2,333 ~ 6,871`、AP表
**After**: `Beat 2,333 / 6,871（未特訓 5,071）`、`特訓 6回 / +1,800`、`【Lv1】Perfect19回毎に...`

step-on-dream の同カード表示と一致：
- Shout: 1,785 / 3,881
- Beat: 2,333 / 6,871（未特訓 5,071）
- Melody: 1,878 / 4,082
- 特訓: 6回 / +1,800

## Test plan
- [x] `npm run test:unit` (119 passed)
- [x] dev サーバーで UR (3700, Beat) と SSR (3699, Melody) を目視確認
- [x] DOM 出力が step-on-dream の `card.php?ID=3700` と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)