### PR TITLE
refactor(score): loadJson 二重 import と EventBonusTier re-export を整理

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -17,7 +17,6 @@
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
   import { ATTR_TEXT_CLASS, cardThumbUrl } from '../lib/ui';
   import { SHARED_BROACHS } from '../lib/data/sharedBroachs';
-  import { loadJson as loadStorageJson } from '../lib/storage';
   import { loadRabbitNotes } from '../lib/data/rabbitNote';
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
@@ -38,7 +37,7 @@
 
   // カード所持数のヘルパ（cardListRenderer由来の関数と同等）
   function loadCounts(): Record<string, number> {
-    return loadStorageJson<Record<string, number>>(STORAGE_KEYS.CARD_COUNTS, {});
+    return loadJson<Record<string, number>>(STORAGE_KEYS.CARD_COUNTS, {});
   }
 
   onMount(() => {

--- a/src/lib/score/constants.ts
+++ b/src/lib/score/constants.ts
@@ -34,4 +34,3 @@ export const TRAIN_BONUS: Record<string, number> = {
 };
 
 export { EVENT_BONUS_MULTIPLIER } from '../data/eventBonusTiers';
-export type { EventBonusTier } from '../data/eventBonusTiers';

--- a/src/lib/score/engine.ts
+++ b/src/lib/score/engine.ts
@@ -14,7 +14,7 @@ import {
   MC_CHUNK_SIZE, CENTER_SKILL_RATES, DEFAULT_CENTER_SKILL_RATE,
   EVENT_BONUS_MULTIPLIER, TRAIN_BONUS,
 } from './constants';
-import type { EventBonusTier } from './constants';
+import type { EventBonusTier } from '../data/eventBonusTiers';
 import { XorShift128Plus } from './rng';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
 import { SKILL_TYPE } from '../data/fetchCardsJson';


### PR DESCRIPTION
Phase 1.4。ScoreCalc の loadJson 二重 import を解消し、score/constants.ts の EventBonusTier 型 re-export を廃止（engine.ts は eventBonusTiers から直接 import）。振る舞い不変（typecheck / unit 217 / E2E 9 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)