### PR TITLE
ci(deploy): wrangler-action を Node.js 24 で強制実行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
       - run: npm run build
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3.15.0
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- `cloudflare/wrangler-action@v3.15.0` が Node.js 20 ランタイムのため、GitHub Actions ランナーで以下の deprecation 警告アノテーションが表示されていた：

  > Node.js 20 actions are deprecated. ... cloudflare/wrangler-action@v3.15.0 ... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

- 上流は Node.js 24 対応版を未リリース ([PR #415](https://github.com/cloudflare/wrangler-action/pull/415) がオープン、[issue #413](https://github.com/cloudflare/wrangler-action/issues/413) で報告済)。
- GitHub 公式が案内するワークアラウンド `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を該当ステップに `env` で付与し、Node.js 24 で強制実行させる。

## Future cleanup

`cloudflare/wrangler-action` の Node.js 24 対応版がリリースされたら、バージョンを上げて本 env を削除する。

## Test plan

- [ ] PR マージ後に Actions タブから `Deploy to Cloudflare Workers` を `workflow_dispatch` で手動実行
- [ ] `Deploy to Cloudflare Workers` ステップで Node.js 20 deprecation 警告が出ないことを確認
- [ ] `wrangler deploy` が成功し、`https://i7.yo4raw.com` が従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)