### PR TITLE
fix(ci): 自動採番タグの push で RELEASE_PAT を効かせ deploy を発火させる

### DIFF
--- a/.github/workflows/fetch-event-db.yml
+++ b/.github/workflows/fetch-event-db.yml
@@ -89,6 +89,9 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Latest: $LATEST  ->  New: $NEW_TAG"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # actions/checkout が永続化した GITHUB_TOKEN の認証ヘッダを除去し、RELEASE_PAT で push する。
+          # （GITHUB_TOKEN 由来の push は deploy.yml をトリガーしないため、PAT を確実に使わせる）
+          git config --local --unset-all http."https://github.com/".extraheader 2>/dev/null || true
           git fetch origin main
           git tag "$NEW_TAG" origin/main
           git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-gap-cards.yml
+++ b/.github/workflows/fetch-gap-cards.yml
@@ -132,6 +132,9 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Latest: $LATEST  ->  New: $NEW_TAG"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # actions/checkout が永続化した GITHUB_TOKEN の認証ヘッダを除去し、RELEASE_PAT で push する。
+          # （GITHUB_TOKEN 由来の push は deploy.yml をトリガーしないため、PAT を確実に使わせる）
+          git config --local --unset-all http."https://github.com/".extraheader 2>/dev/null || true
           git fetch origin main
           git tag "$NEW_TAG" origin/main
           git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-new-cards.yml
+++ b/.github/workflows/fetch-new-cards.yml
@@ -177,6 +177,9 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Latest: $LATEST  ->  New: $NEW_TAG"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # actions/checkout が永続化した GITHUB_TOKEN の認証ヘッダを除去し、RELEASE_PAT で push する。
+          # （GITHUB_TOKEN 由来の push は deploy.yml をトリガーしないため、PAT を確実に使わせる）
+          git config --local --unset-all http."https://github.com/".extraheader 2>/dev/null || true
           git fetch origin main
           git tag "$NEW_TAG" origin/main
           git push origin "$NEW_TAG"

--- a/.github/workflows/fetch-new-songs.yml
+++ b/.github/workflows/fetch-new-songs.yml
@@ -78,6 +78,9 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Latest: $LATEST  ->  New: $NEW_TAG"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # actions/checkout が永続化した GITHUB_TOKEN の認証ヘッダを除去し、RELEASE_PAT で push する。
+          # （GITHUB_TOKEN 由来の push は deploy.yml をトリガーしないため、PAT を確実に使わせる）
+          git config --local --unset-all http."https://github.com/".extraheader 2>/dev/null || true
           git fetch origin main
           git tag "$NEW_TAG" origin/main
           git push origin "$NEW_TAG"


### PR DESCRIPTION
## 背景・問題

fetch 系ワークフロー（`fetch-event-db` / `fetch-gap-cards` / `fetch-new-cards` / `fetch-new-songs`）は、データ取得時に PR 自動マージ → patch タグ採番まで動作しているが、**採番したタグの push が `deploy.yml` を発火させていなかった**。

### 根本原因
「Bump tag」ステップは `https://x-access-token:${RELEASE_PAT}@github.com/...` で push しているが、`actions/checkout` が永続化した `GITHUB_TOKEN` の `http.extraheader` が認証で優先されるため、**実質 GITHUB_TOKEN で push** されていた。GitHub は GITHUB_TOKEN 由来の push から他ワークフローを起動しない（再帰防止）ため、タグは作られても `deploy.yml` / `release.yml` が発火しない。push 自体は成功するためステップは success のまま（サイレント故障）。

### 実績調査による裏付け
- 自動タグ `v1.12.1/.2/.3/.6/.7/.8/.9/.10/.14/.15` はいずれも作成済みだが **deploy 実行ゼロ**
- 例: PR #253 → `v1.12.15` は push 成功（`* [new tag] v1.12.15`）も deploy なし
- deploy が走ったのは手動・feature・dependabot 由来タグのみ

## 修正

タグ push 直前に永続化された extraheader を unset し、`RELEASE_PAT` を実際に使わせる:
```bash
git config --local --unset-all http."https://github.com/".extraheader 2>/dev/null || true
```
PR 作成・auto-merge は GITHUB_TOKEN のまま（影響なし）、最後のタグ push のみ PAT を使用する。4 ワークフロー全てに同一修正。

## 検証
- 4 ファイルとも YAML 構文 OK
- マージ後、いずれかの fetch ワークフローを手動実行（`workflow_dispatch`）しデータ取得が発生すれば、採番タグ push → `deploy.yml` 発火を確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)