### PR TITLE
feat(seo): SEO スターターガイド準拠の不足項目を補完

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
-Allow: /
+# フィルタ・ページネーション系のクエリ URL はクロール対象外
+# (canonical は pathname を指しているため検索評価は本体 URL に集約される)
+Disallow: /*?
 
 Sitemap: https://i7.yo4raw.com/sitemap-index.xml

--- a/src/components/DeckList.svelte
+++ b/src/components/DeckList.svelte
@@ -113,7 +113,7 @@
               {@const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300'}
               <div class="flex flex-col items-center">
                 <div class="text-[9px] {labelClass} mb-0.5">{label}</div>
-                <img src={cardThumbUrl(card.ID!)} alt="" class="w-10 h-auto rounded" loading="lazy" />
+                <img src={cardThumbUrl(card.ID!)} alt={card.cardname || ''} class="w-10 h-auto rounded" loading="lazy" />
                 <div class="flex gap-0.5 mt-0.5">
                   <span class="px-0.5 py-px text-[7px] font-bold text-white rounded {rarityClass}">{card.rarity || '?'}</span>
                   <span class="px-0.5 py-px text-[7px] font-bold text-white rounded {attrBgClass}">{attr}</span>

--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -289,7 +289,7 @@
         container.className = 'slot-content border-2 border-solid rounded-lg p-1.5 flex flex-col items-center cursor-pointer min-h-[120px] transition-colors';
         container.style.borderColor = attrColor;
         container.innerHTML = `
-          <img src="${cardThumbUrl(card.ID!)}" alt="" class="w-full max-w-[60px] h-auto rounded mb-1"
+          <img src="${cardThumbUrl(card.ID!)}" alt="${card.cardname || ''}" class="w-full max-w-[60px] h-auto rounded mb-1"
             onerror="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 67%22><rect width=%2248%22 height=%2267%22 fill=%22%23e5e7eb%22/></svg>'" loading="lazy" />
           <div class="flex gap-0.5 mb-1">
             <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded ${rarityClass}">${card.rarity || '?'}</span>
@@ -626,7 +626,7 @@
         const total = (card.shout_max || 0) + (card.beat_max || 0) + (card.melody_max || 0);
 
         return `<div class="flex items-center gap-2 p-2 rounded hover:bg-gray-50 cursor-pointer border-b border-gray-100" data-pick-card="${card.ID}">
-          <img src="${cardThumbUrl(card.ID!)}" alt="" class="w-10 h-auto rounded flex-shrink-0" loading="lazy" />
+          <img src="${cardThumbUrl(card.ID!)}" alt="${card.cardname || ''}" class="w-10 h-auto rounded flex-shrink-0" loading="lazy" />
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1">
               <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded ${rarityClass}">${card.rarity || '?'}</span>

--- a/src/components/SecretsTool.svelte
+++ b/src/components/SecretsTool.svelte
@@ -484,7 +484,7 @@
             <div>
               <div class="text-[10px] text-center {labelColor} font-bold mb-1">{slotLabel}</div>
               <div class="border-2 rounded-lg p-1.5 flex flex-col items-center min-h-[120px]" style="border-color:{attrColor}">
-                <img src={cardThumbUrl(card.ID!)} alt="" class="w-full max-w-[60px] h-auto rounded mb-1" loading="lazy" />
+                <img src={cardThumbUrl(card.ID!)} alt={card.cardname || ''} class="w-full max-w-[60px] h-auto rounded mb-1" loading="lazy" />
                 <div class="flex gap-0.5 mb-1">
                   <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded {rarityClass}">{card.rarity || '?'}</span>
                   <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded {attrBgClass}">{attr}</span>

--- a/src/components/cards/CardTableRow.svelte
+++ b/src/components/cards/CardTableRow.svelte
@@ -75,7 +75,7 @@
   onclick={handleRowClick}
 >
   <td class="px-3 py-2">
-    <img src={thumb} alt="" class="w-12 h-auto rounded" loading="lazy" />
+    <img src={thumb} alt={card.cardname || ''} class="w-12 h-auto rounded" loading="lazy" />
   </td>
   <td class="px-3 py-2">{card.ID}</td>
   <td class="px-3 py-2" onclick={handleNameClick} role="presentation">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ interface Props {
 const { title, description, image, ogType = 'website', jsonLd, breadcrumbs } = Astro.props;
 const base = import.meta.env.BASE_URL;
 
-const DEFAULT_DESCRIPTION = 'アイドリッシュセブン カードデータベース';
+const DEFAULT_DESCRIPTION = 'アイドリッシュセブン (アイナナ) のカード・楽曲・イベントを検索できるデータベース。スコア計算・所持カード管理・特効カード一覧などの便利ツールも提供します。';
 const desc = description ?? DEFAULT_DESCRIPTION;
 const fullTitle = `${title} | ${SITE_NAME}`;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
@@ -37,6 +37,14 @@ const websiteLd: Record<string, unknown> = {
   url: siteUrl,
   inLanguage: 'ja',
   description: DEFAULT_DESCRIPTION,
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${siteUrl}cards/?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
 };
 
 const organizationLd: Record<string, unknown> = {
@@ -76,6 +84,7 @@ try {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#4f46e5" />
     <meta name="description" content={desc} />
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <link rel="canonical" href={canonicalUrl} />


### PR DESCRIPTION
## Summary

Google [SEO スターター ガイド](https://developers.google.com/search/docs/fundamentals/seo-starter-guide?hl=ja) の観点で本サイトを点検し、推奨されているのに未実装だった項目を補完。

- **BaseLayout (`src/layouts/BaseLayout.astro`)**:
  - `theme-color` メタタグを追加 (Tailwind indigo-600 = `#4f46e5`)
  - `DEFAULT_DESCRIPTION` を「アイドリッシュセブン カードデータベース」から、検索結果スニペットに耐える 80 文字超の説明文に拡充
  - WebSite JSON-LD に `potentialAction.SearchAction` を追加 (検索結果のサイトリンク検索ボックス対応)
- **`public/robots.txt`**:
  - `Disallow: /*?` を追記。`/cards/?q=...&page=...` 等のフィルタ URL クロールを抑止し、クロールバジェットを節約 (canonical は pathname を指しているため、indexing は本体 URL に集約される)
- **画像 alt 属性**: 「Google が画像を理解できるようにする」項目への対応として、カードサムネイル画像の `alt=""` をカード名に変更
  - `src/components/DeckList.svelte`
  - `src/components/ScoreCalc.svelte` (動的レンダー 2 箇所)
  - `src/components/SecretsTool.svelte`
  - `src/components/cards/CardTableRow.svelte`

## 既に実装済みのため対応不要

調査の結果、以下はすでに十分整備されていた:

- title / description / canonical / lang=ja / charset / viewport
- OGP / Twitter Card メタ (詳細ページは og:image も完備)
- JSON-LD: WebSite, Organization, BreadcrumbList, MusicComposition, Event
- パンくずリスト (semantic HTML + JSON-LD)
- sitemap.xml (`@astrojs/sitemap`、priority/changefreq 個別設定)
- 見出し構造 (各ページ単一 h1)
- Static SSG / Mobile-friendly / HTTPS / クリーン URL 構造

## スコープ外

- **デフォルト OG 画像**: 一覧/ツール系ページに og:image が未設定だが、1200x630 のデザイン作成が必要なため別 PR で対応予定
- **画像 width/height (CLS 対策)**: Core Web Vitals の話で、SEO スタータガイドの直接対象ではないため別 PR
- **Product / FAQPage 構造化データ**: ガチャ要素のあるカードに `offers` を付けるのは誤解を招くため見送り

## Test plan

- [x] `npm run dev` で起動 → ホームページの `<head>` を確認:
  - `<meta name="theme-color" content="#4f46e5">` 出力済み
  - description が拡充された文言になっている
  - WebSite JSON-LD に `potentialAction.SearchAction` が含まれる
- [x] カード詳細ページ (`/cards/1659/`) で既存の `og:image` / `twitter:card=summary_large_image` / BreadcrumbList JSON-LD が引き続き出力される
- [x] `curl http://localhost:4321/robots.txt` で `Disallow: /*?` が配信される
- [x] `npm run test:unit` 全 119 件パス
- [ ] (任意) 本番デプロイ後、[Google リッチリザルト テスト](https://search.google.com/test/rich-results) で WebSite/SearchAction/BreadcrumbList が認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)