### PR TITLE
feat(score-calc): たちばなさんロジック切替で別計算式によるスコア表示を追加

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -24,6 +24,7 @@
   import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../lib/data/fetchSongsJson';
   import { fetchFixedBroachsJson } from '../lib/data/fetchFixedBroachsJson';
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
+  import { computeTachibanaResult, TACHIBANA_DEFAULT_OPTIONS, type TachibanaResult } from '../lib/score/tachibana';
 
   type EventForBonus = {
     id: number;
@@ -839,6 +840,7 @@
         _q('shrink-coverage-row').classList.add('hidden');
         _q('shrink-expected-row').classList.add('hidden');
         _q('skill-per-card-section').classList.add('hidden');
+        _q('tachibana-result').classList.add('hidden');
         _q('final-result').textContent = '---';
         simulationResult = null;
         return;
@@ -871,6 +873,52 @@
       _q('skill-stats').classList.add('hidden');
       _q('final-result').textContent = '---';
       simulationResult = null;
+
+      // たちばなさんロジック（チェックON時のみ）
+      renderTachibanaResult(team);
+    }
+
+    function renderTachibanaResult(team: ComputedTeam) {
+      const enabled = _q<HTMLInputElement>('opt-tachibana')?.checked ?? false;
+      const panel = _q('tachibana-result');
+      if (!enabled || !selectedSong) {
+        panel.classList.add('hidden');
+        return;
+      }
+      const result: TachibanaResult = computeTachibanaResult(team, selectedSong, {
+        ...TACHIBANA_DEFAULT_OPTIONS,
+        scoreUpFullActivation: _q<HTMLInputElement>('opt-tachibana-scoreup-full').checked,
+        scoreUpProbabilityBoost: _q<HTMLInputElement>('opt-tachibana-scoreup-boost').checked,
+        scoreUpProbabilityBoostValue: parseFloat(_q<HTMLInputElement>('opt-tachibana-scoreup-boost-val').value) || 0,
+        shrinkFullActivation: _q<HTMLInputElement>('opt-tachibana-shrink-full').checked,
+        excludeNotes20: _q<HTMLInputElement>('opt-tachibana-exclude-notes20').checked,
+        specialEffectActive: _q<HTMLInputElement>('opt-tachibana-special-effect').checked,
+        scoreUpBadgeRate: parseFloat(_q<HTMLInputElement>('opt-scoreup-badge-rate').value) || 0,
+      });
+      panel.classList.remove('hidden');
+      _q('tachi-attr').textContent = result.attributeScore.toLocaleString();
+      _q('tachi-scoreup').textContent = result.scoreUpScore.toLocaleString();
+      _q('tachi-shrink').textContent = result.shrinkScore.toLocaleString();
+      _q('tachi-liveend').textContent = result.liveEndScore.toLocaleString();
+      _q('tachi-final').textContent = result.finalScore.toLocaleString();
+      const coverage = result.shrinkCoverage;
+      const coverageMsg = coverage > 1
+        ? `縮小発動時間カバー率 ${(coverage * 100).toFixed(1)}% — 楽曲時間を超過しているため per-card 重み付け配分で計算しています`
+        : `縮小発動時間カバー率 ${(coverage * 100).toFixed(1)}%`;
+      _q('tachi-shrink-coverage').textContent = coverage > 0 ? coverageMsg : '';
+      const rows = result.cards.map((c, i) => {
+        const slotCls = i === 0 ? 'text-indigo-600 font-bold' : i === 5 ? 'text-amber-600 font-bold' : 'text-gray-500';
+        const slotLabel = i === 0 ? 'C' : i === 5 ? 'F' : String(i);
+        return `<tr class="border-t">
+          <td class="py-1 px-1 text-[10px] ${slotCls}">${slotLabel}</td>
+          <td class="py-1 px-1">${c.cardName}</td>
+          <td class="py-1 px-1 text-[10px] text-gray-500">${c.skillTypeLabel}</td>
+          <td class="py-1 px-1 text-right">${c.attributeScore.toLocaleString()}</td>
+          <td class="py-1 px-1 text-right">${c.scoreUpScore > 0 ? c.scoreUpScore.toLocaleString() : '-'}</td>
+          <td class="py-1 px-1 text-right">${c.shrinkScore > 0 ? c.shrinkScore.toLocaleString() : '-'}</td>
+        </tr>`;
+      }).join('');
+      _q('tachi-cards-body').innerHTML = rows;
     }
 
     function renderSkillPerCard(team: ComputedTeam, notes: FlatNote[], notesCount: number, options: ScoreOptions) {
@@ -1096,6 +1144,21 @@
     }
 
     function buildStateObject() {
+      const tachibana = (() => {
+        const el = rootEl.querySelector<HTMLInputElement>('#opt-tachibana');
+        if (!el) return undefined;
+        return {
+          enabled: el.checked,
+          scoreUpFull: _q<HTMLInputElement>('opt-tachibana-scoreup-full').checked,
+          scoreUpBoost: _q<HTMLInputElement>('opt-tachibana-scoreup-boost').checked,
+          scoreUpBoostVal: parseFloat(_q<HTMLInputElement>('opt-tachibana-scoreup-boost-val').value) || 0,
+          shrinkFull: _q<HTMLInputElement>('opt-tachibana-shrink-full').checked,
+          excludeNotes20: _q<HTMLInputElement>('opt-tachibana-exclude-notes20').checked,
+          specialEffect: _q<HTMLInputElement>('opt-tachibana-special-effect').checked,
+        };
+      })();
+      const badgeRateEl = rootEl.querySelector<HTMLInputElement>('#opt-scoreup-badge-rate');
+      const badgeRate = badgeRateEl ? (parseFloat(badgeRateEl.value) || 0) : undefined;
       return {
         songId: selectedSong?.id ?? null,
         deckIds: deck.map(c => c?.ID ?? null),
@@ -1103,6 +1166,8 @@
         trained: [...deckTrained],
         sharedBroachs: deckSharedBroachs.map(a => [...a]),
         skillLevels: [...deckSkillLevels],
+        tachibana,
+        badgeRate,
       };
     }
 
