### PR TITLE
chore(workflows): fetch 系ワークフローを毎時実行に変更

### DIFF
--- a/.github/workflows/fetch-event-db.yml
+++ b/.github/workflows/fetch-event-db.yml
@@ -2,8 +2,7 @@ name: Fetch event DB
 
 on:
   schedule:
-    # JST 04:00 = UTC 19:00 (前日)
-    - cron: '0 19 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch-gap-cards.yml
+++ b/.github/workflows/fetch-gap-cards.yml
@@ -2,7 +2,7 @@ name: Fetch gap card images
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -2,7 +2,7 @@ name: Fetch new card images
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch-new-songs.yml
+++ b/.github/workflows/fetch-new-songs.yml
@@ -2,8 +2,7 @@ name: Fetch new song images
 
 on:
   schedule:
-    # Every Sunday 18:00 UTC (= Monday 03:00 JST)
-    - cron: '0 18 * * 0'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,12 +103,12 @@ IDOLiSH7 カードデータベースの Astro 6 静的サイト（Cloudflare Wor
 
 画像・イベント DB はゲームサーバー (`i7.step-on-dream.net`) から GitHub Actions の cron ワークフローで自動取得され、PR として追加される:
 
-| ワークフロー | スケジュール (UTC / JST) | 内容 |
-|-------------|-------------------------|------|
-| `fetch-new-cards.yml` | 03:00 UTC | 新規カード画像（フルサイズ + サムネイル）の前方スキャン + ギャップ埋め |
-| `fetch-gap-cards.yml` | 05:00 UTC | カード ID ギャップの補完 |
-| `fetch-event-db.yml` | 19:00 UTC (JST 04:00) | イベント DB CSV を `public/events/events.csv` に取得 |
-| `fetch-new-songs.yml` | 18:00 UTC (日曜・JST 月曜 03:00) | IDOLiSH7 Wiki から不足楽曲ジャケット画像を取得 |
+| ワークフロー | スケジュール | 内容 |
+|-------------|------------|------|
+| `fetch-new-cards.yml` | 毎時 00 分 (UTC) | 新規カード画像（フルサイズ + サムネイル）の前方スキャン + ギャップ埋め |
+| `fetch-gap-cards.yml` | 毎時 00 分 (UTC) | カード ID ギャップの補完 |
+| `fetch-event-db.yml` | 毎時 00 分 (UTC) | イベント DB CSV を `public/events/events.csv` に取得 |
+| `fetch-new-songs.yml` | 毎時 00 分 (UTC) | IDOLiSH7 Wiki から不足楽曲ジャケット画像を取得 |
 
 楽曲ジャケット画像は `public/assets/songs/` に配置される（`SONG_IMAGE_BASE_URL` 経由で参照）。Wiki クローラー本体は `scripts/fetch-song-images.mjs`。
 


### PR DESCRIPTION
## Summary
- `fetch-new-cards.yml` / `fetch-gap-cards.yml` / `fetch-event-db.yml` / `fetch-new-songs.yml` の cron を毎時 00 分 (UTC) に統一
- CLAUDE.md のスケジュール表を追従更新

## Test plan
- [ ] CI (build) が通ること
- [ ] マージ後に各 workflow が次の毎時 00 分に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)