### PR TITLE
fix(ci): batch limit を 1500 に引き上げ既存 gap を一掃

### DIFF
--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -61,8 +61,8 @@ jobs:
           MISSING_COUNT=$(echo "$MISSING_IDS" | grep -c -E '^[0-9]+$' || true)
           echo "IDs to process (total): $MISSING_COUNT"
 
-          # Limit batch size to 500 IDs per run (each ID may fetch full + thumbnail)
-          BATCH_LIMIT=500
+          # Limit batch size to 1500 IDs per run (full + thumbnail per ID, gap fill + forward scan)
+          BATCH_LIMIT=1500
           if [ "$MISSING_COUNT" -gt "$BATCH_LIMIT" ]; then
             MISSING_IDS=$(echo "$MISSING_IDS" | grep -E '^[0-9]+$')
             MISSING_IDS=$(echo "$MISSING_IDS" | head -n "$BATCH_LIMIT")


### PR DESCRIPTION
## Summary
- BATCH_LIMIT を 500 → 1500 に引き上げ
- 既存範囲の incomplete IDs 1000 件 + forward scan 500 件 = 1500 件を 1 回でカバー
- 並列 10 で server impact は cards 単独 workflow と同程度

## Test plan
- [ ] マージ後 workflow_dispatch で実行
- [ ] Full-size downloaded > 0 となり 492 件相当の補完が走ること