### PR TITLE
イベント特効衣装のSNS共有用ページ＋画像ダウンロード機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/svelte": "^8.1.2",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.2",
+        "modern-screenshot": "^4.7.0",
         "svelte": "^5.55.9",
         "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3"
@@ -373,6 +374,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -812,6 +814,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -834,6 +837,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -856,6 +860,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -872,6 +877,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -888,6 +894,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -904,6 +911,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -920,6 +928,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -936,6 +945,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -952,6 +962,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -968,6 +979,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -984,6 +996,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1000,6 +1013,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1016,6 +1030,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1038,6 +1053,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1060,6 +1076,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1082,6 +1099,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1104,6 +1122,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1126,6 +1145,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1148,6 +1168,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1170,6 +1191,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1192,6 +1214,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1211,6 +1234,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1230,6 +1254,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1249,6 +1274,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5921,6 +5947,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/modern-screenshot": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.7.0.tgz",
+      "integrity": "sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -7431,7 +7463,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@astrojs/svelte": "^8.1.2",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.2",
+    "modern-screenshot": "^4.7.0",
     "svelte": "^5.55.9",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3"

--- a/src/components/EventShareImage.svelte
+++ b/src/components/EventShareImage.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  interface Props {
+    /** 拡張子なしのダウンロードファイル名 */
+    filename: string;
+    /** 画像化対象要素の id */
+    targetId?: string;
+  }
+
+  let { filename, targetId = 'share-panel' }: Props = $props();
+
+  let busy = $state(false);
+
+  async function download() {
+    if (busy) return;
+    const node = document.getElementById(targetId);
+    if (!node) return;
+    busy = true;
+    try {
+      const { domToPng } = await import('modern-screenshot');
+      const bg = document.documentElement.classList.contains('dark') ? '#0f172a' : '#ffffff';
+      const dataUrl = await domToPng(node, { scale: 2, backgroundColor: bg });
+      const a = document.createElement('a');
+      a.href = dataUrl;
+      a.download = `${filename}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch (e) {
+      console.error(e);
+      alert('画像の生成に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  onclick={download}
+  disabled={busy}
+  class="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-not-allowed dark:bg-indigo-700 dark:hover:bg-indigo-600"
+>
+  {#if busy}
+    <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+    生成中…
+  {:else}
+    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+    画像をダウンロード
+  {/if}
+</button>

--- a/src/pages/events/[id]/share.astro
+++ b/src/pages/events/[id]/share.astro
@@ -1,0 +1,160 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import EventShareImage from '../../../components/EventShareImage.svelte';
+import { fetchEventsCsv, formatEffectSummary, type EventRow, type EventSpecialTier } from '../../../lib/data/fetchEventsCsv';
+import { fetchCardsJson, type Card } from '../../../lib/data/fetchCardsJson';
+import { ATTR_BADGE_BG, RARITY_BADGE_CLASSES, SITE_NAME } from '../../../lib/constants';
+import { cardThumbUrl } from '../../../lib/ui';
+
+export async function getStaticPaths() {
+  const [events, cards] = await Promise.all([
+    fetchEventsCsv(),
+    fetchCardsJson(),
+  ]);
+  const cardMap = new Map<number, Card>();
+  for (const c of cards as Card[]) {
+    if (c.ID != null) cardMap.set(c.ID, c);
+  }
+  const pick = (ids: number[]): Card[] =>
+    ids.map(id => cardMap.get(id)).filter((c): c is Card => !!c);
+
+  return (events as EventRow[]).map(ev => ({
+    params: { id: String(ev.id) },
+    props: {
+      event: ev,
+      goldCards: pick(ev.gold.cardIds),
+      silverCards: pick(ev.silver.cardIds),
+    },
+  }));
+}
+
+interface Props {
+  event: EventRow;
+  goldCards: Card[];
+  silverCards: Card[];
+}
+
+const { event, goldCards, silverCards } = Astro.props as Props;
+const base = import.meta.env.BASE_URL;
+
+const goldNames = goldCards.map(c => c.cardname).filter(Boolean).slice(0, 3).join('・');
+const description = `${event.eventname}（${event.eventtype}）の金特効・銀特効衣装まとめ（SNS共有用）。${event.start_date}〜${event.end_date}${goldNames ? ` 金特効: ${goldNames}` : ''}`;
+const ogImageCard = goldCards[0] || silverCards[0];
+const ogImage = ogImageCard?.ID != null ? cardThumbUrl(ogImageCard.ID) : undefined;
+
+// ダウンロード画像のファイル名（拡張子なし）。ファイル名に使えない文字を除去
+const safeName = event.eventname.replace(/[\\/:*?"<>|]/g, '').replace(/\s+/g, '_');
+const shareFilename = `${event.id}_${safeName}_特効衣装`;
+
+const breadcrumbs = [
+  { name: 'ホーム', url: base },
+  { name: 'イベント情報', url: `${base}events/` },
+  { name: event.eventname, url: `${base}events/${event.id}/` },
+  { name: 'SNS共有', url: `${base}events/${event.id}/share/` },
+];
+
+interface TierView {
+  key: 'gold' | 'silver';
+  label: string;
+  cards: Card[];
+  tier: EventSpecialTier;
+  headerClass: string;
+  badgeClass: string;
+}
+
+const tiers: TierView[] = [
+  {
+    key: 'gold',
+    label: '金特効衣装',
+    cards: goldCards,
+    tier: event.gold,
+    headerClass: 'bg-yellow-400 text-yellow-950 dark:bg-yellow-500 dark:text-yellow-950',
+    badgeClass: 'bg-yellow-100 text-yellow-800 border-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-200 dark:border-yellow-600',
+  },
+  {
+    key: 'silver',
+    label: '銀特効衣装',
+    cards: silverCards,
+    tier: event.silver,
+    headerClass: 'bg-gray-300 text-gray-800 dark:bg-slate-500 dark:text-slate-50',
+    badgeClass: 'bg-gray-200 text-gray-700 border-gray-400 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-500',
+  },
+];
+---
+
+<BaseLayout
+  title={`${event.eventname} 特効衣装`}
+  description={description}
+  image={ogImage}
+  ogType="article"
+  breadcrumbs={breadcrumbs}
+>
+  <div class="mb-3 flex items-center justify-between gap-3 flex-wrap max-w-3xl">
+    <p class="text-sm text-gray-600 dark:text-slate-300">
+      下の枠をスクリーンショット、または右のボタンで画像保存して SNS でシェアできます（金特効・銀特効の特効衣装まとめ）。
+    </p>
+    <EventShareImage filename={shareFilename} client:load />
+  </div>
+
+  <!-- スクショ対象パネル -->
+  <div id="share-panel" class="max-w-3xl rounded-xl border border-gray-200 dark:border-slate-700 shadow-lg overflow-hidden bg-white dark:bg-slate-800">
+    <!-- ヘッダー帯 -->
+    <div class="bg-indigo-600 dark:bg-indigo-700 text-white px-4 py-3">
+      <div class="flex items-baseline justify-between gap-2 flex-wrap">
+        <h1 class="text-lg sm:text-xl font-bold leading-snug">{event.eventname}</h1>
+        <span class="text-xs font-semibold text-indigo-100 whitespace-nowrap">{SITE_NAME}</span>
+      </div>
+      <div class="mt-1 text-xs text-indigo-100 space-x-2">
+        <span>{event.eventtype}</span>
+        <span>/</span>
+        <span>{event.start_date} 17:00 〜 {event.end_date} 17:00 (JST)</span>
+      </div>
+    </div>
+
+    <div class="p-3 sm:p-4 space-y-5">
+      {tiers.map(t => (
+        <section>
+          <div class="flex items-center gap-2 flex-wrap mb-2">
+            <span class={`inline-block px-3 py-0.5 rounded-full text-sm font-bold ${t.headerClass}`}>{t.label}</span>
+            <span class="text-xs text-gray-500 dark:text-slate-400">{t.cards.length} 着</span>
+            {formatEffectSummary(t.tier) && (
+              <span class="text-xs text-gray-600 dark:text-slate-300">{formatEffectSummary(t.tier)}</span>
+            )}
+          </div>
+
+          {t.cards.length === 0 ? (
+            <p class="text-sm text-gray-400 dark:text-slate-500">対象衣装なし</p>
+          ) : (
+            <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+              {t.cards.map(card => {
+                const attr = card.attribute || '';
+                const rarity = card.rarity || '';
+                const attrBg = ATTR_BADGE_BG[attr] || 'bg-gray-400';
+                const rarityBg = RARITY_BADGE_CLASSES[rarity] || 'bg-gray-300';
+                return (
+                  <div class="flex flex-col">
+                    <div class="relative rounded overflow-hidden border border-gray-200 dark:border-slate-700">
+                      <img
+                        src={cardThumbUrl(card.ID!)}
+                        alt={card.cardname || ''}
+                        class="w-full h-auto block"
+                        width="200"
+                        height="300"
+                      />
+                      <div class="absolute top-0.5 left-0.5 flex gap-0.5">
+                        <span class={`px-1 py-0.5 text-[9px] font-bold text-white rounded ${rarityBg}`}>{rarity || '?'}</span>
+                        {attr && <span class={`px-1 py-0.5 text-[9px] font-bold text-white rounded ${attrBg}`}>{attr}</span>}
+                      </div>
+                    </div>
+                    <div class="mt-1 text-[11px] leading-tight font-medium text-gray-800 dark:text-slate-100 line-clamp-2">{card.cardname || '-'}</div>
+                    <div class="text-[10px] text-gray-500 dark:text-slate-400 truncate">{card.name || ''}</div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## 概要

イベント詳細配下に、**金特効・銀特効の衣装をサムネイルで分かりやすく並べた SNS 共有用ページ** `/events/[id]/share/` を新設しました。枠外の「画像をダウンロード」ボタンで、枠内パネルを PNG 画像として保存できます（運営者が X 等に投稿する用途）。

## 変更点

- **新規ルート** `src/pages/events/[id]/share.astro`
  - 既存 `events/[id].astro` と共存する独立ルート。`getStaticPaths()` は既存と同じ `fetchEventsCsv` + `fetchCardsJson` パターンを流用
  - 自己完結パネル: 藍色ヘッダー帯（イベント名 / 種別 / 期間 / サイト名）＋ 金特効・銀特効セクション（サムネ5列グリッド、レアリティ/属性バッジ、衣装名・キャラ名）
  - 銅特効は非掲載。ダークモード対応
- **新規コンポーネント** `src/components/EventShareImage.svelte`（`client:load`）
  - `modern-screenshot` の `domToPng` で `#share-panel` を画像化（`scale: 2` / テーマ連動の背景色）
  - **動的 import** でコード分割し、ボタン押下時のみライブラリを読み込む（初期バンドルを汚さない）
- **依存追加**: `modern-screenshot`
  - Tailwind v4 のデフォルト配色は oklch で出力されるため、独自CSSパーサで oklch を扱えない旧 html2canvas は不採用。ブラウザ自身がCSS描画する SVG `foreignObject` 方式の modern-screenshot を採用

## 確認済み

- `astro check`: 0 errors / 0 warnings
- `npm run build`: 成功（share ルート 84件生成、`modern-screenshot` の動的importチャンクがビルド済み）
- chrome-devtools MCP で `/events/235/share/` のダウンロードを実行し、ライト/ダーク両モードで生成 PNG（1536×2877）の色・バッジ・サムネが忠実に再現されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)