### PR TITLE
feat(score-calc): 編成組合計算をスコア計算メニュー配下に統合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ IDOLiSH7 カードデータベースの Astro 6 静的サイト（Cloudflare Wor
 | ラビットノート | `src/pages/rabbit-note/index.astro` | ビルド時プリレンダリング |
 | About | `src/pages/about/index.astro` | ビルド時プリレンダリング |
 | リリースノート | `src/pages/releases/index.astro` | ビルド時プリレンダリング |
-| Max スコア探索 | `src/pages/secrets/max-score-finder/index.astro` | ビルド時 + クライアント JS（実験的ツール） |
+| 編成組合計算 | `src/pages/score-calc/max-score-finder/index.astro` | ビルド時 + クライアント JS（理論値最大編成探索） |
 
 ### User Data Backup
 

--- a/src/components/HeaderNav.svelte
+++ b/src/components/HeaderNav.svelte
@@ -5,22 +5,57 @@
   let { base }: Props = $props();
 
   let mobileOpen = $state(false);
+  let scoreCalcOpen = $state(false);
+  let scoreCalcMobileOpen = $state(false);
+  let scoreCalcWrapper: HTMLLIElement | undefined = $state();
 
-  const links: Array<{ href: string; label: string }> = [
+  type LinkItem = { href: string; label: string };
+  type DropdownItem = { label: string; children: LinkItem[] };
+  type NavItem = LinkItem | DropdownItem;
+
+  const isDropdown = (item: NavItem): item is DropdownItem => 'children' in item;
+
+  const items: NavItem[] = [
     { href: base, label: 'ホーム' },
     { href: `${base}cards/`, label: '衣装一覧' },
     { href: `${base}songs/`, label: '楽曲一覧' },
     { href: `${base}events/`, label: 'イベント情報' },
     { href: `${base}mycard/`, label: '所持衣装' },
-    { href: `${base}score-calc/`, label: 'スコア計算' },
+    {
+      label: 'スコア計算',
+      children: [
+        { href: `${base}score-calc/`, label: 'スコア計算' },
+        { href: `${base}score-calc/max-score-finder/`, label: '編成組合計算' },
+      ],
+    },
     { href: `${base}rabbit-note/`, label: 'ラビットノート' },
     { href: `${base}decks/`, label: '保存デッキ' },
   ];
 
   $effect(() => {
-    const handler = (e: Event) => e.preventDefault();
-    document.addEventListener('contextmenu', handler);
-    return () => document.removeEventListener('contextmenu', handler);
+    const contextHandler = (e: Event) => e.preventDefault();
+    document.addEventListener('contextmenu', contextHandler);
+
+    const clickHandler = (e: MouseEvent) => {
+      if (!scoreCalcWrapper) return;
+      if (!scoreCalcWrapper.contains(e.target as Node)) {
+        scoreCalcOpen = false;
+      }
+    };
+    document.addEventListener('click', clickHandler);
+
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        scoreCalcOpen = false;
+      }
+    };
+    document.addEventListener('keydown', keyHandler);
+
+    return () => {
+      document.removeEventListener('contextmenu', contextHandler);
+      document.removeEventListener('click', clickHandler);
+      document.removeEventListener('keydown', keyHandler);
+    };
   });
 </script>
 
@@ -39,14 +74,69 @@
       </svg>
     </button>
     <ul class="hidden md:flex gap-6 text-sm font-medium">
