### PR TITLE
refactor(ui): 属性/レアリティバッジを共通コンポーネント化

### DIFF
--- a/src/components/DeckList.svelte
+++ b/src/components/DeckList.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import type { Card } from '../lib/data/fetchCardsJson';
   import type { Song } from '../lib/data/fetchSongsJson';
-  import { RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../lib/constants';
   import { normalizeAttribute } from '../lib/score/types';
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
   import { cardThumbUrl } from '../lib/ui';
+  import RarityBadge from './ui/RarityBadge.svelte';
+  import AttributeBadge from './ui/AttributeBadge.svelte';
 
   type Props = {
     cards: Card[];
@@ -109,14 +110,12 @@
             {@const labelClass = i === 0 ? 'text-indigo-600 font-bold' : i === 5 ? 'text-amber-600 font-bold' : 'text-gray-500'}
             {#if card}
               {@const attr = normalizeAttribute(card.attribute)}
-              {@const rarityClass = RARITY_BADGE_CLASSES[card.rarity || ''] || 'bg-gray-300'}
-              {@const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300'}
               <div class="flex flex-col items-center">
                 <div class="text-[9px] {labelClass} mb-0.5">{label}</div>
                 <img src={cardThumbUrl(card.ID!)} alt={card.cardname || ''} class="w-10 h-auto rounded" loading="lazy" />
                 <div class="flex gap-0.5 mt-0.5">
-                  <span class="px-0.5 py-px text-[7px] font-bold text-white rounded {rarityClass}">{card.rarity || '?'}</span>
-                  <span class="px-0.5 py-px text-[7px] font-bold text-white rounded {attrBgClass}">{attr}</span>
+                  <RarityBadge rarity={card.rarity} sizeClass="px-0.5 py-px text-[7px]" fallbackLabel="?" />
+                  <AttributeBadge attribute={attr} sizeClass="px-0.5 py-px text-[7px]" />
                 </div>
                 <div class="text-[8px] text-gray-500 dark:text-slate-400 truncate max-w-[60px] text-center" title={card.cardname || ''}>{card.cardname || ''}</div>
               </div>

--- a/src/components/MaxScoreFinder.svelte
+++ b/src/components/MaxScoreFinder.svelte
@@ -22,7 +22,9 @@
   import { resolveDeckBroachs } from '../lib/score/broachResolver';
   import { buildLiveTierMap, isEventLive, BONUS_LABEL, BONUS_CLASS } from '../lib/data/eventBonusTiers';
   import type { EventBonusTier, EventForBonus } from '../lib/data/eventBonusTiers';
-  import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../lib/constants';
+  import { ATTR_HEX } from '../lib/constants';
+  import RarityBadge from './ui/RarityBadge.svelte';
+  import AttributeBadge from './ui/AttributeBadge.svelte';
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
   import { cardThumbUrl } from '../lib/ui';
   import { loadRabbitNotes } from '../lib/data/rabbitNote';
@@ -554,8 +556,6 @@
           {#if card}
             {@const attr = normalizeAttribute(card.attribute)}
             {@const attrColor = ATTR_HEX[attr] || '#6b7280'}
-            {@const rarityClass = RARITY_BADGE_CLASSES[card.rarity || ''] || 'bg-gray-300'}
-            {@const attrBgClass = ATTR_BADGE_BG[attr] || 'bg-gray-300'}
             {@const tier = currentTierMap.get(card.ID!) ?? 'none'}
             {@const bonusLabel = BONUS_LABEL[tier]}
             {@const bonusClass = BONUS_CLASS[tier]}
@@ -566,8 +566,8 @@
               <div class="border-2 rounded-lg p-1.5 flex flex-col items-center min-h-[120px]" style="border-color:{attrColor}">
                 <img src={cardThumbUrl(card.ID!)} alt={card.cardname || ''} class="w-full max-w-[60px] h-auto rounded mb-1" loading="lazy" />
                 <div class="flex gap-0.5 mb-1">
-                  <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded {rarityClass}">{card.rarity || '?'}</span>
-                  <span class="px-1 py-0.5 text-[9px] font-bold text-white rounded {attrBgClass}">{attr}</span>
+                  <RarityBadge rarity={card.rarity} sizeClass="px-1 py-0.5 text-[9px]" fallbackLabel="?" />
+                  <AttributeBadge attribute={attr} sizeClass="px-1 py-0.5 text-[9px]" />
                 </div>
                 <div class="text-[9px] text-gray-600 dark:text-slate-300 text-center truncate w-full" title={card.cardname || ''}>{card.cardname || ''}</div>
                 <div class="text-[8px] text-gray-400 dark:text-slate-500 text-center">{card.name || ''}</div>

--- a/src/components/cards/CardMobileCard.svelte
+++ b/src/components/cards/CardMobileCard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import type { CardListItem } from '../../lib/cardListData';
-  import { ATTR_BADGE_BG, ATTR_BG, ATTR_HEX, RARITY_BADGE_CLASSES } from '../../lib/constants';
+  import { ATTR_BG, ATTR_HEX } from '../../lib/constants';
   import { EVENT_BONUS_TIERS, type EventBonusTier } from '../../lib/data/eventBonusTiers';
   import { ATTR_TEXT_CLASS } from '../../lib/ui';
   import { attrDonutSvg } from '../../lib/donutChart';
   import CountInput from './CountInput.svelte';
+  import RarityBadge from '../ui/RarityBadge.svelte';
+  import AttributeBadge from '../ui/AttributeBadge.svelte';
 
   type Props = {
     card: CardListItem;
@@ -58,12 +60,8 @@
     </div>
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-1 mb-1">
-        <span class="inline-block px-1.5 py-0.5 text-xs font-bold text-white rounded {RARITY_BADGE_CLASSES[card.rarity] || 'bg-gray-300'}">
-          {card.rarity}
-        </span>
-        <span class="inline-block px-1.5 py-0.5 text-xs font-bold text-white rounded {ATTR_BADGE_BG[card.attribute] || 'bg-gray-300'}">
-          {card.attribute || '?'}
-        </span>
+        <RarityBadge rarity={card.rarity} sizeClass="inline-block px-1.5 py-0.5 text-xs" />
+        <AttributeBadge attribute={card.attribute} sizeClass="inline-block px-1.5 py-0.5 text-xs" />
         {#if bonusDef}
           <span class="inline-block px-1.5 py-0.5 text-xs font-bold rounded border {bonusDef.selectClasses.join(' ')}">
             {bonusDef.shortLabel}

--- a/src/components/cards/CardTableRow.svelte
+++ b/src/components/cards/CardTableRow.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { CardListItem } from '../../lib/cardListData';
-  import { ATTR_BADGE_BG, ATTR_BG, ATTR_BG_HOVER, ATTR_HEX, RARITY_BADGE_CLASSES } from '../../lib/constants';
+  import { ATTR_BG, ATTR_BG_HOVER, ATTR_HEX } from '../../lib/constants';
   import { EVENT_BONUS_TIERS, type EventBonusTier } from '../../lib/data/eventBonusTiers';
   import { attrDonutSvg } from '../../lib/donutChart';
   import CountInput from './CountInput.svelte';
+  import RarityBadge from '../ui/RarityBadge.svelte';
+  import AttributeBadge from '../ui/AttributeBadge.svelte';
 
   type Props = {
     card: CardListItem;
@@ -83,14 +85,10 @@
   </td>
   <td class="px-3 py-2">{card.name || ''}</td>
   <td class="px-3 py-2">
-    <span class="inline-block px-1.5 py-0.5 text-xs font-bold text-white rounded {RARITY_BADGE_CLASSES[card.rarity] || 'bg-gray-300'}">
-      {card.rarity}
-    </span>
+    <RarityBadge rarity={card.rarity} sizeClass="inline-block px-1.5 py-0.5 text-xs" />
   </td>
   <td class="px-3 py-2">
-    <span class="inline-block px-1.5 py-0.5 text-xs font-bold text-white rounded {ATTR_BADGE_BG[card.attribute] || 'bg-gray-300'}">
-      {card.attribute || '?'}
-    </span>
+    <AttributeBadge attribute={card.attribute} sizeClass="inline-block px-1.5 py-0.5 text-xs" />
   </td>
   {#if showBonusCell}
     <td class="px-3 py-2 bonus-cell">

--- a/src/components/cards/CardTileCard.svelte
+++ b/src/components/cards/CardTileCard.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import type { CardListItem } from '../../lib/cardListData';
-  import { ATTR_BADGE_BG, ATTR_HEX, RARITY_BADGE_CLASSES } from '../../lib/constants';
+  import { ATTR_HEX } from '../../lib/constants';
   import { EVENT_BONUS_TIERS, type EventBonusTier } from '../../lib/data/eventBonusTiers';
   import CountInput from './CountInput.svelte';
+  import RarityBadge from '../ui/RarityBadge.svelte';
+  import AttributeBadge from '../ui/AttributeBadge.svelte';
 
   type Props = {
     card: CardListItem;
@@ -47,12 +49,8 @@
   </button>
   <div class="p-2 flex flex-col gap-1 flex-1">
     <div class="flex flex-wrap items-center gap-1">
-      <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold text-white rounded {RARITY_BADGE_CLASSES[card.rarity] || 'bg-gray-300'}">
-        {card.rarity}
-      </span>
-      <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold text-white rounded {ATTR_BADGE_BG[card.attribute] || 'bg-gray-300'}">
-        {card.attribute || '?'}
-      </span>
+      <RarityBadge rarity={card.rarity} sizeClass="inline-block px-1.5 py-0.5 text-[10px]" />
+      <AttributeBadge attribute={card.attribute} sizeClass="inline-block px-1.5 py-0.5 text-[10px]" />
       {#if bonusDef}
         <span class="inline-block px-1.5 py-0.5 text-[10px] font-bold rounded border {bonusDef.selectClasses.join(' ')}">
           {bonusDef.shortLabel}

--- a/src/components/ui/AttributeBadge.svelte
+++ b/src/components/ui/AttributeBadge.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { ATTR_BADGE_BG } from '../../lib/constants';
+
+  let { attribute, sizeClass, fallbackLabel = '?' }: {
+    attribute: string | null | undefined;
+    /** px/py/text サイズ系クラス（呼び出し元の既存表示を踏襲） */
+    sizeClass: string;
+    fallbackLabel?: string;
+  } = $props();
+</script>
+
+<span class="{sizeClass} font-bold text-white rounded {ATTR_BADGE_BG[attribute || ''] || 'bg-gray-300'}">
+  {attribute || fallbackLabel}
+</span>

--- a/src/components/ui/RarityBadge.svelte
+++ b/src/components/ui/RarityBadge.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { RARITY_BADGE_CLASSES } from '../../lib/constants';
+
+  let { rarity, sizeClass, fallbackLabel = '' }: {
+    rarity: string | null | undefined;
+    /** px/py/text サイズ系クラス（呼び出し元の既存表示を踏襲） */
+    sizeClass: string;
+    fallbackLabel?: string;
+  } = $props();
+</script>
+
+<span class="{sizeClass} font-bold text-white rounded {RARITY_BADGE_CLASSES[rarity || ''] || 'bg-gray-300'}">
+  {rarity || fallbackLabel}
+</span>


### PR DESCRIPTION
Phase 1.3。RarityBadge / AttributeBadge を src/components/ui/ に新設し、CardTableRow / CardTileCard / CardMobileCard / DeckList / MaxScoreFinder の計 10 バッジを置換。描画される class 集合・ラベルは完全一致（実 DOM 検証済み）。EventBonusCardGrid（フォールバック色違い）と文字列レンダラー（ScoreCalc / EventSharePanel、Phase 2 対応）は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)