### PR TITLE
feat(score-calc): スコアアップ全発動モードを追加

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -832,6 +832,7 @@
         scoreUpAssist: _q<HTMLInputElement>('opt-scoreup-assist').checked,
         scoreUpBadgeRate: parseFloat(_q<HTMLInputElement>('opt-scoreup-badge-rate').value) || 0,
         maxShrinkCoverage: _q<HTMLInputElement>('opt-max-shrink-coverage').checked,
+        maxScoreUpCoverage: _q<HTMLInputElement>('opt-max-scoreup-coverage').checked,
       };
 
       const result = await runSimulation(team, notes, iterations, (pct) => {
@@ -1443,6 +1444,10 @@
         <label class="flex items-center gap-1 text-xs text-gray-600 cursor-pointer select-none" title="ON にすると縮小スキルの確率判定を常に成功扱いにし、縮小カバー率が最大値となる前提で MC シミュレーションを実行します">
           <input type="checkbox" id="opt-max-shrink-coverage" class="rounded" />
           <span>縮小全発動</span>
+        </label>
+        <label class="flex items-center gap-1 text-xs text-gray-600 cursor-pointer select-none" title="ON にするとスコアアップスキル（タイマー型含む）の確率判定を常に成功扱いにし、スコアアップが理論最大発動回数となる前提で MC シミュレーションを実行します">
+          <input type="checkbox" id="opt-max-scoreup-coverage" class="rounded" />
+          <span>スコアアップ全発動</span>
         </label>
       </div>
       <button id="btn-calculate" type="button" class="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold text-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -643,8 +643,9 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
     if (!skill || !skill.isTimer || skill.count <= 0) continue;
 
     const maxAct = Math.floor(team.songDuration / skill.count);
+    const alwaysTrigger = options?.maxScoreUpCoverage === true;
     for (let a = 1; a <= maxAct; a++) {
-      if (rng.next() * 100 < skill.per) {
+      if (alwaysTrigger || rng.next() * 100 < skill.per) {
         activations[c]++;
         const t = a * skill.count;
         const noteIndex = Math.min(Math.floor((t / team.songDuration) * N), N - 1);
@@ -694,7 +695,8 @@ function runOnce(team: ComputedTeam, notes: FlatNote[], rng: XorShift128Plus, op
       if (counters[c] >= skill.count) {
         counters[c] = 0;
         const roll = rng.next() * 100;
-        const alwaysTrigger = skill.isShrink && options?.maxShrinkCoverage === true;
+        const alwaysTrigger = (skill.isShrink && options?.maxShrinkCoverage === true)
+          || (!skill.isShrink && options?.maxScoreUpCoverage === true);
         if (alwaysTrigger || roll < skill.per) {
           activations[c]++;
           if (skill.isShrink) {

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -92,6 +92,12 @@ export interface ScoreOptions {
    * 期待値計算・理論最高/最低スコアには影響しない。
    */
   maxShrinkCoverage?: boolean;
+  /**
+   * true のとき MC シミュレーションでスコアアップスキル（タイマー型含む）の
+   * 確率判定を常に成功扱いにする。スコアアップが理論最大発動回数となる前提の
+   * スコア分布を算出する。期待値計算・理論最高/最低スコアには影響しない。
+   */
+  maxScoreUpCoverage?: boolean;
 }
 
 export interface CardSkillStats {

--- a/src/pages/score-calc/spec.astro
+++ b/src/pages/score-calc/spec.astro
@@ -212,6 +212,19 @@ const mcSvg = mcDistributionSvg({ baseScore: 293120, seed: 42, iterations: 1000 
       <li>キューイング仕様（§2 末尾）は維持されるため、カバー率は引き続き <code class="px-1 bg-gray-100 rounded">songDuration</code> で 100% キャップされます。</li>
       <li>既定は OFF（従来の確率ベース MC）。OFF/ON を切り替えて比較することで、確率ロールの揺らぎ寄与量を定量的に分離できます。</li>
     </ul>
+
+    <h3 class="text-base font-bold text-gray-800 mb-2 mt-6">6-2. スコアアップ全発動モード（最大発動回数前提）</h3>
+    <p class="text-sm text-gray-700 mb-2">
+      シミュレーション回数入力欄の横にある <strong>「スコアアップ全発動」</strong> チェックボックスを ON にすると、
+      MC 試行内で <strong>スコアアップスキル（コンボ型・タイマー型を含む）</strong> の確率ロール（<code class="px-1 bg-gray-100 rounded">per</code>% 判定）を
+      <strong>常に成功扱い</strong> にし、<strong>スコアアップが理論最大発動回数となる前提のスコア分布</strong> を得られます。
+    </p>
+    <ul class="text-xs text-gray-600 list-disc pl-5 space-y-0.5 mb-2">
+      <li>適用対象は <strong>MC シミュレーション結果のみ</strong>（平均・中央値・p90・ヒストグラム・カード別寄与等）。</li>
+      <li>「理論最高/最低スコア」「期待値スコア」「期待発動回数」の表示は<strong>従来通り</strong>（本チェックの影響を受けない）。</li>
+      <li>判定縮小スキルには影響しない。縮小も全発動させたい場合は「縮小全発動」と併用する。</li>
+      <li>既定は OFF（従来の確率ベース MC）。OFF/ON を切り替えて比較することで、確率ロールの揺らぎ寄与量を定量的に分離できます。</li>
+    </ul>
   </section>
 
   <section class="bg-white rounded-lg shadow p-6 mb-6">


### PR DESCRIPTION
## Summary
- シミュレーション条件に「スコアアップ全発動」チェックボックスを追加し、MC 試行内でスコアアップスキル（コンボ型・タイマー型）の確率ロールを常に成功扱いにできるようにした
- 既存の「縮小全発動」と独立して切り替え可能。両方 ON にすれば縮小・スコアアップとも理論最大発動前提の分布を得られる
- 理論最高/最低スコア・期待値スコア・期待発動回数の表示は従来通り（影響なし）
- 仕様書 (\`/score-calc/spec\`) §6-2 に説明を追記

## Test plan
- [x] \`npm run test:unit\` (119 tests pass)
- [x] dev サーバーで \`/score-calc/\` のチェックボックスが「縮小全発動」の隣に表示されることを確認
- [ ] 本番ビルド後、ON/OFF を切り替えて MC 結果が変動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)