### PR TITLE
test(score-calc): たちばなさんロジックのオラクル実装でクロスチェックテストを追加

### DIFF
--- a/tests/unit/score/tachibana/oracle-cross-check.test.ts
+++ b/tests/unit/score/tachibana/oracle-cross-check.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../../src/lib/data/fetchCardsJson';
+import { computeTeam } from '../../../../src/lib/score/engine';
+import { computeTachibanaResult, TACHIBANA_DEFAULT_OPTIONS, type TachibanaOptions } from '../../../../src/lib/score/tachibana';
+import { findCardById, findSongById, findBroachsByCardId } from '../../../fixtures';
+import { computeTachibanaOracle } from './spreadsheet-oracle';
+
+/**
+ * オラクル (シート式の 1:1 トランスクリプション) と本実装 (engine) のクロスチェック。
+ * 両者は実装構造が異なるため、同一の入力に対して同一の出力を返すことで
+ * 互いに正しさを補強する。
+ */
+
+const card2237 = findCardById(2237); // 百[記念日2024] Beat 判定縮小Perfect
+const card1805 = findCardById(1805); // 百[7th Anniversary] Beat スコアアップコンボ
+const card1488 = findCardById(1488); // 千[記念日2021] Beat スコアアップPerfect
+const card1487 = findCardById(1487); // 百[記念日2021] Melody スコアアップコンボ
+const card1806 = findCardById(1806); // 千[7th Anniversary] Shout BAD→Perfect（スコア寄与なし）
+const card408 = findCardById(408);   // 和泉三月[屋外フェス2] Melody スコアアップタイマー
+const card411 = findCardById(411);   // 六弥ナギ[屋外フェス2] Melody スコアアップタイマー
+const card528 = findCardById(528);   // 和泉一織[ユニット2] Melody スコアアップタイマー
+const card529 = findCardById(529);   // 七瀬陸[ユニット2] Melody スコアアップタイマー
+const card574 = findCardById(574);   // 四葉環[ユニット2] Melody スコアアップタイマー
+
+const binaryVampire = findSongById(60);             // Re:vale / 461 / 92s / Melody 偏重
+const monsterGenerationSong = findSongById(2);      // Beat 偏重
+
+const broachs1805 = findBroachsByCardId(1805);
+
+function buildOptions(overrides: Partial<TachibanaOptions> = {}): TachibanaOptions {
+  return { ...TACHIBANA_DEFAULT_OPTIONS, ...overrides };
+}
+
+function runBoth(deck: (Card | null)[], song: Parameters<typeof computeTeam>[2], options: TachibanaOptions, params: {
+  bonusTiers?: Parameters<typeof computeTeam>[3];
+  trained?: Parameters<typeof computeTeam>[4];
+  broachs?: Parameters<typeof computeTeam>[1];
+} = {}) {
+  const team = computeTeam(
+    deck,
+    params.broachs ?? [],
+    song,
+    params.bonusTiers,
+    params.trained,
+    undefined,
+    undefined,
+    [5, 5, 5, 5, 5, 5],
+    {},
+  );
+  const oracle = computeTachibanaOracle(team, song, options);
+  const engine = computeTachibanaResult(team, song, options);
+  return { oracle, engine };
+}
+
+function expectMatch(label: string, oracle: ReturnType<typeof computeTachibanaResult>, engine: ReturnType<typeof computeTachibanaResult>) {
+  expect.soft(engine.attributeScore, `${label}: attributeScore`).toBe(oracle.attributeScore);
+  expect.soft(engine.scoreUpScore,   `${label}: scoreUpScore`).toBe(oracle.scoreUpScore);
+  expect.soft(engine.shrinkScore,    `${label}: shrinkScore`).toBe(oracle.shrinkScore);
+  expect.soft(engine.liveEndScore,   `${label}: liveEndScore`).toBe(oracle.liveEndScore);
+  expect.soft(engine.finalScore,     `${label}: finalScore`).toBe(oracle.finalScore);
+  expect.soft(engine.shrinkCoverage, `${label}: shrinkCoverage`).toBeCloseTo(oracle.shrinkCoverage, 6);
+  for (let i = 0; i < 6; i++) {
+    expect.soft(engine.cards[i].attributeScore, `${label}: cards[${i}].attributeScore`).toBe(oracle.cards[i].attributeScore);
+    expect.soft(engine.cards[i].scoreUpScore,   `${label}: cards[${i}].scoreUpScore`).toBe(oracle.cards[i].scoreUpScore);
+    expect.soft(engine.cards[i].shrinkScore,    `${label}: cards[${i}].shrinkScore`).toBe(oracle.cards[i].shrinkScore);
+  }
+}
+
+describe('oracle 自体の正しさ (公開シート参照値の再現)', () => {
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  const opts = buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 });
+  const { oracle } = runBoth(deck, binaryVampire, opts, {
+    bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+    trained:    [true, true, true, true, true, true],
+    broachs:    broachs1805,
+  });
+  it('オラクル単体: 属性値 1,876,289 / SU 747,118 / 縮小 938,144 / 最終 4,131,399', () => {
+    expect(oracle.attributeScore).toBe(1876289);
+    expect(oracle.scoreUpScore).toBe(747118);
+    expect(oracle.shrinkScore).toBe(938144);
+    expect(oracle.liveEndScore).toBe(3561551);
+    expect(oracle.finalScore).toBe(4131399);
+  });
+});
+
+describe('engine ↔ oracle クロスチェック: 公開シートデッキ × オプション組み合わせ', () => {
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  const params = {
+    bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'] as Parameters<typeof computeTeam>[3],
+    trained:    [true, true, true, true, true, true],
+    broachs:    broachs1805,
+  };
+
+  const cases: { label: string; opts: Partial<TachibanaOptions> }[] = [
+    { label: '特効 OFF / バッジ 0%',                opts: { specialEffectActive: false, scoreUpBadgeRate: 0 } },
+    { label: '特効 OFF / バッジ 16%',               opts: { specialEffectActive: false, scoreUpBadgeRate: 16 } },
+    { label: '特効 ON / バッジ 0%',                 opts: { specialEffectActive: true,  scoreUpBadgeRate: 0 } },
+    { label: '特効 ON / バッジ 30%',                opts: { specialEffectActive: true,  scoreUpBadgeRate: 30 } },
+    { label: 'スコアアップフル発動 OFF',            opts: { scoreUpFullActivation: false } },
+    { label: 'スコアアップ確率UP ON / 値10%',       opts: { scoreUpFullActivation: false, scoreUpProbabilityBoost: true, scoreUpProbabilityBoostValue: 10 } },
+    { label: 'スコアアップ確率UP ON / 値25%',       opts: { scoreUpFullActivation: false, scoreUpProbabilityBoost: true, scoreUpProbabilityBoostValue: 25 } },
+    { label: '縮小フル発動 OFF',                    opts: { shrinkFullActivation: false } },
+    { label: '20ノーツ加算なし ON',                 opts: { specialEffectActive: true, excludeNotes20: true, scoreUpBadgeRate: 16 } },
+    { label: '全オプション OFF (素の確率ベース)',    opts: { scoreUpFullActivation: false, shrinkFullActivation: false, specialEffectActive: false, scoreUpBadgeRate: 0 } },
+  ];
+
+  for (const { label, opts } of cases) {
+    it(label, () => {
+      const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions(opts), params);
+      expectMatch(label, oracle, engine);
+    });
+  }
+});
+
+describe('engine ↔ oracle クロスチェック: 特効ティアごと', () => {
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  const tiers: Parameters<typeof computeTeam>[3][] = [
+    ['none',   'none',   'none',   'none',   'none',   'none'],
+    ['bronze', 'bronze', 'bronze', 'bronze', 'bronze', 'bronze'],
+    ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+    ['gold',   'gold',   'gold',   'gold',   'gold',   'gold'],
+    ['gold',   'silver', 'bronze', 'none',   'silver', 'gold'], // ミックス
+  ];
+  for (const t of tiers) {
+    it(`特効ティア = [${t!.join(',')}]`, () => {
+      const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+        bonusTiers: t,
+        trained:    [true, true, true, true, true, true],
+        broachs:    broachs1805,
+      });
+      expectMatch(`tiers=${t!.join(',')}`, oracle, engine);
+    });
+  }
+});
+
+describe('engine ↔ oracle クロスチェック: 未特訓カードを含む', () => {
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  it('全カード未特訓 / 銀特効 / バッジ16%', () => {
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [false, false, false, false, false, false],
+      broachs:    broachs1805,
+    });
+    expectMatch('全カード未特訓', oracle, engine);
+  });
+});
+
+describe('engine ↔ oracle クロスチェック: 異なるデッキ構成', () => {
+  it('縮小スキルなしデッキ (千記念2021 × 6)', () => {
+    const deck: (Card | null)[] = [card1488, card1488, card1488, card1488, card1488, card1488];
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+    });
+    expectMatch('縮小なし', oracle, engine);
+    expect(engine.shrinkScore).toBe(0);
+  });
+
+  it('スコアアップスキルなしデッキ (百記念2024 × 6 / 全員 判定縮小Perfect)', () => {
+    const deck: (Card | null)[] = [card2237, card2237, card2237, card2237, card2237, card2237];
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+    });
+    expectMatch('スコアアップなし', oracle, engine);
+    expect(engine.scoreUpScore).toBe(0);
+  });
+
+  it('スキル寄与なしカード (BAD→Perfect) を含む', () => {
+    const deck: (Card | null)[] = [card1806, card2237, card1805, card1488, card1488, card1488];
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+    });
+    expectMatch('BAD→Perfect カード混在', oracle, engine);
+    // card1806 (BAD→Perfect) はスコア寄与なし
+    expect(engine.cards[0].scoreUpScore).toBe(0);
+    expect(engine.cards[0].shrinkScore).toBe(0);
+  });
+
+  it('タイマースキルカードを含む混成デッキ', () => {
+    // タイマースキルは秒数ベース (D9) で計算される。固定縮小カードは Perfect/コンボ系のままノーツベース。
+    const deck: (Card | null)[] = [card408, card411, card528, card529, card574, card2237];
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+    });
+    expectMatch('タイマースキル混在', oracle, engine);
+  });
+
+  it('別属性主体デッキ (Melody 百記念2021)', () => {
+    // 百記念2021 は Melody 属性 + コンボスキル
+    const deck: (Card | null)[] = [card1487, card1487, card1487, card1487, card1487, card1487];
+    const { oracle, engine } = runBoth(deck, binaryVampire, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+    });
+    expectMatch('Melody デッキ', oracle, engine);
+  });
+});
+
+describe('engine ↔ oracle クロスチェック: 異なる楽曲', () => {
+  const deck: (Card | null)[] = [card2237, card2237, card1805, card1488, card1488, card1488];
+  it('MONSTER GENERATiON (Beat 偏重楽曲)', () => {
+    const { oracle, engine } = runBoth(deck, monsterGenerationSong, buildOptions({ specialEffectActive: true, scoreUpBadgeRate: 16 }), {
+      bonusTiers: ['silver', 'silver', 'silver', 'silver', 'silver', 'silver'],
+      trained:    [true, true, true, true, true, true],
+      broachs:    broachs1805,
+    });
+    expectMatch('MONSTER GENERATiON', oracle, engine);
+  });
+});

