### PR TITLE
feat(cards): 衣装一覧にタイル表示モードを追加

### DIFF
--- a/src/components/CardList.svelte
+++ b/src/components/CardList.svelte
@@ -4,8 +4,12 @@
   import { buildLiveTierMap, type EventForBonus } from '../lib/data/eventBonusTiers';
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
+  import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
   import CardTableRow from './cards/CardTableRow.svelte';
   import CardMobileCard from './cards/CardMobileCard.svelte';
+  import CardTileCard from './cards/CardTileCard.svelte';
+
+  type ViewMode = 'list' | 'tile';
 
   type Props = {
     cards: CardListItem[];
@@ -31,6 +35,7 @@
   let sortBy = $state('id-desc');
   let visiblePages = $state(1);
   let currentVisiblePage = $state(1);
+  let viewMode = $state<ViewMode>('list');
   let ready = $state(false);
 
   const filtered = $derived.by(() => {
@@ -87,6 +92,7 @@
     if (hasAnyLive && bonusSet.size) params.set('bonus', [...bonusSet].join(','));
     if (sortBy !== 'id-desc') params.set('sort', sortBy);
     if (currentVisiblePage > 1) params.set('page', String(currentVisiblePage));
+    if (viewMode !== 'list') params.set('view', viewMode);
 
     const qs = params.toString();
     history.replaceState(null, '', qs ? `?${qs}` : location.pathname);
@@ -105,6 +111,20 @@
     const target = pageParam ? Math.max(1, parseInt(pageParam, 10) || 1) : 1;
     visiblePages = target;
     currentVisiblePage = target;
+
+    // ビューモードは URL > localStorage > デフォルト の優先順位で復元
+    const viewParam = params.get('view');
+    if (viewParam === 'tile' || viewParam === 'list') {
+      viewMode = viewParam;
+    } else {
+      const stored = loadJson<ViewMode | null>(STORAGE_KEYS.CARD_LIST_VIEW_MODE, null);
+      viewMode = stored === 'tile' ? 'tile' : 'list';
+    }
+  }
+
+  function setViewMode(mode: ViewMode) {
+    viewMode = mode;
+    saveJson(STORAGE_KEYS.CARD_LIST_VIEW_MODE, mode);
   }
 
   function filterByName(name: string) {
@@ -174,9 +194,10 @@
   // フィルタが変わったら URL 更新
   $effect(() => {
     if (!ready) return;
-    // ダーティ参照: フィルタ/ソート/ページ
+    // ダーティ参照: フィルタ/ソート/ページ/ビューモード
     void text; void raritySet; void attributeSet; void characterSet;
     void skillSet; void bonusSet; void sortBy; void currentVisiblePage;
+    void viewMode;
     updateUrlParams();
   });
 
@@ -296,63 +317,97 @@
       </select>
     </div>
   </div>
-  <div class="mt-3 flex items-center gap-3">
+  <div class="mt-3 flex items-center gap-3 flex-wrap">
     <button type="button" class="text-sm text-indigo-600 hover:underline" onclick={reset}>条件リセット</button>
     <span class="text-sm text-gray-500">{resultCountText}</span>
+    <div class="ml-auto inline-flex rounded border border-gray-300 overflow-hidden text-xs" role="group" aria-label="表示モード切替">
+      <button
+        type="button"
+        class="px-3 py-1 {viewMode === 'list' ? 'bg-indigo-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}"
+        aria-pressed={viewMode === 'list'}
+        onclick={() => setViewMode('list')}
+      >
+        <span aria-hidden="true">☰</span> リスト
+      </button>
+      <button
+        type="button"
+        class="px-3 py-1 border-l border-gray-300 {viewMode === 'tile' ? 'bg-indigo-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}"
+        aria-pressed={viewMode === 'tile'}
+        onclick={() => setViewMode('tile')}
+      >
+        <span aria-hidden="true">▦</span> タイル
+      </button>
+    </div>
   </div>
 </div>
 
 <div>
-  <div class="hidden md:block overflow-x-auto">
-    <table class="w-full text-sm">
-      <thead>
-        <tr class="bg-gray-100 text-left text-xs text-gray-500 uppercase">
-          <th class="px-3 py-2 w-16">画像</th>
-          <th class="px-3 py-2">ID</th>
-          <th class="px-3 py-2">衣装名</th>
-          <th class="px-3 py-2">キャラ</th>
-          <th class="px-3 py-2">レア</th>
-          <th class="px-3 py-2">属性</th>
-          {#if hasAnyLive}
-            <th class="px-3 py-2">特効</th>
-          {/if}
-          <th class="px-3 py-2 w-20">属性比率</th>
-          <th class="px-3 py-2 text-right">Shout</th>
-          <th class="px-3 py-2 text-right">Beat</th>
-          <th class="px-3 py-2 text-right">Melody</th>
-          <th class="px-3 py-2">スキル</th>
-          <th class="px-3 py-2 w-28 text-center">所持数</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each visible as card, idx (card.ID)}
-          <CardTableRow
-            {card}
-            {base}
-            {thumbUrl}
-            bonusTier={tierMap.get(card.ID)}
-            enableNameFilter
-            showBonusCell={hasAnyLive}
-            pageMarker={idx % pageSize === 0 ? Math.floor(idx / pageSize) + 1 : null}
-            onFilterByName={filterByName}
-          />
-        {/each}
-      </tbody>
-    </table>
-  </div>
-  <div class="md:hidden space-y-3">
-    {#each visible as card, idx (card.ID)}
-      <CardMobileCard
-        {card}
-        {base}
-        {thumbUrl}
-        bonusTier={tierMap.get(card.ID)}
-        enableNameFilter
-        pageMarker={idx % pageSize === 0 ? Math.floor(idx / pageSize) + 1 : null}
-        onFilterByName={filterByName}
-      />
-    {/each}
-  </div>
+  {#if viewMode === 'tile'}
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+      {#each visible as card, idx (card.ID)}
+        <CardTileCard
+          {card}
+          {base}
+          {thumbUrl}
+          bonusTier={tierMap.get(card.ID)}
+          enableNameFilter
+          pageMarker={idx % pageSize === 0 ? Math.floor(idx / pageSize) + 1 : null}
+          onFilterByName={filterByName}
+        />
+      {/each}
+    </div>
+  {:else}
+    <div class="hidden md:block overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-gray-100 text-left text-xs text-gray-500 uppercase">
+            <th class="px-3 py-2 w-16">画像</th>
+            <th class="px-3 py-2">ID</th>
+            <th class="px-3 py-2">衣装名</th>
+            <th class="px-3 py-2">キャラ</th>
+            <th class="px-3 py-2">レア</th>
+            <th class="px-3 py-2">属性</th>
+            {#if hasAnyLive}
+              <th class="px-3 py-2">特効</th>
+            {/if}
+            <th class="px-3 py-2 w-20">属性比率</th>
+            <th class="px-3 py-2 text-right">Shout</th>
+            <th class="px-3 py-2 text-right">Beat</th>
+            <th class="px-3 py-2 text-right">Melody</th>
+            <th class="px-3 py-2">スキル</th>
+            <th class="px-3 py-2 w-28 text-center">所持数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each visible as card, idx (card.ID)}
+            <CardTableRow
+              {card}
+              {base}
+              {thumbUrl}
+              bonusTier={tierMap.get(card.ID)}
+              enableNameFilter
+              showBonusCell={hasAnyLive}
+              pageMarker={idx % pageSize === 0 ? Math.floor(idx / pageSize) + 1 : null}
+              onFilterByName={filterByName}
+            />
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    <div class="md:hidden space-y-3">
+      {#each visible as card, idx (card.ID)}
+        <CardMobileCard
+          {card}
+          {base}
+          {thumbUrl}
+          bonusTier={tierMap.get(card.ID)}
+          enableNameFilter
+          pageMarker={idx % pageSize === 0 ? Math.floor(idx / pageSize) + 1 : null}
+          onFilterByName={filterByName}
+        />
+      {/each}
+    </div>
+  {/if}
 </div>
 
 <div bind:this={sentinelEl} class="mt-6 flex justify-center py-8">

--- a/src/components/cards/CardTileCard.svelte
+++ b/src/components/cards/CardTileCard.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { CardListItem } from '../../lib/cardListData';
+  import { ATTR_BADGE_BG, ATTR_HEX, RARITY_BADGE_CLASSES } from '../../lib/constants';
+  import { EVENT_BONUS_TIERS, type EventBonusTier } from '../../lib/data/eventBonusTiers';
+  import CountInput from './CountInput.svelte';
+
+  type Props = {
+    card: CardListItem;
+    base: string;
+    thumbUrl: string;
+    bonusTier?: EventBonusTier;
+    enableNameFilter?: boolean;
+    pageMarker?: number | null;
+    onFilterByName?: (name: string) => void;
+  };
+
+  let { card, base, thumbUrl, bonusTier, enableNameFilter = false, pageMarker = null, onFilterByName }: Props = $props();
+
+  const borderColor = $derived(ATTR_HEX[card.attribute] || 'transparent');
+  const thumb = $derived(`${thumbUrl}/${card.ID}.png`);
+  const bonusDef = $derived(bonusTier && bonusTier !== 'none' ? EVENT_BONUS_TIERS.find((t) => t.key === bonusTier) ?? null : null);
+
+  function handleImageClick() {
+    window.location.href = `${base}cards/${card.ID}/`;
+  }
+
+  function handleNameClick(e: MouseEvent) {
+    if (!enableNameFilter) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onFilterByName?.(card.cardname || '');
+  }
+</script>
+
+{#if pageMarker != null}
+  <div data-page-marker={pageMarker} aria-hidden="true"></div>
+{/if}
+<div
+  class="bg-white rounded-lg shadow hover:shadow-md transition-shadow overflow-hidden flex flex-col"
+  style="border-top:3px solid {borderColor}"
+>
+  <button
+    type="button"
+    class="block w-full bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-400"
+    onclick={handleImageClick}
+    aria-label="{card.cardname || ''} の詳細を表示"
+  >
+    <img src={thumb} alt={card.cardname || ''} class="w-full h-auto block" loading="lazy" />
+  </button>
+  <div class="p-2 flex flex-col gap-1 flex-1">
+    <div class="flex flex-wrap items-center gap-1">
+      <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold text-white rounded {RARITY_BADGE_CLASSES[card.rarity] || 'bg-gray-300'}">
+        {card.rarity}
+      </span>
+      <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold text-white rounded {ATTR_BADGE_BG[card.attribute] || 'bg-gray-300'}">
+        {card.attribute || '?'}
+      </span>
+      {#if bonusDef}
+        <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold rounded border {bonusDef.selectClasses.join(' ')}">
+          {bonusDef.shortLabel}
+        </span>
+      {/if}
+    </div>
+    <p class="font-medium text-sm leading-tight break-words">
+      <button
+        type="button"
+        class="text-left text-indigo-600 hover:underline cursor-pointer bg-transparent p-0 border-0"
+        onclick={handleNameClick}
+      >{card.cardname || ''}</button>
+    </p>
+    <p class="text-xs text-gray-500 leading-tight">{card.name || ''}</p>
+    <div class="mt-auto flex items-center justify-between border-t pt-1.5">
+      <span class="text-[10px] text-gray-500">所持</span>
+      <CountInput cardId={card.ID} />
+    </div>
+  </div>
+</div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
   SELECTED_SONGS: 'i7_selected_songs',
   SAVED_DECKS: 'i7_saved_decks',
   SCORE_CALC_STATE: 'i7_score_calc_state',
+  CARD_LIST_VIEW_MODE: 'i7_card_list_view_mode',
 } as const;
 
 export function loadJson<T>(key: string, fallback: T): T {


### PR DESCRIPTION
## Summary
- 衣装一覧にリスト/タイル切替トグルを追加
- タイル表示はサムネ大・レア/属性/特効バッジ・シリーズ名・アイドル名・所持数編集 UI を縦積み
- ビューモードは URL `?view=tile` と localStorage `i7_card_list_view_mode` に両保存（復元優先順位は URL > localStorage > 既定）
- グリッドは 2 / 3 / 4 / 5 / 6 列 (mobile / sm / md / lg / xl)

## Test plan
- [x] `npm run test:unit` 全 119 テスト合格
- [x] dev サーバーで 1280px / 375px の両幅で表示確認
- [x] タイル切替時 URL に `?view=tile` 追加 + localStorage 保存
- [x] URL クエリを消してリロード → localStorage から復元
- [x] 所持数 +/- が `i7_card_counts` に保存される
- [x] フィルタ/ソート/無限スクロールがタイル表示でも動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)