@@ -1151,6 +1216,25 @@
       }
       for (let i = 0; i < 6; i++) {
         validateSharedBroachs(i);
+      }
+      // たちばなさんロジック オプション復元
+      if (state.tachibana) {
+        const t = state.tachibana;
+        const tachibanaCheckbox = _q<HTMLInputElement>('opt-tachibana');
+        const tachibanaSubOptions = _q('tachibana-options');
+        tachibanaCheckbox.checked = !!t.enabled;
+        if (t.enabled) tachibanaSubOptions.classList.remove('hidden');
+        else tachibanaSubOptions.classList.add('hidden');
+        if (typeof t.scoreUpFull === 'boolean') _q<HTMLInputElement>('opt-tachibana-scoreup-full').checked = t.scoreUpFull;
+        if (typeof t.scoreUpBoost === 'boolean') _q<HTMLInputElement>('opt-tachibana-scoreup-boost').checked = t.scoreUpBoost;
+        if (typeof t.scoreUpBoostVal === 'number') _q<HTMLInputElement>('opt-tachibana-scoreup-boost-val').value = String(t.scoreUpBoostVal);
+        if (typeof t.shrinkFull === 'boolean') _q<HTMLInputElement>('opt-tachibana-shrink-full').checked = t.shrinkFull;
+        if (typeof t.excludeNotes20 === 'boolean') _q<HTMLInputElement>('opt-tachibana-exclude-notes20').checked = t.excludeNotes20;
+        if (typeof t.specialEffect === 'boolean') _q<HTMLInputElement>('opt-tachibana-special-effect').checked = t.specialEffect;
+      }
+      if (typeof state.badgeRate === 'number') {
+        const el = _q<HTMLInputElement>('opt-scoreup-badge-rate');
+        if (el) el.value = String(state.badgeRate);
       }
       renderDeckSlots();
       recalculate();
@@ -1402,7 +1486,32 @@
       recalculate();
       renderCardDetailTable();
     });