--- a/tests/unit/score/tachibana/spreadsheet-oracle.ts
+++ b/tests/unit/score/tachibana/spreadsheet-oracle.ts
@@ -1,0 +1,285 @@
+/**
+ * たちばなさんロジック スプレッドシート計算式オラクル (テスト専用)
+ *
+ * 公開シート (https://docs.google.com/spreadsheets/d/1st1aSskGKKKl4H-XLFsTQ8zMnwrGRjqgFgdDs5bhLns/) の
+ * 「スコア計算」シートの各セル (AM/AN/.../BA/BB/.../BF/BI..BN/H..M/D) の formula を
+ * 可能な限り 1:1 で TypeScript に書き起こした実装。
+ *
+ * `src/lib/score/tachibana/engine.ts` の `computeTachibanaResult` とは別の実装で、
+ * 同じ入力に対して同じ結果を返すべき。両者の出力を突き合わせることでバグ検出力を高める。
+ *
+ * 命名はシートのセル位置を反映 (例: `BA11` は `cellBA11` のように)。
+ */
+
+import type { ComputedTeam, DeckCard, AttributeName } from '../../../../src/lib/score/types';
+import type { Song, SongNoteGroup } from '../../../../src/lib/data/fetchSongsJson';
+import type { TachibanaOptions, TachibanaResult } from '../../../../src/lib/score/tachibana';
+
+const ROUNDDOWN = (n: number) => Math.trunc(n); // シートの ROUNDDOWN(x, 0) と等価 (正の値前提)
+const ROUND = (n: number) => Math.round(n);
+
+const SECTION_KEYS: (keyof Pick<Song, 'notes_20' | 'light_2' | 'light_3' | 'light_4' | 'light_5' | 'light_6' | 'chorus_light_5' | 'chorus_light_6'>)[] = [
+  'notes_20', 'light_2', 'light_3', 'light_4', 'light_5', 'light_6', 'chorus_light_5', 'chorus_light_6',
+];
+const SECTION_MULTIPLIERS = [1.0, 1.0, 1.1, 1.2, 1.3, 1.5, 2.6, 3.0]; // AZ22..AZ29
+const ATTR_MULT_BY_INDEX_FROM_2: number[] = [1.1, 1.2, 1.3, 1.5, 2.6, 3.0]; // AZ12..AZ17 (BA12..BF17 用)
+
+/** スキル種別判定 (H31): "スコアアップ" | "判定領域縮小" | "" */
+function cellH31(card: DeckCard): string {
+  const t = card.skill?.originalType ?? '';
+  if (t.startsWith('スコアアップ')) return 'スコアアップ';
+  if (t.startsWith('判定縮小')) return '判定領域縮小';
+  return '';
+}
+
+/** 発動条件 (H33): "Perfect" | "コンボ" | "タイマー" | "" */
+function cellH33(card: DeckCard): string {
+  const t = card.skill?.originalType ?? '';
+  const m = t.match(/（(.+?)）/);
+  return m ? m[1] : '';
+}
+
+/** AM74 系のセンター/フレンドブースト係数 (1 + 0.1*matched_center + 0.1*matched_friend) */
+function attrBoost(attr: AttributeName, center: AttributeName | null, friend: AttributeName | null): number {
+  return 1 + (center === attr ? 0.1 : 0) + (friend === attr ? 0.1 : 0);
+}
+
+/**
+ * オラクル本体: シートのセル順序通りに値を組み上げて、最終的に D20-D24 を返す。
+ */
+export function computeTachibanaOracle(team: ComputedTeam, song: Song, options: TachibanaOptions): TachibanaResult {
+  // 楽曲基本データ (D8 = ノーツ数, D9 = 秒数)
+  const D8 = song.notes_count ?? 0;
+  const D9 = song.duration ?? 0;
+
+  // J20 / M20: センター/フレンドの属性
+  const J20 = team.cards[0]?.attribute ?? null;
+  const M20 = team.cards[5]?.attribute ?? null;
+
+  // ---- 各カードの属性値 (AM/AN/AO/AP/AQ/AR の per-card 計算)
+  // ComputedTeam.cards[i] には:
+  //   - shout_max = ROUND((train-adjusted + rabbit_note) × (1 + bonus)) = AM29 相当
+  //   - broachShout = AM58 相当 (resolveDeckBroachs 後の合計)
+  // よって AM63 = card.shout_max + card.broachShout
+  const perCardShout = team.cards.map((c) => (c.shout_max ?? 0) + (c.broachShout ?? 0));   // AM63 / AN63 / ...
+  const perCardBeat  = team.cards.map((c) => (c.beat_max  ?? 0) + (c.broachBeat  ?? 0));   // AM64 / ...
+  const perCardMelody = team.cards.map((c) => (c.melody_max ?? 0) + (c.broachMelody ?? 0)); // AM65 / ...
+
+  // ---- AN67..AN72 (Shout) / AP67..AP72 (Beat) / AR67..AR72 (Melody): デッキ集約
+  const sumWithoutFriend = (arr: number[]) => arr.slice(0, 5).reduce((a, b) => a + b, 0);
+  const friendOnly = (arr: number[]) => arr[5] ?? 0;
+
+  const an67 = sumWithoutFriend(perCardShout);     // AM63:AQ63 (5枚, AR は friend)
+  const ap67 = sumWithoutFriend(perCardBeat);
+  const ar67 = sumWithoutFriend(perCardMelody);
+  // ラビットノート加算 (シートでは AU26/AV26/AW26 を加算) — 既に card.shout_max が rabbit_note 込みなのでここでは 0
+  const an68 = an67;
+  const ap68 = ap67;
+  const ar68 = ar67;
+  // フレンドカード加算
+  const an69 = an68 + friendOnly(perCardShout);
+  const ap69 = ap68 + friendOnly(perCardBeat);
+  const ar69 = ar68 + friendOnly(perCardMelody);
+  // センター/フレンドスキル属性ブースト (+0.1 each if match)
+  const an71 = ROUNDDOWN(an69 * attrBoost('Shout', J20, M20));
+  const ap71 = ROUNDDOWN(ap69 * attrBoost('Beat',  J20, M20));
+  const ar71 = ROUNDDOWN(ar69 * attrBoost('Melody', J20, M20));
+  // 特効 ON で ×1.2
+  const SE = options.specialEffectActive;
+  const an72 = SE ? ROUNDDOWN(an71 * 1.2) : an71;
+  const ap72 = SE ? ROUNDDOWN(ap71 * 1.2) : ap71;
+  const ar72 = SE ? ROUNDDOWN(ar71 * 1.2) : ar71;
+
+  // ---- BA11..BF11 (各サブカラム × deck total × NOTE_RATE)
+  const ba11 = ROUNDDOWN(an72 * 0.025); // shout_white
+  const bb11 = ROUNDDOWN(an72 * 0.030); // shout_color
+  const bc11 = ROUNDDOWN(ap72 * 0.025); // beat_white
+  const bd11 = ROUNDDOWN(ap72 * 0.030); // beat_color
+  const be11 = ROUNDDOWN(ar72 * 0.025); // melody_white
+  const bf11 = ROUNDDOWN(ar72 * 0.030); // melody_color
+
+  // ---- BA12..BF17: BA11..BF11 × AZ12..AZ17 (1.1, 1.2, 1.3, 1.5, 2.6, 3.0)
+  // 結合した 8 行 (BA11/BB11/.../BF11 row が ×1.0 で行 11 と 12 で共有, BA12..BF17 で残り 6 行)
+  const sectionCoeffs: { sw: number; sc: number; bw: number; bc: number; mw: number; mc: number }[] = [];
+  // 行 11 と行 12 (notes_20, light_2 = ×1.0): 同じ BA11..BF11
+  sectionCoeffs.push({ sw: ba11, sc: bb11, bw: bc11, bc: bd11, mw: be11, mc: bf11 });
+  sectionCoeffs.push({ sw: ba11, sc: bb11, bw: bc11, bc: bd11, mw: be11, mc: bf11 });
+  // 行 13..18 (light_3..chorus_light_6): BA12..BF17 = ROUNDDOWN(BA11..BF11 × multiplier)
+  for (const mult of ATTR_MULT_BY_INDEX_FROM_2) {
+    sectionCoeffs.push({
+      sw: ROUNDDOWN(ba11 * mult),
+      sc: ROUNDDOWN(bb11 * mult),
+      bw: ROUNDDOWN(bc11 * mult),
+      bc: ROUNDDOWN(bd11 * mult),
+      mw: ROUNDDOWN(be11 * mult),
+      mc: ROUNDDOWN(bf11 * mult),
+    });
+  }
+
+  // ---- BI11:BN18 行列 = 各セクション × 各サブカラム × 楽曲ノーツ数
+  const matrix: number[][] = sectionCoeffs.map((c, sectionIdx) => {
+    const g = song[SECTION_KEYS[sectionIdx]] as SongNoteGroup;
+    return [
+      c.sw * (g.shout_white  ?? 0),
+      c.sc * (g.shout_color  ?? 0),
+      c.bw * (g.beat_white   ?? 0),
+      c.bc * (g.beat_color   ?? 0),
+      c.mw * (g.melody_white ?? 0),
+      c.mc * (g.melody_color ?? 0),
+    ];
+  });
+
+  // D20 = BN21 = SUM(BI11:BN18)
+  const D20 = matrix.flat().reduce((a, b) => a + b, 0);
+
+  // ---- per-card スキル計算 (H32..H40)
+  // H32 = スキルレベル (5固定 in 本実装), H34 = count, H35 = per, H36 = value, H37 = rate
+  // H31 = スキル種別, H33 = 発動条件
+  // H38 = スコアアップ score-up 期待値
+  // H39 = 縮小スキル per second
+  // H40 = 縮小スキル score
+  const perCardScoreUp: number[] = [];
+  const perCardShrinkSec: number[] = []; // H39
+  const perCardShrinkRate: number[] = []; // H37
+  for (const card of team.cards) {
+    const t = cellH31(card);
+    const req = cellH33(card);
+    const skill = card.skill;
+    if (!skill) {
+      perCardScoreUp.push(0);
+      perCardShrinkSec.push(0);
+      perCardShrinkRate.push(0);
+      continue;
+    }
+    const H34 = skill.count;
+    const H35 = skill.per;
+    const H36 = skill.value;
+    const H37 = skill.rate;
+    if (H34 === 0) {
+      perCardScoreUp.push(0);
+      perCardShrinkSec.push(0);
+      perCardShrinkRate.push(H37);
+      continue;
+    }
+
+    // 分母: Perfect/コンボ は D8 (ノーツ数), タイマー は D9 (秒数)
+    const denom = req === 'タイマー' ? D9 : D8;
+    if (req !== 'Perfect' && req !== 'コンボ' && req !== 'タイマー') {
+      perCardScoreUp.push(0);
+      perCardShrinkSec.push(0);
+      perCardShrinkRate.push(H37);
+      continue;
+    }
+
+    if (t === 'スコアアップ') {
+      // H38 = ROUNDDOWN(denom / H34 × prob_coeff × H36)
+      let probCoeff: number;
+      if (options.scoreUpFullActivation) {
+        probCoeff = 1;
+      } else if (options.scoreUpProbabilityBoost) {
+        probCoeff = (H35 + options.scoreUpProbabilityBoostValue) / 100;
+      } else {
+        probCoeff = H35 / 100;
+      }
+      perCardScoreUp.push(ROUNDDOWN((denom / H34) * probCoeff * H36));
+      perCardShrinkSec.push(0);
+      perCardShrinkRate.push(0);
+    } else if (t === '判定領域縮小') {
+      // H39 = ROUNDDOWN(denom / H34 × (B15 ? 1 : H35/100) × H36)
+      const probCoeff = options.shrinkFullActivation ? 1 : (H35 / 100);
+      perCardScoreUp.push(0);
+      perCardShrinkSec.push(ROUNDDOWN((denom / H34) * probCoeff * H36));
+      perCardShrinkRate.push(H37);
+    } else {
+      perCardScoreUp.push(0);
+      perCardShrinkSec.push(0);
+      perCardShrinkRate.push(H37);
+    }
+  }
+
+  // D21 = SUM(H38:M38)
+  const D21 = perCardScoreUp.reduce((a, b) => a + b, 0);
+
+  // BN22 = if(I6=TRUE, ROUNDDOWN(SUM/1.2, 0), BN21) — "特効なし" 基準
+  const BN22 = SE ? ROUNDDOWN(D20 / 1.2) : D20;
+  // BN23 = "20ノーツなし" 基準 = SUM(BI12:BN18) ÷ (特効 ? 1.2 : 1)
+  const notes20Sum = matrix[0].reduce((a, b) => a + b, 0); // notes_20 行 (BI11..BN11)
+  const sumExcludingNotes20 = D20 - notes20Sum;
+  const BN23 = SE ? ROUNDDOWN(sumExcludingNotes20 / 1.2) : sumExcludingNotes20;
+
+  // M6 = SUM(H39:M39) / D9
+  const sumH39ToM39 = perCardShrinkSec.reduce((a, b) => a + b, 0);
+  const M6 = D9 > 0 ? sumH39ToM39 / D9 : 0;
+
+  // H40 = 縮小 per-card final
+  const perCardShrink: number[] = perCardShrinkSec.map((sec, i) => {
+    const rate = perCardShrinkRate[i];
+    if (rate <= 1) return 0;
+    const factor = rate - 1; // H37 - 1
+    if (M6 >= 1) {
+      const pool = options.excludeNotes20 ? BN23 : BN22;
+      const weight = sumH39ToM39 > 0 ? sec / sumH39ToM39 : 0;
+      return ROUNDDOWN(pool * weight * factor);
+    } else {
+      return ROUNDDOWN(BN22 * (D9 > 0 ? sec / D9 : 0) * factor);
+    }
+  });
+
+  // D22 = SUM(H40:M40)
+  const D22 = perCardShrink.reduce((a, b) => a + b, 0);
+
+  // D23 = SUM(D20, D21, D22)
+  const D23 = D20 + D21 + D22;
+
+  // D24 = IF(K6=TRUE, ROUNDDOWN(D23 × (1 + 設定!B3), 0), D23)
+  const D24 = options.scoreUpBadgeRate > 0
+    ? ROUNDDOWN(D23 * (1 + options.scoreUpBadgeRate / 100))
+    : D23;
+
+  // per-card 内訳 (AM74 系) — engine 側との比較用
+  const cardCoeff = (attr: AttributeName) => {
+    return SECTION_KEYS.reduce((acc, key, i) => {
+      const g = song[key] as SongNoteGroup;
+      const mult = SECTION_MULTIPLIERS[i];
+      const white = attr === 'Shout' ? g.shout_white : attr === 'Beat' ? g.beat_white : g.melody_white;
+      const color = attr === 'Shout' ? g.shout_color : attr === 'Beat' ? g.beat_color : g.melody_color;
+      return acc + mult * ((white ?? 0) * 0.025 + (color ?? 0) * 0.030);
+    }, 0);
+  };
+  const coeffShout = cardCoeff('Shout');
+  const coeffBeat  = cardCoeff('Beat');
+  const coeffMelody = cardCoeff('Melody');
+  const cards = team.cards.map((c, i) => {
+    const shoutPost = perCardShout[i];
+    const beatPost  = perCardBeat[i];
+    const melodyPost = perCardMelody[i];
+    const attrScore = ROUNDDOWN(
+      shoutPost  * attrBoost('Shout',  J20, M20) * coeffShout +
+      beatPost   * attrBoost('Beat',   J20, M20) * coeffBeat +
+      melodyPost * attrBoost('Melody', J20, M20) * coeffMelody,
+    );
+    return {
+      slotIndex: i,
+      cardName: c.cardname,
+      attribute: c.attribute,
+      attributeScore: attrScore,
+      scoreUpScore: perCardScoreUp[i],
+      shrinkScore: perCardShrink[i],
+      skillTypeLabel: c.skill?.originalType ?? '',
+      skillReqLabel: cellH33(c),
+    };
+  });
+
+  return {
+    attributeScore: D20,
+    scoreUpScore: D21,
+    shrinkScore: D22,
+    liveEndScore: D23,
+    finalScore: D24,
+    cards,
+    shrinkCoverage: M6,
+  };
+}
+
+// 不使用変数の lint 抑止用 (デバッグ時に検証用エクスポート)
+export const _unused = { ROUND };