-      {#each links as { href, label }}
-        <li><a {href} class="hover:text-indigo-200 transition-colors">{label}</a></li>
+      {#each items as item}
+        {#if isDropdown(item)}
+          <li class="relative" bind:this={scoreCalcWrapper}>
+            <button
+              type="button"
+              class="hover:text-indigo-200 transition-colors inline-flex items-center gap-1 cursor-pointer"
+              aria-haspopup="menu"
+              aria-expanded={scoreCalcOpen}
+              onclick={() => (scoreCalcOpen = !scoreCalcOpen)}
+            >
+              {item.label}
+              <svg class="w-3 h-3 transition-transform" class:rotate-180={scoreCalcOpen} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {#if scoreCalcOpen}
+              <ul role="menu" class="absolute left-0 top-full mt-2 min-w-44 bg-white text-gray-800 rounded-md shadow-lg ring-1 ring-black/10 py-1 z-50">
+                {#each item.children as child}
+                  <li role="none">
+                    <a
+                      role="menuitem"
+                      href={child.href}
+                      class="block px-4 py-2 hover:bg-indigo-50 hover:text-indigo-700"
+                    >
+                      {child.label}
+                    </a>
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </li>
+        {:else}
+          <li><a href={item.href} class="hover:text-indigo-200 transition-colors">{item.label}</a></li>
+        {/if}
       {/each}
     </ul>
   </nav>
   <ul class="flex-col gap-2 px-4 pb-3 text-sm font-medium md:hidden" class:hidden={!mobileOpen} class:flex={mobileOpen}>
-    {#each links as { href, label }}
-      <li><a {href} class="block py-1 hover:text-indigo-200">{label}</a></li>
+    {#each items as item}
+      {#if isDropdown(item)}
+        <li>
+          <button
+            type="button"
+            class="w-full flex items-center justify-between py-1 hover:text-indigo-200"
+            aria-expanded={scoreCalcMobileOpen}
+            onclick={() => (scoreCalcMobileOpen = !scoreCalcMobileOpen)}
+          >
+            <span>{item.label}</span>
+            <svg class="w-3 h-3 transition-transform" class:rotate-180={scoreCalcMobileOpen} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {#if scoreCalcMobileOpen}
+            <ul class="pl-4 flex flex-col gap-1 mt-1">
+              {#each item.children as child}
+                <li><a href={child.href} class="block py-1 hover:text-indigo-200">{child.label}</a></li>
+              {/each}
+            </ul>
+          {/if}
+        </li>
+      {:else}
+        <li><a href={item.href} class="block py-1 hover:text-indigo-200">{item.label}</a></li>
+      {/if}
     {/each}
   </ul>
 </header>

--- a/src/pages/score-calc/max-score-finder/index.astro
+++ b/src/pages/score-calc/max-score-finder/index.astro
@@ -26,10 +26,16 @@ const eventsForBonus = allEvents.map(e => ({
 }));
 
 const base = import.meta.env.BASE_URL;
+
+const breadcrumbs = [
+  { name: 'ホーム', url: base },
+  { name: 'スコア計算', url: `${base}score-calc/` },
+  { name: '編成組合計算', url: `${base}score-calc/max-score-finder/` },
+];
 ---
 
-<BaseLayout title="Secrets">
-  <h1 class="text-2xl font-bold mb-4">🔐 Secrets - 理論値最大編成探索</h1>
+<BaseLayout title="編成組合計算" breadcrumbs={breadcrumbs}>
+  <h1 class="text-2xl font-bold mb-4">編成組合計算 — 理論値最大編成探索</h1>
   <p class="text-xs text-gray-500 mb-4">
     楽曲を選択すると、開催中イベントの <b>金特効</b> / <b>銀特効</b> の UR 衣装のみを対象に、理論期待値が最大となる 6 枚編成（フレンド含む）を総当たりで探索します。
     <br />同じ衣装を複数スロットに配置することも許容します（例: 金特効を複数スロットに重複装備）。


### PR DESCRIPTION
## Summary
- ヘッダーの「スコア計算」をドロップダウン化し、従来の「スコア計算」と「編成組合計算」（旧 `/secrets/max-score-finder`）を選択できるようにした
- `src/pages/secrets/` を削除し、ツールを `/score-calc/max-score-finder/` に移動。秘密ページではなく通常機能としてアクセス可能に
- 新ページにパンくず「ホーム / スコア計算 / 編成組合計算」を追加

## UI 詳細
- デスクトップ: ボタンクリックで開閉、外側クリック・Escape キーで閉じる、`aria-haspopup="menu"` / `aria-expanded` 付与
- モバイル: ハンバーガーメニュー内で「スコア計算」セクションを展開し、子リンクをインデントで表示

## Test plan
- [x] `npm run dev` でデスクトップ幅 → 「スコア計算」クリックで 2 項目が下に展開し、それぞれ正しい URL に遷移
- [x] モバイル幅（375px）→ ハンバーガー → 「スコア計算」展開 → 子リンクが表示・遷移可能
- [x] `/score-calc/max-score-finder/` が正常表示、パンくず・h1・ツール本体が動作
- [x] 旧 URL `/secrets/max-score-finder/` は廃止（リダイレクトなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)