### PR TITLE
refactor(score): ノートグループキーを型付き定数化し as any を排除

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -21,7 +21,7 @@
   import { loadRabbitNotes } from '../lib/data/rabbitNote';
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
-  import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../lib/data/fetchSongsJson';
+  import { fetchSongsJson, filterValidSongs, filterAllowedSongs, SONG_NOTE_GROUP_KEYS } from '../lib/data/fetchSongsJson';
   import { fetchFixedBroachsJson } from '../lib/data/fetchFixedBroachsJson';
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
   type Props = {
@@ -144,10 +144,9 @@
       _q('song-name-val').textContent = selectedSong.song_name || '-';
       _q('song-artist').textContent = selectedSong.artist || '-';
       _q('song-notes').textContent = (selectedSong.notes_count || 0).toLocaleString();
-      const NOTE_GROUPS: (keyof Song)[] = ['notes_20', 'light_2', 'light_3', 'light_4', 'light_5', 'light_6', 'chorus_light_5', 'chorus_light_6'];
       let sCount = 0, bCount = 0, mCount = 0;
-      for (const gk of NOTE_GROUPS) {
-        const g = selectedSong[gk] as any;
+      for (const gk of SONG_NOTE_GROUP_KEYS) {
+        const g = selectedSong[gk];
         if (!g) continue;
         sCount += (g.shout_white || 0) + (g.shout_color || 0);
         bCount += (g.beat_white || 0) + (g.beat_color || 0);
@@ -310,7 +309,7 @@
     }
 
     function renderDeckSlots() {
-      const slotDummySong = selectedSong || { song_name: '' } as any;
+      const slotDummySong = selectedSong || { song_name: '' };
       const slotResolvedMap = resolveDeckBroachs(deck, allBroachs, slotDummySong);
 
       // 縮小スキルの並び順警告: 発動優先度 メンバー1(idx=1) → センター(idx=0) → メンバー2(idx=2)
@@ -527,7 +526,7 @@
       }
       _q('card-detail-section').classList.remove('hidden');
 
-      const dummySong = selectedSong || { song_name: '' } as any;
+      const dummySong = selectedSong || { song_name: '' };
       const resolvedMap = resolveDeckBroachs(deck, allBroachs, dummySong);
 
       const attrCounts: Record<string, number> = { Shout: 0, Beat: 0, Melody: 0 };
@@ -930,8 +929,9 @@
       let bWhiteWeighted = 0, bColorWeighted = 0;
       let mWhiteWeighted = 0, mColorWeighted = 0;
 
-      for (const [groupKey, mult] of Object.entries(LIGHT_MULTIPLIER)) {
-        const g = (song as any)[groupKey];
+      for (const gk of SONG_NOTE_GROUP_KEYS) {
+        const mult = LIGHT_MULTIPLIER[gk];
+        const g = song[gk];
         if (!g) continue;
         sWhiteWeighted += (g.shout_white || 0) * mult;
         sColorWeighted += (g.shout_color || 0) * mult;

--- a/src/lib/data/fetchSongsJson.ts
+++ b/src/lib/data/fetchSongsJson.ts
@@ -41,6 +41,11 @@ export interface Song {
   [key: string]: string | number | boolean | null | SongNoteGroup;
 }
 
+/** ノートグループの 8 キー（ステージ進行順）。LIGHT_MULTIPLIER (score/constants.ts) のキー順と一致 */
+export const SONG_NOTE_GROUP_KEYS = [
+  'notes_20', 'light_2', 'light_3', 'light_4', 'light_5', 'light_6', 'chorus_light_5', 'chorus_light_6',
+] as const;
+
 const SONGS_GID = 1083871743;
 
 // フラットカラム定義 (col index → key)

--- a/src/lib/score/broachResolver.ts
+++ b/src/lib/score/broachResolver.ts
@@ -61,7 +61,7 @@ function countIdolAttrMatch(deck: (Card | null)[], idol: string, attribute: stri
 function checkBroachCondition(
   broach: FixedBroach,
   deck: (Card | null)[],
-  song: Song,
+  song: Pick<Song, 'song_name'>,
 ): boolean {
   const type = broach.broach_type;
 
@@ -106,7 +106,7 @@ function checkBroachCondition(
 export function resolveDeckBroachs(
   deck: (Card | null)[],
   allBroachs: FixedBroach[],
-  song: Song,
+  song: Pick<Song, 'song_name'>,
   selectedBroachIds?: (number | null)[],
 ): Map<number, ResolvedBroach[]> {
   const result = new Map<number, ResolvedBroach[]>();


### PR DESCRIPTION
Phase 1.2。SONG_NOTE_GROUP_KEYS 定数を導入し、ScoreCalc の as any 4 箇所を排除。broachResolver の song 引数を Pick<Song, 'song_name'> に縮小。型のみの変更で振る舞い不変（typecheck / unit 217 / E2E 9 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)