### PR DESCRIPTION
## Summary

- スプレッドシートの formula を 1:1 で書き起こした **オラクル実装** を \`tests/unit/score/tachibana/spreadsheet-oracle.ts\` に追加
- 本実装 (\`computeTachibanaResult\`) とオラクルが同じ入力で同じ出力を返すことをクロスチェック
- 公開シートのサンプル値でオラクル単体の整合性も再確認 (4,131,399 を独立再現)
- 全 30 テストパス（engine 単体 7 + クロスチェック 23）

## クロスチェック網羅範囲（22 シナリオ）

**オプション単体 ON/OFF（10 ケース）**
- 特効 ON/OFF × バッジ 0%/16%/30%（4 組）
- スコアアップフル発動 OFF
- スコアアップ確率UP ON / 値 10% & 25%
- 縮小フル発動 OFF
- 20ノーツ加算なし ON
- 全オプション OFF（素の確率ベース）

**異なる特効ティア（5 ケース）**
- 全 none / 全 bronze / 全 silver / 全 gold / ミックス（gold,silver,bronze,none,silver,gold）

**異なるデッキ構成（6 ケース）**
- 全カード未特訓
- 縮小スキルなしデッキ（千記念2021 × 6）
- スコアアップスキルなしデッキ（百記念2024 × 6）
- BAD→Perfect スキル混在
- タイマースキル混成（屋外フェス2・ユニット2）
- Melody 主体デッキ（百記念2021 × 6）

**異なる楽曲（1 ケース）**
- MONSTER GENERATiON（Beat 偏重）

## Test plan

- [x] \`npm run test:unit\` — 全 162 件パス（tachibana の 30 件含む）
- [x] \`npx tsc --noEmit\` — 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)