### PR TITLE
fix(ci): gap fill を forward scan より優先する

### DIFF
--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -55,8 +55,8 @@ jobs:
           GAP_COUNT=$(echo "$GAP_IDS" | grep -c -E '^[0-9]+$' || true)
           echo "Incomplete IDs in existing range: $GAP_COUNT"
 
-          # 3. Combine: scan IDs first, then gap IDs (deduplicated)
-          MISSING_IDS=$(printf '%s\n%s' "$SCAN_IDS" "$GAP_IDS" | awk 'NF && !seen[$0]++')
+          # 3. Combine: gap IDs first (heal existing dataset), then forward scan (deduplicated)
+          MISSING_IDS=$(printf '%s\n%s' "$GAP_IDS" "$SCAN_IDS" | awk 'NF && !seen[$0]++')
 
           MISSING_COUNT=$(echo "$MISSING_IDS" | grep -c -E '^[0-9]+$' || true)
           echo "IDs to process (total): $MISSING_COUNT"


### PR DESCRIPTION
## Summary
- 統合ワークフローで forward scan が batch limit 500 を消費しきり、既存範囲の不完全 ID が取得されない問題を修正
- gap fill (cards/ または th_cards/ が片方欠けている既存範囲内の ID、降順) を forward scan より先に処理する順序に変更

## Why
現状サムネイルだけ存在しフルサイズが無い ID が 492 件あり、これを優先的に補完したいため。
新規 ID は翌日以降の cron で順次取得される（forward scan 余地は十分残る）。

## Test plan
- [ ] マージ後 workflow_dispatch で手動実行
- [ ] Full-size downloaded > 0 になり 492 件のうち 500 件以下が補完されること
- [ ] 自動 PR が auto-merge → タグ → deploy まで進むこと