### PR TITLE
fix(ci): batch limit パイプの SIGPIPE 失敗を修正

### DIFF
--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -64,7 +64,8 @@ jobs:
           # Limit batch size to 500 IDs per run (each ID may fetch full + thumbnail)
           BATCH_LIMIT=500
           if [ "$MISSING_COUNT" -gt "$BATCH_LIMIT" ]; then
-            MISSING_IDS=$(echo "$MISSING_IDS" | grep -E '^[0-9]+$' | head -n "$BATCH_LIMIT")
+            MISSING_IDS=$(echo "$MISSING_IDS" | grep -E '^[0-9]+$')
+            MISSING_IDS=$(echo "$MISSING_IDS" | head -n "$BATCH_LIMIT")
             MISSING_COUNT=$BATCH_LIMIT
             echo "Batch limited to: $BATCH_LIMIT"
           fi


### PR DESCRIPTION
## Summary
- 統合 workflow で `grep | head` 単一パイプが pipefail + SIGPIPE で exit 2 になっていたのを修正
- `grep` と `head` を 2 段階の代入に分割（元の fetch-new-cards.yml と同形）

## Test plan
- [ ] マージ後 workflow_dispatch で実行し、Batch limited 経路が正常に通ること