### PR TITLE
feat(secrets): 上位候補 TOP 10 のサムネイル下にカード名・キャラ名を表示

### DIFF
--- a/src/components/SecretsTool.svelte
+++ b/src/components/SecretsTool.svelte
@@ -835,7 +835,7 @@
                     {@const tierMark = tier === 'gold' ? '🥇' : tier === 'silver' ? '🥈' : ''}
                     {@const slotMark = i === 0 ? '★' : i === 5 ? '✦' : ''}
                     {@const slotColor = i === 0 ? 'text-indigo-600' : i === 5 ? 'text-amber-600' : 'text-gray-400'}
-                    <div class="flex-shrink-0 flex flex-col items-center" title={`${SLOT_LABELS[i]}: ${card.cardname || ''} (${card.name || ''})`}>
+                    <div class="flex-shrink-0 flex flex-col items-center w-20" title={`${SLOT_LABELS[i]}: ${card.cardname || ''} (${card.name || ''})`}>
                       <div class="text-[10px] {slotColor} font-bold leading-none">{slotMark}{tierMark}</div>
                       <img
                         src={cardThumbUrl(card.ID!)}
@@ -844,6 +844,8 @@
                         style="border-color:{attrColor}"
                         loading="lazy"
                       />
+                      <div class="mt-0.5 text-[9px] leading-tight text-center w-full truncate" style="color:{attrColor}">{card.cardname || ''}</div>
+                      <div class="text-[8px] leading-tight text-center w-full truncate text-gray-400">{card.name || ''}</div>
                     </div>
                   {/if}
                 {/each}


### PR DESCRIPTION
## Summary

max-score-finder の「🏅 上位候補 TOP 10」パネルで、各サムネイルの下にカード名とキャラ名を 2 行で併記し、サムネイルだけでは識別しづらいカードを判別しやすくする。

## 変更内容

- 各サムネイルセルの幅を `w-20` (80px) に固定
- サムネイル下に `card.cardname` (属性カラー / truncate) と `card.name` (gray-400 / truncate) を表示
- 長い名前は省略 (`truncate`) され、title 属性でフル名を確認可能 (既存実装維持)

## Test plan

- [x] `npx astro check` で型エラー 0
- [x] dev サーバーで TOP 10 各行のカード下にカード名・キャラ名が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)