### PR TITLE
chore(deploy): カスタムドメインを wrangler で管理

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,7 @@ compatibility_date = "2026-04-19"
 [assets]
 directory = "./dist"
 not_found_handling = "404-page"
+
+[[routes]]
+pattern = "i7.yo4raw.com"
+custom_domain = true


### PR DESCRIPTION
## Summary
- v1.8.6 デプロイ後に `i7.yo4raw.com` で旧コンテンツが返り `i7-gottani.yo4raw.workers.dev` のみ最新だった問題への対策
- `wrangler.toml` に `[[routes]] custom_domain = true` を追加し、カスタムドメインの紐付けを Worker のデプロイ単位で管理する

## ⚠️ マージ前チェック
カスタムドメイン `i7.yo4raw.com` が **別の Worker / Pages プロジェクト** に紐付いていないか Cloudflare ダッシュボード (Workers & Pages) で先に確認すること。別の所有者が居たまま `wrangler deploy` を走らせると "domain already in use" でデプロイが失敗する。
- 旧紐付けがある場合: そちらから Custom Domain を解除してから本 PR をマージ
- 旧紐付けがない場合: 本 PR をマージ → タグを切ると deploy.yml が i7-gottani へドメインを取得する

## Test plan
- [ ] Cloudflare ダッシュボードで `i7.yo4raw.com` の現状の紐付け先を確認
- [ ] 旧 Worker / Pages が居ればそちらから解除
- [ ] マージ後タグ発行 → `wrangler deploy` 成功を確認
- [ ] `https://i7.yo4raw.com/secrets/max-score-finder/` で「所持カードで検索」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)