### PR TITLE
refactor(cards): 衣装名/キャラ名検索の述語を cardFilter に共通化

### DIFF
--- a/src/components/CardList.svelte
+++ b/src/components/CardList.svelte
@@ -5,6 +5,7 @@
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
+  import { cardTextMatches } from '../lib/cardFilter';
   import CardTableRow from './cards/CardTableRow.svelte';
   import CardMobileCard from './cards/CardMobileCard.svelte';
   import CardTileCard from './cards/CardTileCard.svelte';
@@ -41,7 +42,7 @@
   const filtered = $derived.by(() => {
     const t = text.toLowerCase();
     let result = allCards.filter((card) => {
-      if (t && !(card.cardname || '').toLowerCase().includes(t) && !(card.name || '').toLowerCase().includes(t)) return false;
+      if (!cardTextMatches(card, t)) return false;
       if (raritySet.size && !raritySet.has(card.rarity)) return false;
       if (attributeSet.size && !attributeSet.has(card.attribute)) return false;
       if (characterSet.size && !characterSet.has(card.name)) return false;

--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -20,6 +20,7 @@
   import { loadRabbitNotes } from '../lib/data/rabbitNote';
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
+  import { cardTextMatches } from '../lib/cardFilter';
   import { fetchSongsJson, filterValidSongs, filterAllowedSongs, SONG_NOTE_GROUP_KEYS } from '../lib/data/fetchSongsJson';
   import { fetchFixedBroachsJson } from '../lib/data/fetchFixedBroachsJson';
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
@@ -744,11 +745,7 @@
 
       let filtered = allCards.filter(card => {
         if (ownedOnly && !(counts[String(card.ID)] >= 1)) return false;
-        if (text) {
-          const name = (card.cardname || '').toLowerCase();
-          const charName = (card.name || '').toLowerCase();
-          if (!name.includes(text) && !charName.includes(text)) return false;
-        }
+        if (!cardTextMatches(card, text)) return false;
         if (rarity && card.rarity !== rarity) return false;
         if (attribute && normalizeAttribute(card.attribute) !== attribute) return false;
         return true;

--- a/src/lib/cardFilter.ts
+++ b/src/lib/cardFilter.ts
@@ -1,0 +1,12 @@
+/**
+ * 衣装名(cardname)・キャラ名(name) の部分一致検索。
+ * query は呼び出し元で小文字化済みのものを渡す。空文字なら常に true。
+ */
+export function cardTextMatches(
+  card: { cardname: string | null; name: string | null },
+  lowerQuery: string,
+): boolean {
+  if (!lowerQuery) return true;
+  return (card.cardname || '').toLowerCase().includes(lowerQuery)
+    || (card.name || '').toLowerCase().includes(lowerQuery);
+}

--- a/tests/unit/cardFilter.test.ts
+++ b/tests/unit/cardFilter.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { cardTextMatches } from '../../src/lib/cardFilter';
+
+describe('cardTextMatches (衣装名/キャラ名の部分一致検索)', () => {
+  const card = { cardname: 'MEMORiES MELODiES', name: '七瀬陸' };
+
+  it('空クエリは常にマッチ', () => {
+    expect(cardTextMatches(card, '')).toBe(true);
+  });
+
+  it('衣装名の部分一致 (小文字化して比較)', () => {
+    expect(cardTextMatches(card, 'memories')).toBe(true);
+  });
+
+  it('キャラ名の部分一致', () => {
+    expect(cardTextMatches(card, '七瀬')).toBe(true);
+  });
+
+  it('どちらにも含まれなければ不一致', () => {
+    expect(cardTextMatches(card, 'trigger')).toBe(false);
+  });
+
+  it('cardname/name が null でも落ちない', () => {
+    expect(cardTextMatches({ cardname: null, name: null }, 'x')).toBe(false);
+    expect(cardTextMatches({ cardname: null, name: null }, '')).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 1.5（縮小スコープ）。CardList と ScoreCalc ピッカーで同一実装だった名前検索述語を src/lib/cardFilter.ts に抽出（単体テスト 5 件付き）。レアリティ・属性フィルタは両者で意味論が異なる（Set 複数選択 vs 単一値・正規化）ため対象外。振る舞い不変（typecheck / unit 222 / E2E 9 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)