-    _q('opt-scoreup-badge-rate').addEventListener('input', recalculate);
+    _q('opt-scoreup-badge-rate').addEventListener('input', () => { recalculate(); saveState(); });
+
+    // たちばなさんロジック チェックボックス・サブオプション
+    const tachibanaCheckbox = _q<HTMLInputElement>('opt-tachibana');
+    const tachibanaSubOptions = _q('tachibana-options');
+    tachibanaCheckbox.addEventListener('change', () => {
+      if (tachibanaCheckbox.checked) {
+        tachibanaSubOptions.classList.remove('hidden');
+      } else {
+        tachibanaSubOptions.classList.add('hidden');
+      }
+      recalculate();
+      saveState();
+    });
+    for (const id of [
+      'opt-tachibana-scoreup-full',
+      'opt-tachibana-scoreup-boost',
+      'opt-tachibana-scoreup-boost-val',
+      'opt-tachibana-shrink-full',
+      'opt-tachibana-exclude-notes20',
+      'opt-tachibana-special-effect',
+    ]) {
+      const el = _q<HTMLInputElement>(id);
+      const evt = el.type === 'number' ? 'input' : 'change';
+      el.addEventListener(evt, () => { recalculate(); saveState(); });
+    }
 
     _q('shrink-offset-input').addEventListener('input', () => {
       if (!selectedSong || deck.filter(c => c !== null).length === 0) return;
@@ -1497,6 +1606,36 @@
         </label>
       </div>
       <p class="text-[11px] text-gray-400 dark:text-slate-500 mt-2">バッジ倍率: 0 で未装着、例: 15 → ×1.15</p>
+      <div class="mt-3 pt-3 border-t border-gray-100 dark:border-slate-800">
+        <label class="flex items-center gap-2 text-sm" title="ON にすると、たちばなさん作のスプレッドシート計算ツール（https://ota-life.com/id7-score-tool/）と同じ式で属性値スコア・スコアアップスキル・縮小スキルを計算して表示します">
+          <input type="checkbox" id="opt-tachibana" class="rounded" />
+          <span>たちばなさんロジックで計算する</span>
+        </label>
+        <div id="tachibana-options" class="hidden mt-2 ml-6 grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-gray-600 dark:text-slate-300">
+          <label class="flex items-center gap-2">
+            <input type="checkbox" id="opt-tachibana-scoreup-full" class="rounded" checked />
+            <span>スコアアップフル発動 (確率 100% 扱い)</span>
+          </label>
+          <label class="flex items-center gap-2">
+            <input type="checkbox" id="opt-tachibana-scoreup-boost" class="rounded" />
+            <span>スコアアップ確率UP</span>
+            <input type="number" id="opt-tachibana-scoreup-boost-val" class="w-12 border border-gray-300 dark:border-slate-600 rounded px-1 py-0.5 text-xs" min="0" max="100" step="1" value="10" />
+            <span>%</span>
+          </label>
+          <label class="flex items-center gap-2">
+            <input type="checkbox" id="opt-tachibana-shrink-full" class="rounded" checked />
+            <span>縮小フル発動 (確率 100% 扱い)</span>
+          </label>
+          <label class="flex items-center gap-2">
+            <input type="checkbox" id="opt-tachibana-exclude-notes20" class="rounded" />
+            <span>20ノーツ加算なし (β)</span>
+          </label>
+          <label class="flex items-center gap-2 md:col-span-2">
+            <input type="checkbox" id="opt-tachibana-special-effect" class="rounded" />
+            <span>特効を入れる (デッキ属性値に追加で ×1.2)</span>
+          </label>
+        </div>
+      </div>
     </div>
   </details>
 
@@ -1683,6 +1822,42 @@
         <span class="text-[10px] text-gray-500 dark:text-slate-400">試行回数: </span>
         <span id="mc-iterations" class="text-xs md:text-sm font-bold text-gray-700 dark:text-slate-200">-</span>
       </div>
+    </section>
+
+    <!-- たちばなさんロジック結果パネル（チェックON時にのみ表示） -->
+    <section id="tachibana-result" class="hidden bg-white dark:bg-slate-800 rounded-lg shadow p-4">
+      <h2 class="text-sm font-bold text-gray-700 dark:text-slate-200 mb-3 flex items-center gap-2">
+        🌸 たちばなさんロジック計算結果
+        <a href="https://ota-life.com/id7-score-tool/" target="_blank" rel="noopener noreferrer" class="text-[10px] font-normal text-indigo-500 hover:underline">参照元</a>
+      </h2>
+      <table class="w-full text-sm">
+        <tbody>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">属性値スコア</td><td id="tachi-attr" class="text-right py-1"></td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">スコアアップスキル</td><td id="tachi-scoreup" class="text-right py-1"></td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">縮小スキル</td><td id="tachi-shrink" class="text-right py-1"></td></tr>
+          <tr class="border-t"><td class="text-gray-500 dark:text-slate-400 py-1">ライブ終了時</td><td id="tachi-liveend" class="text-right py-1"></td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1 font-bold">最終リザルト</td><td id="tachi-final" class="text-right py-1 font-bold text-indigo-700 dark:text-indigo-300 text-base"></td></tr>
+        </tbody>
+      </table>
+      <p id="tachi-shrink-coverage" class="text-[11px] text-gray-500 dark:text-slate-400 mt-2"></p>
+      <details class="mt-3">
+        <summary class="cursor-pointer text-xs text-gray-500 dark:text-slate-400 select-none">カードごとの内訳</summary>
+        <div class="overflow-x-auto mt-2">
+          <table class="w-full text-xs">
+            <thead>
+              <tr class="text-gray-500 dark:text-slate-400 border-b">
+                <th class="text-left py-1">枠</th>
+                <th class="text-left py-1">衣装</th>
+                <th class="text-left py-1">スキル</th>
+                <th class="text-right py-1">属性値</th>
+                <th class="text-right py-1">スコアUP</th>
+                <th class="text-right py-1">縮小</th>
+              </tr>
+            </thead>
+            <tbody id="tachi-cards-body"></tbody>
+          </table>
+        </div>
+      </details>
     </section>
 
     <section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4">

--- a/src/lib/score/tachibana/constants.ts
+++ b/src/lib/score/tachibana/constants.ts
@@ -1,0 +1,37 @@
+import type { TachibanaOptions } from './types';
+
+/**
+ * たちばなさんロジック（公開 Sheets `スコア計算` シート）のデフォルト値。
+ * セル参照は B12, B13, C14, B15, B16, K6, M6 に対応。
+ */
+export const TACHIBANA_DEFAULT_OPTIONS: TachibanaOptions = {
+  scoreUpFullActivation: true,    // B12 = TRUE
+  scoreUpProbabilityBoost: false, // B13 = FALSE
+  scoreUpProbabilityBoostValue: 10, // C14 = 10
+  shrinkFullActivation: true,     // B15 = TRUE
+  excludeNotes20: false,          // B16 = FALSE
+  scoreUpBadgeRate: 16,           // 設定シート B3 = 16%
+  shrinkCoverage: 0,              // M6（縮小フル発動 OFF 時はシートの ELSE 分岐を使う）
+  specialEffectActive: false,     // I6
+};
+
+/**
+ * 楽曲セクションキー（`Song` 型のグループキー）と per-section 倍率。
+ * シートの BI11..BN18 行と完全に一致する。
+ */
+export const TACHIBANA_SONG_SECTIONS: Array<{
+  key: 'notes_20' | 'light_2' | 'light_3' | 'light_4' | 'light_5' | 'light_6' | 'chorus_light_5' | 'chorus_light_6';
+  multiplier: number;
+}> = [
+  { key: 'notes_20',        multiplier: 1.0 }, // BI11..BN11
+  { key: 'light_2',         multiplier: 1.0 }, // BI12..BN12
+  { key: 'light_3',         multiplier: 1.1 },
+  { key: 'light_4',         multiplier: 1.2 },
+  { key: 'light_5',         multiplier: 1.3 },
+  { key: 'light_6',         multiplier: 1.5 },
+  { key: 'chorus_light_5',  multiplier: 2.6 },
+  { key: 'chorus_light_6',  multiplier: 3.0 },
+];
+
+/** センタースキル / フレンドスキルの属性ブースト率（シート式の +0.1 部分） */
+export const TACHIBANA_CENTER_FRIEND_BOOST = 0.1;

--- a/src/lib/score/tachibana/engine.ts
+++ b/src/lib/score/tachibana/engine.ts
@@ -1,0 +1,293 @@
+/**
+ * たちばなさんロジック スコア計算エンジン
+ *
+ * 公開スプレッドシート (https://docs.google.com/spreadsheets/d/1st1aSskGKKKl4H-XLFsTQ8zMnwrGRjqgFgdDs5bhLns/)
+ * の「スコア計算」シートの計算式を忠実に再現する。
+ *
+ * 計算フロー:
+ *   1. デッキ集約属性値 (AN72/AP72/AR72) = Σ(card.shout_max + card.broachShout) × center/friend boost × 1.2 (特効ON時)
+ *   2. 属性値スコア (D20) = Σ_8sections Σ_6subkeys (deck_attr × 0.025 or 0.030 × note_count × section_multiplier)
+ *   3. スコアアップスキル (D21) = Σ_cards (denom / count × probability × score)
+ *   4. 縮小スキル     (D22) = 縮小フル発動オプションと縮小カバー率に応じた分配計算
+ *   5. ライブ終了時 (D23) = D20 + D21 + D22
+ *   6. 最終リザルト (D24) = D23 × (1 + SCOREUPバッジ%)
+ */
+
+import type { ComputedTeam, DeckCard, AttributeName } from '../types';
+import type { Song, SongNoteGroup } from '../../data/fetchSongsJson';
+import type { TachibanaCardBreakdown, TachibanaOptions, TachibanaResult } from './types';
+import { TACHIBANA_SONG_SECTIONS, TACHIBANA_CENTER_FRIEND_BOOST } from './constants';
+import { SKILL_TYPE } from '../../data/fetchCardsJson';
+
+const NOTE_RATE_WHITE = 0.025;
+const NOTE_RATE_COLOR = 0.030;
+const SPECIAL_EFFECT_MULTIPLIER = 1.2; // シート式の AN72 で固定的に掛けられる値 (I6=TRUE 時)
+
+/** スキル種別を spreadsheet の H31 表記 (`スコアアップ` / `判定領域縮小` / その他) に正規化 */
+function classifySkill(card: DeckCard): 'scoreUp' | 'shrink' | 'none' {
+  const s = card.skill;
+  if (!s) return 'none';
+  if (s.skillType === 'scoreUp' || s.skillType === 'timerScoreUp') return 'scoreUp';
+  if (s.skillType === 'shrink') return 'shrink';
+  return 'none';
+}
+
+/** スキル発動条件を H33 表記 (`Perfect` / `コンボ` / `タイマー`) に正規化 */
+function skillRequirement(card: DeckCard): 'Perfect' | 'コンボ' | 'タイマー' | 'other' {
+  const s = card.skill;
+  if (!s) return 'other';
+  if (s.skillType === 'timerScoreUp') return 'タイマー';
+  const t = s.originalType ?? '';
+  if (t.includes('（タイマー）')) return 'タイマー';
+  if (t.includes('（コンボ）')) return 'コンボ';
+  if (t.includes('（Perfect）')) return 'Perfect';
+  return 'other';
+}
+
+/** 属性別の center/friend ブースト (+0.1 if matched) */
+function attrBoost(attr: AttributeName, centerAttr: AttributeName | null, friendAttr: AttributeName | null): number {
+  let boost = 1;
+  if (centerAttr === attr) boost += TACHIBANA_CENTER_FRIEND_BOOST;
+  if (friendAttr === attr) boost += TACHIBANA_CENTER_FRIEND_BOOST;
+  return boost;
+}
+
+/** AN72 / AP72 / AR72: デッキ集約属性値（全 6 枚 + ラビットノート + center/friend boost + 特効 ×1.2） */
+function computeDeckTotals(
+  team: ComputedTeam,
+  options: TachibanaOptions,
+  centerAttr: AttributeName | null,
+  friendAttr: AttributeName | null,
+): { shout: number; beat: number; melody: number } {
+  // 6 枚のカードの (post-train + post-rabbit-note + post-event-bonus) + broach
+  let shout = 0, beat = 0, melody = 0;
+  for (const card of team.cards) {
+    shout  += card.shout_max  + card.broachShout;
+    beat   += card.beat_max   + card.broachBeat;
+    melody += card.melody_max + card.broachMelody;
+  }
+  // center/friend boost (AN71 / AP71 / AR71)
+  shout  = Math.floor(shout  * attrBoost('Shout', centerAttr, friendAttr));
+  beat   = Math.floor(beat   * attrBoost('Beat',  centerAttr, friendAttr));
+  melody = Math.floor(melody * attrBoost('Melody', centerAttr, friendAttr));
+  // 特効 ×1.2 (AN72 / AP72 / AR72)
+  if (options.specialEffectActive) {
+    shout  = Math.floor(shout  * SPECIAL_EFFECT_MULTIPLIER);
+    beat   = Math.floor(beat   * SPECIAL_EFFECT_MULTIPLIER);
+    melody = Math.floor(melody * SPECIAL_EFFECT_MULTIPLIER);
+  }
+  return { shout, beat, melody };
+}
+
+/** BA11..BF11 base + per-section scaled (BA12..BF17): 6 属性サブキー × 8 セクション の係数行列 */
+function computeAttrCoefficients(deckTotals: { shout: number; beat: number; melody: number }) {
+  // 行 = 8 セクション (multiplier 1.0, 1.0, 1.1, 1.2, 1.3, 1.5, 2.6, 3.0)
+  // 列 = 6 サブキー (shout_white, shout_color, beat_white, beat_color, melody_white, melody_color)
+  const base = {
+    shout_white:  Math.floor(deckTotals.shout  * NOTE_RATE_WHITE),
+    shout_color:  Math.floor(deckTotals.shout  * NOTE_RATE_COLOR),
+    beat_white:   Math.floor(deckTotals.beat   * NOTE_RATE_WHITE),
+    beat_color:   Math.floor(deckTotals.beat   * NOTE_RATE_COLOR),
+    melody_white: Math.floor(deckTotals.melody * NOTE_RATE_WHITE),
+    melody_color: Math.floor(deckTotals.melody * NOTE_RATE_COLOR),
+  };
+  return TACHIBANA_SONG_SECTIONS.map(({ multiplier }) => {
+    if (multiplier === 1.0) return base;
+    return {
+      shout_white:  Math.floor(base.shout_white  * multiplier),
+      shout_color:  Math.floor(base.shout_color  * multiplier),
+      beat_white:   Math.floor(base.beat_white   * multiplier),
+      beat_color:   Math.floor(base.beat_color   * multiplier),
+      melody_white: Math.floor(base.melody_white * multiplier),
+      melody_color: Math.floor(base.melody_color * multiplier),
+    };
+  });
+}
+
+/** D20: 属性値スコア = Σ over 8 sections × 6 subkeys (coeff × note_count) */
+function computeAttributeScore(coeffs: ReturnType<typeof computeAttrCoefficients>, song: Song): number {
+  let total = 0;
+  for (let i = 0; i < TACHIBANA_SONG_SECTIONS.length; i++) {
+    const { key } = TACHIBANA_SONG_SECTIONS[i];
+    const g = song[key] as SongNoteGroup;
+    const c = coeffs[i];
+    total += c.shout_white  * (g.shout_white  ?? 0)
+           + c.shout_color  * (g.shout_color  ?? 0)
+           + c.beat_white   * (g.beat_white   ?? 0)
+           + c.beat_color   * (g.beat_color   ?? 0)
+           + c.melody_white * (g.melody_white ?? 0)
+           + c.melody_color * (g.melody_color ?? 0);
+  }
+  return total;
+}
+
+/** カード 1 枚分のスコアアップスキル期待値 (H38) */
+function computeCardScoreUp(card: DeckCard, song: Song, options: TachibanaOptions): number {
+  if (classifySkill(card) !== 'scoreUp') return 0;
+  const s = card.skill!;
+  const req = skillRequirement(card);
+  if (req === 'other') return 0;
+  if (s.count === 0) return 0;
+  const denom = req === 'タイマー' ? (song.duration ?? 0) : (song.notes_count ?? 0);
+  let probMult: number;
+  if (options.scoreUpFullActivation) {
+    probMult = 1;
+  } else if (options.scoreUpProbabilityBoost) {
+    probMult = (s.per + options.scoreUpProbabilityBoostValue) / 100;
+  } else {
+    probMult = s.per / 100;
+  }
+  return Math.floor((denom / s.count) * probMult * s.value);
+}
+
+/** カード 1 枚分の縮小スキル base/秒 (H39) */
+function computeCardShrinkPerSecond(card: DeckCard, song: Song, options: TachibanaOptions): number {
+  if (classifySkill(card) !== 'shrink') return 0;
+  const s = card.skill!;
+  const req = skillRequirement(card);
+  if (req === 'other') return 0;
+  if (s.count === 0) return 0;
+  const denom = req === 'タイマー' ? (song.duration ?? 0) : (song.notes_count ?? 0);
+  const probMult = options.shrinkFullActivation ? 1 : (s.per / 100);
+  return Math.floor((denom / s.count) * probMult * s.value);
+}
+
+/** D21: スコアアップスキル合計 */
+function computeScoreUpScore(team: ComputedTeam, song: Song, options: TachibanaOptions): number[] {
+  return team.cards.map((c) => computeCardScoreUp(c, song, options));
+}
+
+/** D22: 縮小スキル合計（per-card 配列を返す） */
+function computeShrinkScores(
+  team: ComputedTeam,
+  song: Song,
+  options: TachibanaOptions,
+  attributeScore: number,
+): { perCard: number[]; total: number; coverage: number } {
+  const perSecond = team.cards.map((c) => computeCardShrinkPerSecond(c, song, options));
+  const sumPerSecond = perSecond.reduce((a, b) => a + b, 0);
+  const duration = song.duration ?? 0;
+  const coverage = duration > 0 ? sumPerSecond / duration : 0;
+
+  // BN22 = "without 特効" baseline attribute score
+  // BN23 = "without notes_20" baseline
+  // 特効 ON で属性値スコアは既に ×1.2 されているので、ベースは ÷1.2 で「特効なし」相当に戻す
+  const withoutSpecial = options.specialEffectActive
+    ? Math.floor(attributeScore / SPECIAL_EFFECT_MULTIPLIER)
+    : attributeScore;
+  // BN23 (20ノーツなし): notes_20 セクションを除いた合計
+  let notes20Contribution = 0;
+  if (options.excludeNotes20) {
+    notes20Contribution = computeNotes20Contribution(team, song, options);
+  }
+  const withoutSpecialMinusNotes20 = options.specialEffectActive
+    ? Math.floor((attributeScore - notes20Contribution) / SPECIAL_EFFECT_MULTIPLIER)
+    : (attributeScore - notes20Contribution);
+
+  const perCard = team.cards.map((c, i) => {
+    if (classifySkill(c) !== 'shrink') return 0;
+    const s = c.skill!;
+    const rate = s.rate; // H37: 縮小倍率 (1.6 など)
+    if (rate <= 1) return 0;
+    const factor = rate - 1; // H37 - 1
+    const sec = perSecond[i];
+    if (coverage >= 1) {
+      // フル発動時間オーバー: per-card 重み付け正規化
+      const pool = options.excludeNotes20 ? withoutSpecialMinusNotes20 : withoutSpecial;
+      const weight = sumPerSecond > 0 ? sec / sumPerSecond : 0;
+      return Math.floor(pool * weight * factor);
+    } else {
+      // 通常: pool × (sec/duration) × factor
+      return Math.floor(withoutSpecial * (duration > 0 ? sec / duration : 0) * factor);
+    }
+  });
+  return {
+    perCard,
+    total: perCard.reduce((a, b) => a + b, 0),
+    coverage,
+  };
+}
+
+/** notes_20 セクションの寄与（excludeNotes20 オプション用） */
+function computeNotes20Contribution(team: ComputedTeam, song: Song, options: TachibanaOptions): number {
+  const centerAttr = team.cards[0]?.attribute ?? null;
+  const friendAttr = team.cards[5]?.attribute ?? null;
+  const deck = computeDeckTotals(team, options, centerAttr, friendAttr);
+  const coeffs = computeAttrCoefficients(deck);
+  const c = coeffs[0]; // notes_20 セクション
+  const g = song.notes_20;
+  return c.shout_white  * (g.shout_white  ?? 0)
+       + c.shout_color  * (g.shout_color  ?? 0)
+       + c.beat_white   * (g.beat_white   ?? 0)
+       + c.beat_color   * (g.beat_color   ?? 0)
+       + c.melody_white * (g.melody_white ?? 0)
+       + c.melody_color * (g.melody_color ?? 0);
+}
+
+/**
+ * たちばなさんロジックでスコアを計算する。
+ * `computeTeam` の戻り値をそのまま `team` に渡す。
+ */
+export function computeTachibanaResult(team: ComputedTeam, song: Song, options: TachibanaOptions): TachibanaResult {
+  const centerAttr = team.cards[0]?.attribute ?? null;
+  const friendAttr = team.cards[5]?.attribute ?? null;
+
+  const deckTotals = computeDeckTotals(team, options, centerAttr, friendAttr);
+  const coeffs = computeAttrCoefficients(deckTotals);
+
+  const attributeScore = computeAttributeScore(coeffs, song);
+  const scoreUpPerCard = computeScoreUpScore(team, song, options);
+  const scoreUpTotal = scoreUpPerCard.reduce((a, b) => a + b, 0);
+  const shrink = computeShrinkScores(team, song, options, attributeScore);
+
+  const liveEndScore = attributeScore + scoreUpTotal + shrink.total;
+  const finalScore = options.scoreUpBadgeRate > 0
+    ? Math.floor(liveEndScore * (1 + options.scoreUpBadgeRate / 100))
+    : liveEndScore;
+
+  // per-card attribute score (AM74 シート式) — 表示用
+  const cardBreakdown: TachibanaCardBreakdown[] = team.cards.map((c, i) => {
+    const shoutPost = c.shout_max + c.broachShout;
+    const beatPost  = c.beat_max  + c.broachBeat;
+    const melodyPost = c.melody_max + c.broachMelody;
+    // BB33 / BD33 / BF33: 各属性の楽曲全体係数
+    const coeffSum = TACHIBANA_SONG_SECTIONS.reduce(
+      (acc, { key, multiplier }) => {
+        const g = song[key] as SongNoteGroup;
+        acc.shout  += multiplier * ((g.shout_white  ?? 0) * NOTE_RATE_WHITE + (g.shout_color  ?? 0) * NOTE_RATE_COLOR);
+        acc.beat   += multiplier * ((g.beat_white   ?? 0) * NOTE_RATE_WHITE + (g.beat_color   ?? 0) * NOTE_RATE_COLOR);
+        acc.melody += multiplier * ((g.melody_white ?? 0) * NOTE_RATE_WHITE + (g.melody_color ?? 0) * NOTE_RATE_COLOR);
+        return acc;
+      },
+      { shout: 0, beat: 0, melody: 0 },
+    );
+    const cardAttrScore = Math.floor(
+      shoutPost  * attrBoost('Shout',  centerAttr, friendAttr) * coeffSum.shout +
+      beatPost   * attrBoost('Beat',   centerAttr, friendAttr) * coeffSum.beat +
+      melodyPost * attrBoost('Melody', centerAttr, friendAttr) * coeffSum.melody,
+    );
+    return {
+      slotIndex: i,
+      cardName: c.cardname,
+      attribute: c.attribute,
+      attributeScore: cardAttrScore,
+      scoreUpScore: scoreUpPerCard[i],
+      shrinkScore: shrink.perCard[i],
+      skillTypeLabel: c.skill?.originalType ?? '',
+      skillReqLabel: c.skill?.originalType?.match(/（(.+?)）/)?.[1] ?? '',
+    };
+  });
+
+  return {
+    attributeScore,
+    scoreUpScore: scoreUpTotal,
+    shrinkScore: shrink.total,
+    liveEndScore,
+    finalScore,
+    cards: cardBreakdown,
+    shrinkCoverage: shrink.coverage,
+  };
+}
+
+// 既存のスキル種別文字列定数を参照したい場合に外部公開
+export { SKILL_TYPE };

--- a/src/lib/score/tachibana/index.ts
+++ b/src/lib/score/tachibana/index.ts
@@ -1,0 +1,12 @@
+export { computeTachibanaResult } from './engine';
+export {
+  TACHIBANA_DEFAULT_OPTIONS,
+  TACHIBANA_SONG_SECTIONS,
+  TACHIBANA_CENTER_FRIEND_BOOST,
+} from './constants';
+export type {
+  TachibanaOptions,
+  TachibanaResult,
+  TachibanaCardBreakdown,
+  TachibanaInput,
+} from './types';

--- a/src/lib/score/tachibana/types.ts
+++ b/src/lib/score/tachibana/types.ts
@@ -1,0 +1,64 @@
+import type { ComputedTeam } from '../types';
+import type { Song } from '../../data/fetchSongsJson';
+
+export interface TachibanaOptions {
+  /** スコアアップフル発動: TRUE のとき確率係数を 1 として扱う */
+  scoreUpFullActivation: boolean;
+  /** スコアアップ確率UP: TRUE のとき確率に scoreUpProbabilityBoost%（既定 10）を加算 */
+  scoreUpProbabilityBoost: boolean;
+  /** scoreUpProbabilityBoost が TRUE のときに確率へ加算する値（％） */
+  scoreUpProbabilityBoostValue: number;
+  /** 縮小フル発動: TRUE のとき縮小スキルの確率を 1 として扱う */
+  shrinkFullActivation: boolean;
+  /** 20ノーツ加算なし（β）: TRUE のとき縮小スコアの上限を 20ノーツ分除外した属性値で算出 */
+  excludeNotes20: boolean;
+  /** SCOREUPバッジ倍率（％）。0 なら未使用 */
+  scoreUpBadgeRate: number;
+  /**
+   * 縮小発動時間カバー率（縮小フル発動時に縮小スキルの累計発動時間が楽曲時間を超える割合）。
+   * 1 以上で縮小フル発動 ON のとき、シート式と同じく per-card 重み付け正規化に切り替える。
+   */
+  shrinkCoverage: number;
+  /** 特効が有効か（縮小スキルの「20ノーツなし」基準値計算用の判定に使う） */
+  specialEffectActive: boolean;
+}
+
+export interface TachibanaCardBreakdown {
+  slotIndex: number;
+  cardName: string;
+  attribute: 'Shout' | 'Beat' | 'Melody' | null;
+  /** カード単位の属性値スコア（センター/フレンドスキル・特効・ブローチ反映後 × 楽曲属性係数） */
+  attributeScore: number;
+  /** カード単位のスコアアップスキル期待値（スキルが該当しなければ 0） */
+  scoreUpScore: number;
+  /** カード単位の縮小スキル期待値（スキルが該当しなければ 0） */
+  shrinkScore: number;
+  /** スキル種別表示文字列 */
+  skillTypeLabel: string;
+  /** スキル発動条件表示文字列 */
+  skillReqLabel: string;
+}
+
+export interface TachibanaResult {
+  /** 属性値スコア合計（D20 相当） */
+  attributeScore: number;
+  /** スコアアップスキル合計（D21 相当） */
+  scoreUpScore: number;
+  /** 縮小スキル合計（D22 相当） */
+  shrinkScore: number;
+  /** ライブ終了時スコア（D23 相当） */
+  liveEndScore: number;
+  /** 最終リザルト（D24 相当、SCOREUPバッジ適用後） */
+  finalScore: number;
+  /** カードごとの内訳（6 スロット分） */
+  cards: TachibanaCardBreakdown[];
+  /** 縮小発動時間カバー率（縮小フル発動時のオーバー検知用） */
+  shrinkCoverage: number;
+}
+
+/** computeTachibanaResult への入力。`computeTeam` の出力をそのまま渡す。 */
+export interface TachibanaInput {
+  team: ComputedTeam;
+  song: Song;
+  options: TachibanaOptions;
+}

--- a/tests/unit/score/tachibana/engine.test.ts
+++ b/tests/unit/score/tachibana/engine.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../../src/lib/data/fetchCardsJson';
+import { computeTeam } from '../../../../src/lib/score/engine';
+import { computeTachibanaResult, TACHIBANA_DEFAULT_OPTIONS } from '../../../../src/lib/score/tachibana';
+import { findCardById, findSongById, findBroachsByCardId } from '../../../fixtures';
+
+/**
+ * 公開スプレッドシート (https://docs.google.com/spreadsheets/d/1st1aSskGKKKl4H-XLFsTQ8zMnwrGRjqgFgdDs5bhLns/)
+ * の「スコア計算」シートの参照値と一致することを検証する。
+ *
+ * デッキ構成:
+ *   - 1枚目, 2枚目: 百[記念日2024] (cardID 2237, Beat, 判定縮小 Perfect, lv5)
+ *   - 3枚目(センター): 百[7th Anniversary] (cardID 1805, Beat, スコアアップ コンボ, lv5)
+ *   - 4枚目, 5枚目, 6枚目(フレンド): 千[記念日2021] (cardID 1488, Beat, スコアアップ Perfect, lv5)
+ *
+ * 楽曲: Binary Vampire (id 60, Re:vale, ノーツ 461, 92 秒)
+ *
+ * オプション:
+ *   - 特効: 銀 (per-card) + 特効ON (deck-level ×1.2)
+ *   - スコアアップフル発動 ON, 縮小フル発動 ON
+ *   - SCOREUPバッジ 16%
+ *
+ * 期待値（シートの D20..D24 セル）:
+ *   - 属性値スコア D20 = 1,876,289
+ *   - スコアアップスキル D21 = 747,118
+ *   - 縮小スキル D22 = 938,144
+ *   - ライブ終了時 D23 = 3,561,551
+ *   - 最終リザルト D24 = 4,131,399
+ */
+describe('computeTachibanaResult — 公開シート参照値の再現', () => {
+  const card2237 = findCardById(2237); // 百[記念日2024] Beat 判定縮小Perfect
+  const card1805 = findCardById(1805); // 百[7th Anniversary] Beat スコアアップコンボ
+  const card1488 = findCardById(1488); // 千[記念日2021] Beat スコアアップPerfect
+  const song = findSongById(60);       // Binary Vampire
+
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  // 百[7th Anniversary] には Beat +800 の固定ブローチが紐づいている
+  const broachs = findBroachsByCardId(1805);
+  const team = computeTeam(
+    deck,
+    broachs,
+    song,
+    ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'], // 全カード銀特効
+    [true, true, true, true, true, true],
+    undefined,
+    undefined,
+    [5, 5, 5, 5, 5, 5],
+    {},
+  );
+
+  const result = computeTachibanaResult(team, song, {
+    ...TACHIBANA_DEFAULT_OPTIONS,
+    specialEffectActive: true,  // I6 = TRUE
+    scoreUpBadgeRate: 16,       // K6 = TRUE, バッジ 16%
+  });
+
+  it('属性値スコア (D20) = 1,876,289', () => {
+    expect(result.attributeScore).toBe(1876289);
+  });
+
+  it('スコアアップスキル (D21) = 747,118', () => {
+    expect(result.scoreUpScore).toBe(747118);
+  });
+
+  it('縮小スキル (D22) = 938,144', () => {
+    expect(result.shrinkScore).toBe(938144);
+  });
+
+  it('ライブ終了時 (D23) = 3,561,551', () => {
+    expect(result.liveEndScore).toBe(3561551);
+  });
+
+  it('最終リザルト (D24) = 4,131,399', () => {
+    expect(result.finalScore).toBe(4131399);
+  });
+
+  it('縮小カバー率 (M6) ≈ 1.804', () => {
+    expect(result.shrinkCoverage).toBeCloseTo(1.804347826, 3);
+  });
+});
+
+describe('computeTachibanaResult — SCOREUPバッジ無効時', () => {
+  const card1488 = findCardById(1488);
+  const song = findSongById(60);
+  const deck: (Card | null)[] = [card1488, card1488, card1488, card1488, card1488, card1488];
+  const team = computeTeam(deck, [], song, undefined, undefined, undefined, undefined, [5, 5, 5, 5, 5, 5], {});
+
+  it('SCOREUPバッジ 0% のとき finalScore = liveEndScore', () => {
+    const result = computeTachibanaResult(team, song, {
+      ...TACHIBANA_DEFAULT_OPTIONS,
+      scoreUpBadgeRate: 0,
+    });
+    expect(result.finalScore).toBe(result.liveEndScore);
+  });
+});


### PR DESCRIPTION
## Summary

- スコア計算画面に「たちばなさんロジックで計算する」チェックボックスを追加
- ON のとき [@lop_0125 さん作の公開スプレッドシート計算ツール](https://ota-life.com/id7-score-tool/) と同じ計算式で 属性値スコア / スコアアップスキル / 縮小スキル / ライブ終了時 / 最終リザルト を算出して専用パネルに表示
- 計算ロジックは新規モジュール \`src/lib/score/tachibana/\` に分離。既存 Monte Carlo シミュレーションエンジンには変更を加えない
- サブオプション（スコアアップフル発動 / 確率UP+%値 / 縮小フル発動 / 20ノーツ加算なし / 特効 ON）を localStorage (\`i7_score_calc_state\`) に永続化

## 実装内容

- 楽曲 8 セクション × 6 サブカラム (white/color × Shout/Beat/Melody) を使ったデッキ集約属性値スコア
- Perfect / コンボ / タイマー別のスコアアップ・縮小スキル期待値（縮小カバー率超過時は per-card 重み付け配分）
- 特効 ON 時のデッキ ×1.2 と SCOREUPバッジ倍率の反映
- 公開シートのサンプル（百記念2024×2 + 百7th + 千記念2021×3 / Binary Vampire / 銀特効）で属性値 1,876,289 / SU 747,118 / 縮小 938,144 / 最終 4,131,399 を ±0 で再現する単体テスト

## Test plan

- [x] \`npm run test:unit\` — 全 139 件パス（tachibana の 7 件含む）
- [x] \`npx tsc --noEmit\` — 型エラーなし
- [x] \`npm run dev\` 上で動作確認：チェックボックス表示・サブオプション展開・結果パネル表示・OFF 時の従来表示・ページリロード後の状態復元
- [ ] \`npm run preview\`（本番ビルド）でも同様に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)