### PR TITLE
fix(cards): タイル表示で先頭タイルが 1 列ずれる問題を修正

### DIFF
--- a/src/components/cards/CardTileCard.svelte
+++ b/src/components/cards/CardTileCard.svelte
@@ -32,12 +32,10 @@
   }
 </script>
 
-{#if pageMarker != null}
-  <div data-page-marker={pageMarker} aria-hidden="true"></div>
-{/if}
 <div
   class="bg-white rounded-lg shadow hover:shadow-md transition-shadow overflow-hidden flex flex-col"
   style="border-top:3px solid {borderColor}"
+  data-page-marker={pageMarker ?? undefined}
 >
   <button
     type="button"


### PR DESCRIPTION
## Summary
- タイル表示モードで先頭タイル（および 100 件毎のページ先頭タイル）がグリッド 1 列分右にずれて表示されていた問題を修正
- 原因: ページ判定用センチネル \`<div>\` がタイル本体の兄弟要素として描画され、grid セルを 1 つ占有していた
- 対応: \`data-page-marker\` 属性をタイル本体ルート \`<div>\` に直接付与し、センチネル要素を廃止

## Test plan
- [x] \`npm run dev\` でタイル表示に切替え、1 枚目がグリッド 1 列目から開始されることを確認 (left=16px)
- [x] スクロールで 6 ページ目まで読み込み、各ページに \`data-page-marker\` が正しく付与され URL の \`?page=\` が連動更新されることを確認
- [x] CardTableRow / CardMobileCard は変更なしで影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)