### PR TITLE
refactor(score-calc): 計算結果表示を ScoreCalcResults に抽出 (Runes 化)

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -3,25 +3,22 @@
   import type { Card } from '../lib/data/fetchCardsJson';
   import type { Song } from '../lib/data/fetchSongsJson';
   import type { FixedBroach } from '../lib/data/fetchFixedBroachsJson';
-  import type { ComputedTeam, SimulationResult, ScoreOptions, FlatNote } from '../lib/score/types';
-  import { computeTeam, calcMinScore, calcMaxScore, calcShrinkCoverage, calcExpectedScore, calcCardSkillExpected, calcCardSkillMax, calcCardSkillMaxActivations, runSimulation, flattenNotes, computeShrinkExclusion, computeGroupSizes } from '../lib/score/engine';
-  import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER } from '../lib/score/constants';
   import { buildLiveTierMap } from '../lib/data/eventBonusTiers';
   import type { EventBonusTier, EventForBonus } from '../lib/data/eventBonusTiers';
-  import { renderHistogramSvg } from '../lib/score/histogram';
   import { attrDonutSvg } from '../lib/donutChart';
   import { ATTR_HEX } from '../lib/constants';
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
-  import { loadRabbitNotes } from '../lib/data/rabbitNote';
   import { refreshData } from '../lib/data/clientRefresh';
   import { fetchCardsJson } from '../lib/data/fetchCardsJson';
   import { fetchSongsJson, filterValidSongs, filterAllowedSongs, SONG_NOTE_GROUP_KEYS } from '../lib/data/fetchSongsJson';
   import { fetchFixedBroachsJson } from '../lib/data/fetchFixedBroachsJson';
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
-  import { createEmptyDeckState, swapSlots, clampSharedBroachs, setCard, clearSlot, SLOT_LABELS, DISPLAY_ORDER } from '../lib/score/deckState';
+  import { createEmptyDeckState, swapSlots, clampSharedBroachs, setCard, clearSlot, SLOT_LABELS } from '../lib/score/deckState';
+  import { DEFAULT_SCOREUP_BADGE_RATE } from '../lib/score/constants';
   import CardPickerModal from './score/CardPickerModal.svelte';
   import DeckSlots from './score/DeckSlots.svelte';
   import CardDetailTable from './score/CardDetailTable.svelte';
+  import ScoreCalcResults from './score/ScoreCalcResults.svelte';
   type Props = {
     cards: Card[];
     songs: Song[];
@@ -37,19 +34,50 @@
   let allBroachsState = $state<FixedBroach[]>(initialBroachs);
   let selectedSong = $state<Song | null>(null);
 
+  // スキルオプション
+  let scoreUpAssist = $state(false);
+  let scoreUpBadgeRate = $state(DEFAULT_SCOREUP_BADGE_RATE);
+
   let rootEl: HTMLDivElement;
   let picker: CardPickerModal | undefined;
+
+  // 楽曲サマリー表示用の派生値
+  const songAttrCounts = $derived.by(() => {
+    if (!selectedSong) return null;
+    let s = 0, b = 0, m = 0;
+    for (const gk of SONG_NOTE_GROUP_KEYS) {
+      const g = selectedSong[gk];
+      if (!g) continue;
+      s += (g.shout_white || 0) + (g.shout_color || 0);
+      b += (g.beat_white || 0) + (g.beat_color || 0);
+      m += (g.melody_white || 0) + (g.melody_color || 0);
+    }
+    return { s, b, m };
+  });
+  const songChartSvg = $derived(
+    selectedSong
+      ? attrDonutSvg(selectedSong.shout_ratio || 0, selectedSong.beat_ratio || 0, selectedSong.melody_ratio || 0, { sizeClass: 'w-20 h-20' })
+      : ''
+  );
+
+  // 保存デッキ読込ドロップダウン（null = 閉じている）
+  type LoadDeckItem = { id: string; name: string; dateLabel: string; cardCount: number };
+  let loadDeckItems = $state<LoadDeckItem[] | null>(null);
 
   // ピッカー / DeckSlots のコールバック実体は onMount 閉包内で代入される
   let handlePickImpl: (slot: number, card: Card) => void = () => {};
   let handleClearImpl: (slot: number) => void = () => {};
   let handleSwapImpl: (a: number, b: number) => void = () => {};
   let handleDeckChangedImpl: () => void = () => {};
+  let saveStateImpl: () => void = () => {};
+  let loadDeckImpl: (id: string) => void = () => {};
   function handlePick(slot: number, card: Card) { handlePickImpl(slot, card); }
   function handleClear(slot: number) { handleClearImpl(slot); }
   function handleSlotClick(slot: number) { picker!.open(slot, SLOT_LABELS[slot]); }
   function handleSwap(a: number, b: number) { handleSwapImpl(a, b); }
   function handleDeckChanged() { handleDeckChangedImpl(); }
+  function handleBadgeRateInput() { saveStateImpl(); }
+  function handleLoadDeckClick(id: string) { loadDeckImpl(id); }
 
   onMount(() => {
     let allSongs: Song[] = initialSongs;
@@ -64,25 +92,22 @@
 
     const _q = <T extends HTMLElement = HTMLElement>(id: string): T => rootEl.querySelector<T>(`#${id}`) as T;
 
-    let simulationResult: SimulationResult | null = null;
-
     handlePickImpl = (slot, card) => {
       setCard(deckState, slot, card, defaultTierFor(card), allBroachsState);
-      recalculate();
       saveState();
     };
     handleClearImpl = (slot) => {
       clearSlot(deckState, slot);
-      recalculate();
       saveState();
     };
     handleSwapImpl = (a, b) => {
       swapSlots(deckState, a, b);
-      recalculate();
       saveState();
     };
     handleDeckChangedImpl = () => {
-      recalculate();
+      saveState();
+    };
+    saveStateImpl = () => {
       saveState();
     };
 
@@ -133,322 +158,11 @@
       sel.addEventListener('change', () => {
         const id = Number(sel.value);
         selectedSong = allSongs.find(s => s.id === id) || null;
-        renderSongInfo();
-        recalculate();
         saveState();
       });
     }
 
-    function renderSongInfo() {
-      const info = _q('song-info');
-      if (!selectedSong) {
-        info.classList.add('hidden');
-        _q('area-values-section').classList.add('hidden');
-        return;
-      }
-      info.classList.remove('hidden');
-      _q('song-type').textContent = selectedSong.song_type || '-';
-      _q('song-name-val').textContent = selectedSong.song_name || '-';
-      _q('song-artist').textContent = selectedSong.artist || '-';
-      _q('song-notes').textContent = (selectedSong.notes_count || 0).toLocaleString();
-      let sCount = 0, bCount = 0, mCount = 0;
-      for (const gk of SONG_NOTE_GROUP_KEYS) {
-        const g = selectedSong[gk];
-        if (!g) continue;
-        sCount += (g.shout_white || 0) + (g.shout_color || 0);
-        bCount += (g.beat_white || 0) + (g.beat_color || 0);
-        mCount += (g.melody_white || 0) + (g.melody_color || 0);
-      }
-      _q('song-attr-counts').innerHTML = `<span style="color:${ATTR_HEX.Shout}">🔴${sCount}</span> <span style="color:${ATTR_HEX.Beat}">🟢${bCount}</span> <span style="color:${ATTR_HEX.Melody}">🔵${mCount}</span>`;
-      _q('song-duration-val').textContent = `${selectedSong.duration || '-'}秒`;
-
-      const sr = selectedSong.shout_ratio || 0;
-      const br = selectedSong.beat_ratio || 0;
-      const mr = selectedSong.melody_ratio || 0;
-      _q('song-chart').innerHTML = attrDonutSvg(sr, br, mr, { sizeClass: 'w-20 h-20' });
-      _q('song-ratios').innerHTML = `
-        <div style="color:${ATTR_HEX.Shout}">Shout: ${Math.round(sr * 100)}%</div>
-        <div style="color:${ATTR_HEX.Beat}">Beat: ${Math.round(br * 100)}%</div>
-        <div style="color:${ATTR_HEX.Melody}">Melody: ${Math.round(mr * 100)}%</div>
-      `;
-
-      const anchor = _q<HTMLAnchorElement>('song-detail-anchor');
-      anchor.href = `${base}songs/${selectedSong.id}/`;
-    }
-
-    function recalculate() {
-      updateCalcButton();
-      const filledCards = deckState.cards.filter(c => c !== null);
-      if (!selectedSong || filledCards.length === 0) {
-        _q('score-breakdown').classList.add('hidden');
-        _q('area-values-section').classList.add('hidden');
-        _q('mc-results').classList.add('hidden');
-        _q('expected-score').classList.add('hidden');
-        _q('skill-stats').classList.add('hidden');
-        _q('shrink-coverage-row').classList.add('hidden');
-        _q('shrink-expected-row').classList.add('hidden');
-        _q('skill-per-card-section').classList.add('hidden');
-        _q('final-result').textContent = '---';
-        simulationResult = null;
-        return;
-      }
-
-      const team = computeTeam(deckState.cards, allBroachsState, selectedSong, deckState.bonusTiers, deckState.trained, undefined, deckState.sharedBroachs, deckState.skillLevels, loadRabbitNotes());
-      const exclusion = computeShrinkExclusion(team, computeGroupSizes(selectedSong));
-      const notes = flattenNotes(selectedSong, 42, exclusion);
-
-      _q('score-breakdown').classList.remove('hidden');
-
-      const scoreOptions: ScoreOptions = {
-        scoreUpAssist: _q<HTMLInputElement>('opt-scoreup-assist').checked,
-        scoreUpBadgeRate: parseFloat(_q<HTMLInputElement>('opt-scoreup-badge-rate').value) || 0,
-      };
-
-      const minScore = calcMinScore(team, notes, scoreOptions);
-      const maxScore = calcMaxScore(team, notes, scoreOptions);
-      _q('score-min').textContent = minScore.toLocaleString();
-      _q('score-max').textContent = maxScore.toLocaleString();
-
-      updateShrinkCoverage(team, selectedSong);
-
-      renderSkillPerCard(team, notes, selectedSong.notes_count || 0, scoreOptions);
-
-      renderAreaValues(team, selectedSong);
-
-      _q('mc-results').classList.add('hidden');
-      _q('expected-score').classList.add('hidden');
-      _q('skill-stats').classList.add('hidden');
-      _q('final-result').textContent = '---';
-      simulationResult = null;
-
-    }
-
-    function renderSkillPerCard(team: ComputedTeam, notes: FlatNote[], notesCount: number, options: ScoreOptions) {
-      const rows: string[] = [];
-      let totalExp = 0;
-      let totalMax = 0;
-      let totalActivations = 0;
-      for (const i of DISPLAY_ORDER) {
-        const card = deckState.cards[i];
-        if (!card) continue;
-        const exp = calcCardSkillExpected(team, notes, notesCount, i, options);
-        const max = calcCardSkillMax(team, notes, notesCount, i, options);
-        const activations = calcCardSkillMaxActivations(team, notesCount, i);
-        totalExp += exp;
-        totalMax += max;
-        totalActivations += activations;
-        const slotCls = i === 0 ? 'text-indigo-600 font-bold' : i === 5 ? 'text-amber-600 font-bold' : 'text-gray-500';
-        rows.push(`<tr class="border-t">
-          <td class="py-1 px-1 text-[10px] ${slotCls}">${SLOT_LABELS[i]}</td>
-          <td class="py-1 px-1">
-            <div>${card.cardname || ''}</div>
-            <div class="text-[10px] text-gray-400 dark:text-slate-500">${card.name || ''}</div>
-          </td>
-          <td class="py-1 px-1">${card.ap_skill_type || '-'}</td>
-          <td class="py-1 px-1 text-right">${exp > 0 ? exp.toLocaleString() : '-'}</td>
-          <td class="py-1 px-1 text-right">${activations > 0 ? activations.toLocaleString() : '-'}</td>
-          <td class="py-1 px-1 text-right">${max > 0 ? max.toLocaleString() : '-'}</td>
-        </tr>`);
-      }
-      if (rows.length === 0) {
-        _q('skill-per-card-section').classList.add('hidden');
-        return;
-      }
-      _q('skill-per-card-section').classList.remove('hidden');
-      _q('skill-per-card-body').innerHTML = rows.join('');
-      _q('skill-per-card-foot').innerHTML = `<tr class="border-t-2 border-gray-300 dark:border-slate-600 font-bold">
-        <td colspan="3" class="py-1 px-1 text-right text-gray-700 dark:text-slate-200">合計</td>
-        <td class="py-1 px-1 text-right">${totalExp.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right">${totalActivations.toLocaleString()}</td>
-        <td class="py-1 px-1 text-right">${totalMax.toLocaleString()}</td>
-      </tr>`;
-    }
-
-    function updateShrinkCoverage(team: ComputedTeam, song: Song) {
-      const offset = Number(_q<HTMLInputElement>('shrink-offset-input').value) || 0;
-      const exclusion = computeShrinkExclusion(team, computeGroupSizes(song));
-
-      const noteEl = _q('shrink-exclusion-note');
-      const countEl = _q('shrink-exclusion-count');
-      if (exclusion.totalExcluded > 0) {
-        countEl.textContent = String(exclusion.totalExcluded);
-        noteEl.classList.remove('hidden');
-      } else {
-        noteEl.classList.add('hidden');
-      }
-
-      const shrinkCoverage = calcShrinkCoverage(team, song.notes_count || 0, offset, exclusion.totalExcluded);
-      if (shrinkCoverage) {
-        _q('shrink-coverage-row').classList.remove('hidden');
-        _q('shrink-expected-row').classList.remove('hidden');
-        _q('shrink-offset-row').classList.remove('hidden');
-        const rawPct = (shrinkCoverage.rawCoverageRate * 100).toFixed(1);
-        const rawText = `${rawPct}%（${shrinkCoverage.rawCoveredSeconds.toFixed(1)}秒 / ${shrinkCoverage.effectiveSeconds.toFixed(1)}秒）`;
-        _q('shrink-coverage-val').textContent = shrinkCoverage.rawCoverageRate > 1.0
-          ? `${rawText} ※100%超過分は計算対象外`
-          : rawText;
-        const rawExpPct = (shrinkCoverage.rawExpectedCoverageRate * 100).toFixed(1);
-        const rawExpText = `${rawExpPct}%（${shrinkCoverage.rawExpectedCoveredSeconds.toFixed(1)}秒 / ${shrinkCoverage.effectiveSeconds.toFixed(1)}秒）`;
-        const hasOverlapCorrection =
-          Math.abs(shrinkCoverage.rawExpectedCoverageRate - shrinkCoverage.expectedCoverageRate) > 0.001;
-        _q('shrink-expected-val').textContent = hasOverlapCorrection
-          ? `${rawExpText} ※重複区間で確率合成により実効カバー率は低下`
-          : rawExpText;
-      } else {
-        _q('shrink-coverage-row').classList.add('hidden');
-        _q('shrink-expected-row').classList.add('hidden');
-        _q('shrink-offset-row').classList.add('hidden');
-      }
-    }
-
-    function renderAreaValues(team: ComputedTeam, song: Song) {
-      _q('area-values-section').classList.remove('hidden');
-
-      let sWhiteWeighted = 0, sColorWeighted = 0;
-      let bWhiteWeighted = 0, bColorWeighted = 0;
-      let mWhiteWeighted = 0, mColorWeighted = 0;
-
-      for (const gk of SONG_NOTE_GROUP_KEYS) {
-        const mult = LIGHT_MULTIPLIER[gk];
-        const g = song[gk];
-        if (!g) continue;
-        sWhiteWeighted += (g.shout_white || 0) * mult;
-        sColorWeighted += (g.shout_color || 0) * mult;
-        bWhiteWeighted += (g.beat_white || 0) * mult;
-        bColorWeighted += (g.beat_color || 0) * mult;
-        mWhiteWeighted += (g.melody_white || 0) * mult;
-        mColorWeighted += (g.melody_color || 0) * mult;
-      }
-
-      const sArea = { white: Math.floor(team.Shout * NOTE_RATE.white * sWhiteWeighted), color: Math.floor(team.Shout * NOTE_RATE.color * sColorWeighted) };
-      const bArea = { white: Math.floor(team.Beat * NOTE_RATE.white * bWhiteWeighted), color: Math.floor(team.Beat * NOTE_RATE.color * bColorWeighted) };
-      const mArea = { white: Math.floor(team.Melody * NOTE_RATE.white * mWhiteWeighted), color: Math.floor(team.Melody * NOTE_RATE.color * mColorWeighted) };
-
-      _q('area-s-white').textContent = sArea.white.toLocaleString();
-      _q('area-s-color').textContent = sArea.color.toLocaleString();
-      _q('area-s-total').textContent = (sArea.white + sArea.color).toLocaleString();
-      _q('area-b-white').textContent = bArea.white.toLocaleString();
-      _q('area-b-color').textContent = bArea.color.toLocaleString();
-      _q('area-b-total').textContent = (bArea.white + bArea.color).toLocaleString();
-      _q('area-m-white').textContent = mArea.white.toLocaleString();
-      _q('area-m-color').textContent = mArea.color.toLocaleString();
-      _q('area-m-total').textContent = (mArea.white + mArea.color).toLocaleString();
-    }
-
-    async function runMC() {
-      if (!selectedSong || deckState.cards.filter(c => c !== null).length === 0) return;
-
-      const btn = _q<HTMLButtonElement>('btn-calculate');
-      btn.disabled = true;
-      btn.textContent = '計算中...';
-      _q('progress-container').classList.remove('hidden');
-
-      const team = computeTeam(deckState.cards, allBroachsState, selectedSong, deckState.bonusTiers, deckState.trained, undefined, deckState.sharedBroachs, deckState.skillLevels, loadRabbitNotes());
-      const exclusion = computeShrinkExclusion(team, computeGroupSizes(selectedSong));
-      const notes = flattenNotes(selectedSong, 42, exclusion);
-
-      const iterations = Math.max(1, Math.floor(Number(_q<HTMLInputElement>('mc-iterations-input').value) || MC_ITERATIONS));
-
-      const scoreOptions: ScoreOptions = {
-        scoreUpAssist: _q<HTMLInputElement>('opt-scoreup-assist').checked,
-        scoreUpBadgeRate: parseFloat(_q<HTMLInputElement>('opt-scoreup-badge-rate').value) || 0,
-        maxShrinkCoverage: _q<HTMLInputElement>('opt-max-shrink-coverage').checked,
-        maxScoreUpCoverage: _q<HTMLInputElement>('opt-max-scoreup-coverage').checked,
-      };
-
-      const result = await runSimulation(team, notes, iterations, (pct) => {
-        const percent = Math.round(pct * 100);
-        _q<HTMLElement>('progress-bar').style.width = `${percent}%`;
-        _q('progress-text').textContent = `計算中... ${percent}%`;
-      }, undefined, scoreOptions);
-
-      simulationResult = result;
-
-      _q('final-result').textContent = result.mean.toLocaleString();
-
-      _q('mc-results').classList.remove('hidden');
-      _q('mc-min-bound').textContent = result.minScore.toLocaleString();
-      _q('mc-min').textContent = result.mcMin.toLocaleString();
-      _q('mc-mean').textContent = result.mean.toLocaleString();
-      _q('mc-median').textContent = result.median.toLocaleString();
-      _q('mc-max').textContent = result.mcMax.toLocaleString();
-      _q('mc-max-bound').textContent = result.maxScore.toLocaleString();
-      _q('mc-stddev').textContent = result.stddev.toLocaleString();
-      _q('mc-p90').textContent = result.p90.toLocaleString();
-      _q('mc-iterations').textContent = iterations.toLocaleString();
-
-      _q('histogram-container').innerHTML = renderHistogramSvg(result.scores, result.minScore, result.maxScore, result.mean);
-
-      let sharedMin = Infinity, sharedMax = -Infinity;
-      for (const v of result.shrinkScores) {
-        if (v < sharedMin) sharedMin = v;
-        if (v > sharedMax) sharedMax = v;
-      }
-      for (const v of result.scoreUpScores) {
-        if (v < sharedMin) sharedMin = v;
-        if (v > sharedMax) sharedMax = v;
-      }
-      const renderContributionHistogram = (values: number[], containerId: string, label: string, color: string) => {
-        if (values.length === 0) {
-          _q(containerId).innerHTML = '<span class="text-gray-400 dark:text-slate-500 text-xs">データなし</span>';
-          return;
-        }
-        let sum = 0;
-        for (const v of values) sum += v;
-        const mean = sum / values.length;
-        _q(containerId).innerHTML = renderHistogramSvg(values, sharedMin, sharedMax, mean, { xAxisLabel: label, barColor: color });
-      };
-      renderContributionHistogram(result.shrinkScores, 'histogram-shrink', '縮小スキル寄与', '#10b981');
-      renderContributionHistogram(result.scoreUpScores, 'histogram-scoreup', 'スコアアップ寄与', '#6366f1');
-
-      const expected = calcExpectedScore(team, notes, selectedSong.notes_count || notes.length, scoreOptions);
-      _q('expected-score').classList.remove('hidden');
-      _q('exp-base').textContent = expected.baseScore.toLocaleString();
-      _q('exp-scoreup').textContent = expected.scoreUpExpected.toLocaleString();
-      _q('exp-shrink').textContent = expected.shrinkExpected.toLocaleString();
-      _q('exp-liveend').textContent = expected.liveEndScore.toLocaleString();
-      _q('exp-final').textContent = expected.finalScore.toLocaleString();
-
-      if (result.cardStats.length > 0) {
-        _q('skill-stats').classList.remove('hidden');
-        _q('skill-stats-body').innerHTML = result.cardStats.map(cs => `
-          <tr class="border-t">
-            <td class="py-1">${cs.cardname}</td>
-            <td class="py-1">${cs.skillType}</td>
-            <td class="py-1 text-right">${cs.theoreticalRate}%</td>
-            <td class="py-1 text-right">${cs.avgActivations.toFixed(1)}回</td>
-            <td class="py-1 text-right">+${Math.round(cs.avgScoreContribution).toLocaleString()}</td>
-          </tr>`).join('');
-      }
-
-      btn.disabled = false;
-      btn.textContent = 'シミュレーション計算';
-      _q('progress-container').classList.add('hidden');
-    }
-
-    function updateCalcButton() {
-      const btn = _q<HTMLButtonElement>('btn-calculate');
-      const reason = _q('calc-disabled-reason');
-      const hasCards = deckState.cards.some(c => c !== null);
-
-      if (!selectedSong && !hasCards) {
-        btn.disabled = true;
-        reason.textContent = '楽曲を選択し、衣装を1枚以上配置してください';
-      } else if (!selectedSong) {
-        btn.disabled = true;
-        reason.textContent = '楽曲を選択してください';
-      } else if (!hasCards) {
-        btn.disabled = true;
-        reason.textContent = '衣装を1枚以上配置してください';
-      } else {
-        btn.disabled = false;
-        reason.textContent = '';
-      }
-    }
-
     function buildStateObject() {
-      const badgeRateEl = rootEl.querySelector<HTMLInputElement>('#opt-scoreup-badge-rate');
-      const badgeRate = badgeRateEl ? (parseFloat(badgeRateEl.value) || 0) : undefined;
       return {
         songId: selectedSong?.id ?? null,
         deckIds: deckState.cards.map(c => c?.ID ?? null),
@@ -456,7 +170,7 @@
         trained: [...deckState.trained],
         sharedBroachs: deckState.sharedBroachs.map(a => [...a]),
         skillLevels: [...deckState.skillLevels],
-        badgeRate,
+        badgeRate: Number(scoreUpBadgeRate) || 0,
       };
     }
 
@@ -466,12 +180,10 @@
         if (song) {
           selectedSong = song;
           _q<HTMLSelectElement>('song-select').value = String(song.id);
-          renderSongInfo();
         }
       } else {
         selectedSong = null;
         _q<HTMLSelectElement>('song-select').value = '';
-        renderSongInfo();
       }
       if (Array.isArray(state.bonusTiers)) {
         for (let i = 0; i < 6; i++) {
@@ -507,10 +219,8 @@
         clampSharedBroachs(deckState, i, allBroachsState);
       }
       if (typeof state.badgeRate === 'number') {
-        const el = _q<HTMLInputElement>('opt-scoreup-badge-rate');
-        if (el) el.value = String(state.badgeRate);
+        scoreUpBadgeRate = state.badgeRate;
       }
-      recalculate();
     }
 
     function saveState() {
@@ -616,108 +326,38 @@
     }
 
     function showLoadDropdown() {
-      const dropdown = _q('load-deck-dropdown');
-      const isVisible = !dropdown.classList.contains('hidden');
-      if (isVisible) { hideLoadDropdown(); return; }
-
+      if (loadDeckItems !== null) { hideLoadDropdown(); return; }
       const decks = loadSavedDecks();
-      if (decks.length === 0) {
-        dropdown.innerHTML = '<div class="p-3 text-xs text-gray-400 dark:text-slate-500 text-center">保存されたデッキがありません</div>';
-      } else {
-        const items = decks.slice().reverse().map(d => {
-          const date = new Date(d.updatedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-          const cardCount = (d.state.deckIds || []).filter((id: number | null) => id != null).length;
-          return `<div class="load-deck-item flex items-center justify-between px-3 py-2 hover:bg-indigo-50 cursor-pointer border-b border-gray-100 dark:border-slate-800 last:border-0" data-deck-id="${d.id}">
-            <div class="min-w-0 flex-1">
-              <div class="text-xs font-medium text-gray-700 dark:text-slate-200 truncate">${d.name}</div>
-              <div class="text-[10px] text-gray-400 dark:text-slate-500">${date} / ${cardCount}枚</div>
-            </div>
-          </div>`;
-        }).join('');
-        dropdown.innerHTML = items + `<a href="${base}decks/" class="block text-center text-[10px] text-indigo-500 hover:text-indigo-700 py-2 border-t border-gray-100 dark:border-slate-800">デッキ管理ページ →</a>`;
-      }
-
-      dropdown.classList.remove('hidden');
-
-      dropdown.querySelectorAll('.load-deck-item').forEach(el => {
-        el.addEventListener('click', () => {
-          const deckId = (el as HTMLElement).dataset.deckId!;
-          loadDeck(deckId);
-        });
-      });
+      loadDeckItems = decks.slice().reverse().map(d => ({
+        id: d.id,
+        name: d.name,
+        dateLabel: new Date(d.updatedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
+        cardCount: (d.state.deckIds || []).filter((id: number | null) => id != null).length,
+      }));
     }
 
     function hideLoadDropdown() {
-      _q('load-deck-dropdown').classList.add('hidden');
+      loadDeckItems = null;
     }
 
-    function loadDeck(deckId: string) {
+    loadDeckImpl = (deckId: string) => {
       const decks = loadSavedDecks();
       const target = decks.find(d => d.id === deckId);
       if (!target) return;
       applyState(target.state);
       saveState();
       hideLoadDropdown();
-    }
-
-    function initResultTabs() {
-      const buttons = rootEl.querySelectorAll<HTMLButtonElement>('[data-tab]');
-      const panels = rootEl.querySelectorAll<HTMLElement>('[data-tab-panel]');
-      const activate = (key: string) => {
-        panels.forEach(p => p.classList.toggle('hidden', p.id !== `tab-panel-${key}`));
-        buttons.forEach(b => {
-          const isActive = b.dataset.tab === key;
-          b.classList.toggle('border-indigo-500', isActive);
-          b.classList.toggle('text-indigo-700', isActive);
-          b.classList.toggle('bg-indigo-50', isActive);
-          b.classList.toggle('border-transparent', !isActive);
-          b.classList.toggle('text-gray-500', !isActive);
-        });
-      };
-      buttons.forEach(b => b.addEventListener('click', () => activate(b.dataset.tab!)));
-      activate('expected');
-    }
-
-    const mutationObservers: MutationObserver[] = [];
-    function initResultPlaceholders() {
-      const pairs: Array<[string, string]> = [
-        ['score-breakdown', 'breakdown-placeholder'],
-        ['mc-results', 'mc-placeholder'],
-        ['expected-score', 'expected-placeholder'],
-        ['skill-stats', 'skills-placeholder'],
-        ['area-values-section', 'area-placeholder'],
-      ];
-      const sync = (sectionId: string, placeholderId: string) => {
-        const s = rootEl.querySelector(`#${sectionId}`);
-        const p = rootEl.querySelector(`#${placeholderId}`);
-        if (s && p) p.classList.toggle('hidden', !s.classList.contains('hidden'));
-      };
-      for (const [sec, ph] of pairs) {
-        sync(sec, ph);
-        const s = rootEl.querySelector(`#${sec}`);
-        if (!s) continue;
-        const mo = new MutationObserver(() => sync(sec, ph));
-        mo.observe(s, {
-          attributes: true,
-          attributeFilter: ['class'],
-        });
-        mutationObservers.push(mo);
-      }
-    }
+    };
 
     // body-level dropdown-close handler (documented)
     const bodyClickHandler = (e: MouseEvent) => {
-      const dropdown = rootEl.querySelector<HTMLElement>('#load-deck-dropdown');
-      if (!dropdown) return;
-      if (!dropdown.classList.contains('hidden') &&
+      if (loadDeckItems !== null &&
           !(e.target as HTMLElement).closest('#load-deck-dropdown') &&
           !(e.target as HTMLElement).closest('#btn-load-deck')) {
         hideLoadDropdown();
       }
     };
 
-    initResultTabs();
-    initResultPlaceholders();
     initSongSelect();
 
     _q('btn-save-deck').addEventListener('click', saveDeck);
@@ -725,28 +365,13 @@
     _q('btn-share-url').addEventListener('click', shareDeckUrl);
     document.addEventListener('click', bodyClickHandler);
 
-    _q('btn-calculate').addEventListener('click', runMC);
-
-    _q('opt-scoreup-assist').addEventListener('change', () => {
-      recalculate();
-    });
-    _q('opt-scoreup-badge-rate').addEventListener('input', () => { recalculate(); saveState(); });
-
-    _q('shrink-offset-input').addEventListener('input', () => {
-      if (!selectedSong || deckState.cards.filter(c => c !== null).length === 0) return;
-      const team = computeTeam(deckState.cards, allBroachsState, selectedSong, deckState.bonusTiers, deckState.trained, undefined, deckState.sharedBroachs, deckState.skillLevels, loadRabbitNotes());
-      updateShrinkCoverage(team, selectedSong);
-    });
-
     if (!tryRestoreFromUrl()) {
       restoreState();
     }
-    updateCalcButton();
 
     refreshData('cards', fetchCardsJson, (fresh) => {
       allCardsState = fresh as Card[];
       deckState.cards = deckState.cards.map(c => c ? allCardsState.find(fc => fc.ID === c.ID) || null : null);
-      recalculate();
     });
 
     refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
@@ -758,18 +383,14 @@
       if (selectedSong) {
         _q<HTMLSelectElement>('song-select').value = String(selectedSong.id);
       }
-      renderSongInfo();
-      recalculate();
     });
 
     refreshData('broachs', fetchFixedBroachsJson, (fresh) => {
       allBroachsState = fresh as FixedBroach[];
-      recalculate();
     });
 
     return () => {
       document.removeEventListener('click', bodyClickHandler);
-      for (const mo of mutationObservers) mo.disconnect();
     };
   });
 </script>
@@ -783,23 +404,29 @@
         <select id="song-select" class="w-full border border-gray-300 dark:border-slate-600 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400">
           <option value="">楽曲を選択</option>
         </select>
-        <div id="song-info" class="mt-3 hidden">
+        <div id="song-info" class="mt-3" class:hidden={!selectedSong}>
           <dl class="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 text-xs">
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">曲名</dt><dd id="song-name-val" class="font-medium truncate"></dd></div>
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">アーティスト</dt><dd id="song-artist" class="font-medium truncate"></dd></div>
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">楽曲種類</dt><dd id="song-type" class="font-medium"></dd></div>
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">ノーツ数</dt><dd id="song-notes" class="font-medium"></dd></div>
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">秒数</dt><dd id="song-duration-val" class="font-medium"></dd></div>
-            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">構成</dt><dd id="song-attr-counts"></dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">曲名</dt><dd id="song-name-val" class="font-medium truncate">{selectedSong ? selectedSong.song_name || '-' : ''}</dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">アーティスト</dt><dd id="song-artist" class="font-medium truncate">{selectedSong ? selectedSong.artist || '-' : ''}</dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">楽曲種類</dt><dd id="song-type" class="font-medium">{selectedSong ? selectedSong.song_type || '-' : ''}</dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">ノーツ数</dt><dd id="song-notes" class="font-medium">{selectedSong ? (selectedSong.notes_count || 0).toLocaleString() : ''}</dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">秒数</dt><dd id="song-duration-val" class="font-medium">{selectedSong ? `${selectedSong.duration || '-'}秒` : ''}</dd></div>
+            <div><dt class="text-gray-500 dark:text-slate-400 text-[10px]">構成</dt><dd id="song-attr-counts">{#if songAttrCounts}<span style="color:{ATTR_HEX.Shout}">🔴{songAttrCounts.s}</span> <span style="color:{ATTR_HEX.Beat}">🟢{songAttrCounts.b}</span> <span style="color:{ATTR_HEX.Melody}">🔵{songAttrCounts.m}</span>{/if}</dd></div>
           </dl>
           <div class="mt-2 text-right">
-            <a id="song-detail-anchor" href="#" class="text-xs text-indigo-600 hover:underline">楽曲詳細を見る →</a>
+            <a id="song-detail-anchor" href={selectedSong ? `${base}songs/${selectedSong.id}/` : '#'} class="text-xs text-indigo-600 hover:underline">楽曲詳細を見る →</a>
           </div>
         </div>
       </div>
       <div id="song-info-chart" class="flex items-center gap-3 md:border-l md:border-gray-200 md:pl-4 md:min-w-[180px]">
-        <div id="song-chart" class="flex-shrink-0"></div>
-        <div id="song-ratios" class="text-[11px] space-y-0.5"></div>
+        <div id="song-chart" class="flex-shrink-0">{#if selectedSong}{@html songChartSvg}{/if}</div>
+        <div id="song-ratios" class="text-[11px] space-y-0.5">
+          {#if selectedSong}
+            <div style="color:{ATTR_HEX.Shout}">Shout: {Math.round((selectedSong.shout_ratio || 0) * 100)}%</div>
+            <div style="color:{ATTR_HEX.Beat}">Beat: {Math.round((selectedSong.beat_ratio || 0) * 100)}%</div>
+            <div style="color:{ATTR_HEX.Melody}">Melody: {Math.round((selectedSong.melody_ratio || 0) * 100)}%</div>
+          {/if}
+        </div>
       </div>
     </div>
   </section>
@@ -813,12 +440,12 @@
     <div class="px-4 pb-4 border-t border-gray-100 dark:border-slate-800 pt-3">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
         <label class="flex items-center gap-2">
-          <input type="checkbox" id="opt-scoreup-assist" class="rounded" />
+          <input type="checkbox" id="opt-scoreup-assist" class="rounded" bind:checked={scoreUpAssist} />
           <span>SCOREUPアシスト（属性値 ×1.2）</span>
         </label>
         <label class="flex items-center gap-2">
           <span class="text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">SCOREUPバッジ倍率</span>
-          <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm" min="0" max="100" step="1" value="16" />
+          <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm" min="0" max="100" step="1" bind:value={scoreUpBadgeRate} oninput={handleBadgeRateInput} />
           <span class="text-xs text-gray-500 dark:text-slate-400">%</span>
         </label>
       </div>
@@ -834,206 +461,31 @@
           <button id="btn-save-deck" type="button" class="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 transition-colors">保存</button>
           <button id="btn-load-deck" type="button" class="text-xs px-2 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-slate-200 rounded hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors">読込</button>
           <button id="btn-share-url" type="button" class="text-xs px-2 py-1 bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors" aria-label="編成シェア URL をコピー">🔗 URLコピー</button>
-          <div id="load-deck-dropdown" class="hidden absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto"></div>
+          <div id="load-deck-dropdown" class="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto" class:hidden={loadDeckItems === null}>
+            {#if loadDeckItems !== null}
+              {#if loadDeckItems.length === 0}
+                <div class="p-3 text-xs text-gray-400 dark:text-slate-500 text-center">保存されたデッキがありません</div>
+              {:else}
+                {#each loadDeckItems as d (d.id)}
+                  <div class="load-deck-item flex items-center justify-between px-3 py-2 hover:bg-indigo-50 cursor-pointer border-b border-gray-100 dark:border-slate-800 last:border-0" data-deck-id={d.id} onclick={() => handleLoadDeckClick(d.id)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleLoadDeckClick(d.id); }}>
+                    <div class="min-w-0 flex-1">
+                      <div class="text-xs font-medium text-gray-700 dark:text-slate-200 truncate">{d.name}</div>
+                      <div class="text-[10px] text-gray-400 dark:text-slate-500">{d.dateLabel} / {d.cardCount}枚</div>
+                    </div>
+                  </div>
+                {/each}
+                <a href="{base}decks/" class="block text-center text-[10px] text-indigo-500 hover:text-indigo-700 py-2 border-t border-gray-100 dark:border-slate-800">デッキ管理ページ →</a>
+              {/if}
+            {/if}
+          </div>
         </div>
       </div>
       <DeckSlots deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} onSlotClick={handleSlotClick} onSwap={handleSwap} onChanged={handleDeckChanged} />
     </section>
 
-    <CardDetailTable deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} />
+    <CardDetailTable deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} scoreUpAssist={scoreUpAssist} />
 
-    <details id="breakdown-section" class="bg-white dark:bg-slate-800 rounded-lg shadow p-4 group" open>
-      <summary class="cursor-pointer text-sm font-bold text-gray-700 dark:text-slate-200 flex items-center justify-between select-none mb-3">
-        <span>📊 スキル詳細</span>
-        <svg class="w-4 h-4 text-gray-400 dark:text-slate-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-      </summary>
-      <section id="score-breakdown" class="hidden">
-        <div class="space-y-1">
-          <div id="shrink-coverage-row" class="flex justify-between text-sm hidden">
-            <span class="text-gray-500 dark:text-slate-400">縮小カバー率（最大発動時）</span>
-            <span id="shrink-coverage-val" class="font-medium text-orange-600"></span>
-          </div>
-          <div id="shrink-expected-row" class="flex justify-between text-sm hidden">
-            <span class="text-gray-500 dark:text-slate-400">縮小カバー率（期待値）</span>
-            <span id="shrink-expected-val" class="font-medium text-orange-600"></span>
-          </div>
-        </div>
-        <p id="shrink-exclusion-note" class="text-xs text-gray-400 dark:text-slate-500 mt-2 hidden">※ 最初の<span id="shrink-exclusion-count" class="font-medium">0</span>ノーツは縮小の計算対象外です</p>
-        <div id="shrink-offset-row" class="flex items-center justify-end gap-1 mt-2 text-xs text-gray-500 dark:text-slate-400 hidden">
-          <label for="shrink-offset-input">先頭</label>
-          <input type="number" id="shrink-offset-input" value="0" min="0" step="1" class="w-12 border border-gray-300 dark:border-slate-600 rounded px-1 py-0.5 text-right" />
-          <span>秒除外</span>
-        </div>
-        <div id="skill-per-card-section" class="mt-4 border-t pt-3 hidden">
-          <table class="w-full text-xs">
-            <thead>
-              <tr class="text-gray-500 dark:text-slate-400 border-b">
-                <th class="text-left py-1 px-1">スロット</th>
-                <th class="text-left py-1 px-1">衣装名</th>
-                <th class="text-left py-1 px-1">スキル</th>
-                <th class="text-right py-1 px-1">スキル期待値</th>
-                <th class="text-right py-1 px-1">スキル最大発動回数</th>
-                <th class="text-right py-1 px-1">スキル論理最高値</th>
-              </tr>
-            </thead>
-            <tbody id="skill-per-card-body"></tbody>
-            <tfoot id="skill-per-card-foot"></tfoot>
-          </table>
-          <p class="text-xs text-gray-400 dark:text-slate-500 mt-2">※ 複数の判定縮小スキルが共存する場合、値は按分されます</p>
-        </div>
-      </section>
-      <p id="breakdown-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6">楽曲と衣装を設定するとスキル詳細が表示されます</p>
-    </details>
-
-    <section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4">
-      <div class="grid grid-cols-2 gap-4 text-center">
-        <div>
-          <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest">理論最低</div>
-          <div id="score-min" class="text-base md:text-lg font-bold text-gray-700 dark:text-slate-200 mt-1">-</div>
-        </div>
-        <div>
-          <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest">理論最高</div>
-          <div id="score-max" class="text-base md:text-lg font-bold text-gray-700 dark:text-slate-200 mt-1">-</div>
-        </div>
-      </div>
-    </section>
-
-    <div class="space-y-2">
-      <div class="flex items-center justify-end gap-2 flex-wrap">
-        <label for="mc-iterations-input" class="text-xs text-gray-500 dark:text-slate-400">シミュレーション回数</label>
-        <input
-          id="mc-iterations-input"
-          type="number"
-          min="1"
-          step="1"
-          class="w-28 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-          value={MC_ITERATIONS}
-        />
-        <span class="text-xs text-gray-500 dark:text-slate-400">回</span>
-        <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-slate-300 cursor-pointer select-none" title="ON にすると縮小スキルの確率判定を常に成功扱いにし、縮小カバー率が最大値となる前提で MC シミュレーションを実行します">
-          <input type="checkbox" id="opt-max-shrink-coverage" class="rounded" />
-          <span>縮小全発動</span>
-        </label>
-        <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-slate-300 cursor-pointer select-none" title="ON にするとスコアアップスキル（タイマー型含む）の確率判定を常に成功扱いにし、スコアアップが理論最大発動回数となる前提で MC シミュレーションを実行します">
-          <input type="checkbox" id="opt-max-scoreup-coverage" class="rounded" />
-          <span>スコアアップ全発動</span>
-        </label>
-      </div>
-      <button id="btn-calculate" type="button" class="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold text-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
-        🧮 シミュレーション計算
-      </button>
-      <p id="calc-disabled-reason" class="text-xs text-center text-amber-600"></p>
-      <div id="progress-container" class="hidden">
-        <div class="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2">
-          <div id="progress-bar" class="bg-indigo-600 h-2 rounded-full transition-all" style="width: 0%"></div>
-        </div>
-        <p id="progress-text" class="text-xs text-gray-500 dark:text-slate-400 mt-1 text-center">計算中...</p>
-      </div>
-    </div>
-
-    <section class="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-lg shadow p-4 md:p-6">
-      <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest text-center">平均スコア</div>
-      <div id="final-result" class="text-3xl md:text-5xl font-bold text-indigo-700 text-center mt-1">---</div>
-      <div class="mt-3 text-center">
-        <span class="text-[10px] text-gray-500 dark:text-slate-400">試行回数: </span>
-        <span id="mc-iterations" class="text-xs md:text-sm font-bold text-gray-700 dark:text-slate-200">-</span>
-      </div>
-    </section>
-
-    <section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4">
-      <h2 class="text-sm font-bold text-gray-700 dark:text-slate-200 mb-3">🎲 シミュレーション統計</h2>
-      <section id="mc-results" class="hidden">
-        <table class="w-full text-sm">
-          <tbody>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">期待最低値</td><td id="mc-min-bound" class="text-right py-1"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">最小</td><td id="mc-min" class="text-right py-1"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">平均</td><td id="mc-mean" class="text-right py-1 font-bold"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">中央値</td><td id="mc-median" class="text-right py-1"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">最大</td><td id="mc-max" class="text-right py-1"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">期待最高値</td><td id="mc-max-bound" class="text-right py-1"></td></tr>
-            <tr class="border-t"><td class="text-gray-500 dark:text-slate-400 py-1">標準偏差</td><td id="mc-stddev" class="text-right py-1"></td></tr>
-            <tr><td class="text-gray-500 dark:text-slate-400 py-1">90パーセンタイル</td><td id="mc-p90" class="text-right py-1"></td></tr>
-          </tbody>
-        </table>
-        <div id="histogram-container" class="mt-4"></div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-          <div>
-            <div class="text-xs text-gray-600 dark:text-slate-300 mb-1">縮小スキル寄与量の分布</div>
-            <div id="histogram-shrink"></div>
-          </div>
-          <div>
-            <div class="text-xs text-gray-600 dark:text-slate-300 mb-1">スコアアップスキル寄与量の分布</div>
-            <div id="histogram-scoreup"></div>
-          </div>
-        </div>
-      </section>
-      <p id="mc-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6">計算を実行するとシミュレーション結果が表示されます</p>
-    </section>
-
-    <div class="bg-white dark:bg-slate-800 rounded-lg shadow">
-      <div class="flex border-b overflow-x-auto" role="tablist" aria-label="結果タブ">
-        <button type="button" data-tab="expected" class="result-tab px-3 py-2.5 text-xs font-medium whitespace-nowrap border-b-2 border-transparent text-gray-500 dark:text-slate-400 hover:text-indigo-600 transition-colors">📈 期待値</button>
-        <button type="button" data-tab="skills" class="result-tab px-3 py-2.5 text-xs font-medium whitespace-nowrap border-b-2 border-transparent text-gray-500 dark:text-slate-400 hover:text-indigo-600 transition-colors">⚡ スキル発動</button>
-        <button type="button" data-tab="area" class="result-tab px-3 py-2.5 text-xs font-medium whitespace-nowrap border-b-2 border-transparent text-gray-500 dark:text-slate-400 hover:text-indigo-600 transition-colors">🎵 面積値</button>
-      </div>
-
-      <div id="tab-panel-expected" data-tab-panel class="p-4 hidden">
-        <section id="expected-score" class="hidden">
-          <p class="text-[11px] text-gray-500 dark:text-slate-400 mb-3">外部サイト準拠の単純期待値（シミュレーションの確率的揺れを含まない決定論的な値）</p>
-          <table class="w-full text-sm">
-            <tbody>
-              <tr><td class="text-gray-500 dark:text-slate-400 py-1">属性値による楽曲スコア</td><td id="exp-base" class="text-right py-1"></td></tr>
-              <tr><td class="text-gray-500 dark:text-slate-400 py-1">スコアアップ期待値</td><td id="exp-scoreup" class="text-right py-1"></td></tr>
-              <tr><td class="text-gray-500 dark:text-slate-400 py-1">判定縮小期待値</td><td id="exp-shrink" class="text-right py-1"></td></tr>
-              <tr class="border-t"><td class="text-gray-500 dark:text-slate-400 py-1">ライブ終了時スコア</td><td id="exp-liveend" class="text-right py-1"></td></tr>
-              <tr><td class="text-gray-500 dark:text-slate-400 py-1 font-bold">最終リザルト</td><td id="exp-final" class="text-right py-1 font-bold"></td></tr>
-            </tbody>
-          </table>
-        </section>
-        <p id="expected-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6">計算を実行すると算術期待値が表示されます</p>
-      </div>
-
-      <div id="tab-panel-skills" data-tab-panel class="p-4 hidden">
-        <section id="skill-stats" class="hidden">
-          <div class="overflow-x-auto">
-            <table class="w-full text-xs">
-              <thead>
-                <tr class="text-gray-500 dark:text-slate-400 border-b">
-                  <th class="text-left py-1">衣装名</th>
-                  <th class="text-left py-1">スキル</th>
-                  <th class="text-right py-1">発動率</th>
-                  <th class="text-right py-1">平均発動</th>
-                  <th class="text-right py-1">スコア寄与</th>
-                </tr>
-              </thead>
-              <tbody id="skill-stats-body"></tbody>
-            </table>
-          </div>
-        </section>
-        <p id="skills-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6">計算を実行するとスキル発動統計が表示されます</p>
-      </div>
-
-      <div id="tab-panel-area" data-tab-panel class="p-4 hidden">
-        <section id="area-values-section" class="hidden">
-          <table class="w-full text-xs">
-            <thead>
-              <tr class="text-gray-500 dark:text-slate-400">
-                <th class="text-left py-1">属性</th>
-                <th class="text-right py-1">白ノート</th>
-                <th class="text-right py-1">色ノート</th>
-                <th class="text-right py-1">合計</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td class="py-1 text-red-500 font-medium">Shout</td><td id="area-s-white" class="text-right py-1"></td><td id="area-s-color" class="text-right py-1"></td><td id="area-s-total" class="text-right py-1 font-bold"></td></tr>
-              <tr><td class="py-1 text-green-500 font-medium">Beat</td><td id="area-b-white" class="text-right py-1"></td><td id="area-b-color" class="text-right py-1"></td><td id="area-b-total" class="text-right py-1 font-bold"></td></tr>
-              <tr><td class="py-1 text-blue-500 font-medium">Melody</td><td id="area-m-white" class="text-right py-1"></td><td id="area-m-color" class="text-right py-1"></td><td id="area-m-total" class="text-right py-1 font-bold"></td></tr>
-            </tbody>
-          </table>
-        </section>
-        <p id="area-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6">楽曲と衣装を設定すると楽曲属性面積値が表示されます</p>
-      </div>
-    </div>
+    <ScoreCalcResults deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} scoreUpAssist={scoreUpAssist} scoreUpBadgeRate={scoreUpBadgeRate} />
   </div>
 
   <CardPickerModal bind:this={picker} allCards={allCardsState} onPick={handlePick} onClear={handleClear} />

--- a/src/components/score/CardDetailTable.svelte
+++ b/src/components/score/CardDetailTable.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { getApSkillLevel } from '../../lib/data/fetchCardsJson';
   import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
   import type { Song } from '../../lib/data/fetchSongsJson';
@@ -15,25 +14,12 @@
   import { loadRabbitNotes } from '../../lib/data/rabbitNote';
   import { ATTR_TEXT_CLASS } from '../../lib/ui';
 
-  let { deckState, selectedSong, allBroachs }: {
+  let { deckState, selectedSong, allBroachs, scoreUpAssist }: {
     deckState: DeckState;
     selectedSong: Song | null;
     allBroachs: FixedBroach[];
+    scoreUpAssist: boolean;
   } = $props();
-
-  // 親 (ScoreCalc) テンプレート内の #opt-scoreup-assist と同期する。
-  // 既存実装は renderCardDetailTable() 実行時にチェックボックスを直接読んでいたため、
-  // change イベントで $state に反映して同じタイミングで再描画する。
-  let scoreUpAssistEnabled = $state(false);
-
-  onMount(() => {
-    const el = document.getElementById('opt-scoreup-assist') as HTMLInputElement | null;
-    if (!el) return;
-    scoreUpAssistEnabled = el.checked;
-    const handler = () => { scoreUpAssistEnabled = el.checked; };
-    el.addEventListener('change', handler);
-    return () => el.removeEventListener('change', handler);
-  });
 
   type DetailRow = {
     i: number;
@@ -166,9 +152,9 @@
     const teamShout = baseShout + csShout;
     const teamBeat = baseBeat + csBeat;
     const teamMelody = baseMelody + csMelody;
-    const assistShout = scoreUpAssistEnabled ? Math.floor(teamShout * (1 + SCOREUP_ASSIST_RATE)) - teamShout : 0;
-    const assistBeat = scoreUpAssistEnabled ? Math.floor(teamBeat * (1 + SCOREUP_ASSIST_RATE)) - teamBeat : 0;
-    const assistMelody = scoreUpAssistEnabled ? Math.floor(teamMelody * (1 + SCOREUP_ASSIST_RATE)) - teamMelody : 0;
+    const assistShout = scoreUpAssist ? Math.floor(teamShout * (1 + SCOREUP_ASSIST_RATE)) - teamShout : 0;
+    const assistBeat = scoreUpAssist ? Math.floor(teamBeat * (1 + SCOREUP_ASSIST_RATE)) - teamBeat : 0;
+    const assistMelody = scoreUpAssist ? Math.floor(teamMelody * (1 + SCOREUP_ASSIST_RATE)) - teamMelody : 0;
     const assistPct = Math.round(SCOREUP_ASSIST_RATE * 100);
 
     const deckShout  = teamShout  + assistShout;
@@ -192,7 +178,7 @@
         centerRate, friendRate,
         centerShout, centerBeat, centerMelody,
         friendShout, friendBeat, friendMelody,
-        scoreUpAssistEnabled,
+        scoreUpAssist,
         assistPct, assistShout, assistBeat, assistMelody,
         deckShout, deckBeat, deckMelody,
         noteShoutWhite, noteBeatWhite, noteMelodyWhite,
@@ -289,7 +275,7 @@
               <td colspan="2"></td>
             </tr>
           {/if}
-          {#if f.scoreUpAssistEnabled}
+          {#if f.scoreUpAssist}
             <tr class="border-t-2 border-gray-300 dark:border-slate-600 font-bold text-xs text-emerald-600">
               <td colspan="4" class="py-1 px-1 text-right">ScoreUPアシスト (+{f.assistPct}%)</td>
               <td class="py-1 px-1 text-right">{f.assistShout > 0 ? `+${f.assistShout.toLocaleString()}` : '-'}</td>

--- a/src/components/score/ScoreCalcResults.svelte
+++ b/src/components/score/ScoreCalcResults.svelte
@@ -1,0 +1,482 @@
+<script lang="ts">
+  import type { Song } from '../../lib/data/fetchSongsJson';
+  import type { FixedBroach } from '../../lib/data/fetchFixedBroachsJson';
+  import type { DeckState } from '../../lib/score/deckState';
+  import type { ScoreOptions, SimulationResult, ExpectedScore } from '../../lib/score/types';
+  import {
+    computeTeam,
+    calcMinScore,
+    calcMaxScore,
+    calcShrinkCoverage,
+    calcExpectedScore,
+    calcCardSkillExpected,
+    calcCardSkillMax,
+    calcCardSkillMaxActivations,
+    runSimulation,
+    flattenNotes,
+    computeShrinkExclusion,
+    computeGroupSizes,
+  } from '../../lib/score/engine';
+  import { MC_ITERATIONS, NOTE_RATE, LIGHT_MULTIPLIER } from '../../lib/score/constants';
+  import { renderHistogramSvg } from '../../lib/score/histogram';
+  import { SONG_NOTE_GROUP_KEYS } from '../../lib/data/fetchSongsJson';
+  import { loadRabbitNotes } from '../../lib/data/rabbitNote';
+  import { SLOT_LABELS, DISPLAY_ORDER } from '../../lib/score/deckState';
+
+  let { deckState, selectedSong, allBroachs, scoreUpAssist, scoreUpBadgeRate }: {
+    deckState: DeckState;
+    selectedSong: Song | null;
+    allBroachs: FixedBroach[];
+    scoreUpAssist: boolean;
+    scoreUpBadgeRate: number;
+  } = $props();
+
+  // --- 結果系の入力状態 ---
+  let shrinkOffset = $state(0);
+  let mcIterationsValue = $state(MC_ITERATIONS);
+  let maxShrinkCoverageOpt = $state(false);
+  let maxScoreUpCoverageOpt = $state(false);
+
+  // --- MC シミュレーション状態 ---
+  let running = $state(false);
+  let hasRunOnce = $state(false);
+  let progressPercent = $state(0);
+  let progressText = $state('計算中...');
+  let simulationResult = $state<SimulationResult | null>(null);
+  let expectedScore = $state<ExpectedScore | null>(null);
+  let mcIterationsUsed = $state<number | null>(null);
+
+  // --- タブ ---
+  type TabKey = 'expected' | 'skills' | 'area';
+  let activeTab = $state<TabKey>('expected');
+  const TABS: Array<{ key: TabKey; label: string }> = [
+    { key: 'expected', label: '📈 期待値' },
+    { key: 'skills', label: '⚡ スキル発動' },
+    { key: 'area', label: '🎵 面積値' },
+  ];
+
+  // --- 計算（旧 recalculate の計算部）---
+  const calc = $derived.by(() => {
+    const filledCount = deckState.cards.filter(c => c !== null).length;
+    if (!selectedSong || filledCount === 0) return null;
+
+    const team = computeTeam(deckState.cards, allBroachs, selectedSong, deckState.bonusTiers, deckState.trained, undefined, deckState.sharedBroachs, deckState.skillLevels, loadRabbitNotes());
+    const exclusion = computeShrinkExclusion(team, computeGroupSizes(selectedSong));
+    const notes = flattenNotes(selectedSong, 42, exclusion);
+
+    const options: ScoreOptions = {
+      scoreUpAssist,
+      scoreUpBadgeRate: Number(scoreUpBadgeRate) || 0,
+    };
+
+    const minScore = calcMinScore(team, notes, options);
+    const maxScore = calcMaxScore(team, notes, options);
+
+    return { team, exclusion, notes, options, minScore, maxScore };
+  });
+
+  // 理論値は旧実装どおり、デッキ/楽曲が空になっても直前の値を保持する
+  let scoreMinText = $state('-');
+  let scoreMaxText = $state('-');
+  $effect(() => {
+    if (calc) {
+      scoreMinText = calc.minScore.toLocaleString();
+      scoreMaxText = calc.maxScore.toLocaleString();
+    }
+  });
+
+  // デッキ・楽曲・オプション変更で MC 結果をクリア（旧 recalculate の挙動）
+  $effect(() => {
+    void calc;
+    simulationResult = null;
+    expectedScore = null;
+  });
+
+  // --- スキル詳細（旧 renderSkillPerCard）---
+  const skillRows = $derived.by(() => {
+    if (!calc || !selectedSong) return null;
+    const notesCount = selectedSong.notes_count || 0;
+    type Row = { i: number; slotCls: string; cardname: string; name: string; skillType: string; exp: number; activations: number; max: number };
+    const rows: Row[] = [];
+    let totalExp = 0;
+    let totalMax = 0;
+    let totalActivations = 0;
+    for (const i of DISPLAY_ORDER) {
+      const card = deckState.cards[i];
+      if (!card) continue;
+      const exp = calcCardSkillExpected(calc.team, calc.notes, notesCount, i, calc.options);
+      const max = calcCardSkillMax(calc.team, calc.notes, notesCount, i, calc.options);
+      const activations = calcCardSkillMaxActivations(calc.team, notesCount, i);
+      totalExp += exp;
+      totalMax += max;
+      totalActivations += activations;
+      rows.push({
+        i,
+        slotCls: i === 0 ? 'text-indigo-600 font-bold' : i === 5 ? 'text-amber-600 font-bold' : 'text-gray-500',
+        cardname: card.cardname || '',
+        name: card.name || '',
+        skillType: card.ap_skill_type || '-',
+        exp,
+        activations,
+        max,
+      });
+    }
+    if (rows.length === 0) return null;
+    return { rows, totalExp, totalMax, totalActivations };
+  });
+
+  // --- 縮小カバー率（旧 updateShrinkCoverage）---
+  const shrink = $derived.by(() => {
+    if (!calc || !selectedSong) return null;
+    const offset = Number(shrinkOffset) || 0;
+    const coverage = calcShrinkCoverage(calc.team, selectedSong.notes_count || 0, offset, calc.exclusion.totalExcluded);
+    if (!coverage) return null;
+    const rawPct = (coverage.rawCoverageRate * 100).toFixed(1);
+    const rawText = `${rawPct}%（${coverage.rawCoveredSeconds.toFixed(1)}秒 / ${coverage.effectiveSeconds.toFixed(1)}秒）`;
+    const coverageText = coverage.rawCoverageRate > 1.0
+      ? `${rawText} ※100%超過分は計算対象外`
+      : rawText;
+    const rawExpPct = (coverage.rawExpectedCoverageRate * 100).toFixed(1);
+    const rawExpText = `${rawExpPct}%（${coverage.rawExpectedCoveredSeconds.toFixed(1)}秒 / ${coverage.effectiveSeconds.toFixed(1)}秒）`;
+    const hasOverlapCorrection =
+      Math.abs(coverage.rawExpectedCoverageRate - coverage.expectedCoverageRate) > 0.001;
+    const expectedText = hasOverlapCorrection
+      ? `${rawExpText} ※重複区間で確率合成により実効カバー率は低下`
+      : rawExpText;
+    return { coverageText, expectedText };
+  });
+
+  // --- 面積値（旧 renderAreaValues）---
+  const area = $derived.by(() => {
+    if (!calc || !selectedSong) return null;
+
+    let sWhiteWeighted = 0, sColorWeighted = 0;
+    let bWhiteWeighted = 0, bColorWeighted = 0;
+    let mWhiteWeighted = 0, mColorWeighted = 0;
+
+    for (const gk of SONG_NOTE_GROUP_KEYS) {
+      const mult = LIGHT_MULTIPLIER[gk];
+      const g = selectedSong[gk];
+      if (!g) continue;
+      sWhiteWeighted += (g.shout_white || 0) * mult;
+      sColorWeighted += (g.shout_color || 0) * mult;
+      bWhiteWeighted += (g.beat_white || 0) * mult;
+      bColorWeighted += (g.beat_color || 0) * mult;
+      mWhiteWeighted += (g.melody_white || 0) * mult;
+      mColorWeighted += (g.melody_color || 0) * mult;
+    }
+
+    const team = calc.team;
+    return {
+      s: { white: Math.floor(team.Shout * NOTE_RATE.white * sWhiteWeighted), color: Math.floor(team.Shout * NOTE_RATE.color * sColorWeighted) },
+      b: { white: Math.floor(team.Beat * NOTE_RATE.white * bWhiteWeighted), color: Math.floor(team.Beat * NOTE_RATE.color * bColorWeighted) },
+      m: { white: Math.floor(team.Melody * NOTE_RATE.white * mWhiteWeighted), color: Math.floor(team.Melody * NOTE_RATE.color * mColorWeighted) },
+    };
+  });
+
+  // --- 計算ボタン（旧 updateCalcButton）---
+  const hasCards = $derived(deckState.cards.some(c => c !== null));
+  const calcDisabledReason = $derived(
+    !selectedSong && !hasCards ? '楽曲を選択し、衣装を1枚以上配置してください'
+      : !selectedSong ? '楽曲を選択してください'
+      : !hasCards ? '衣装を1枚以上配置してください'
+      : ''
+  );
+  const calcDisabled = $derived(running || calcDisabledReason !== '');
+
+  // --- ヒストグラム ---
+  const mainHistogram = $derived(
+    simulationResult
+      ? renderHistogramSvg(simulationResult.scores, simulationResult.minScore, simulationResult.maxScore, simulationResult.mean)
+      : ''
+  );
+  const contribHistograms = $derived.by(() => {
+    const result = simulationResult;
+    if (!result) return null;
+    let sharedMin = Infinity, sharedMax = -Infinity;
+    for (const v of result.shrinkScores) {
+      if (v < sharedMin) sharedMin = v;
+      if (v > sharedMax) sharedMax = v;
+    }
+    for (const v of result.scoreUpScores) {
+      if (v < sharedMin) sharedMin = v;
+      if (v > sharedMax) sharedMax = v;
+    }
+    const make = (values: number[], label: string, color: string): string | null => {
+      if (values.length === 0) return null;
+      let sum = 0;
+      for (const v of values) sum += v;
+      return renderHistogramSvg(values, sharedMin, sharedMax, sum / values.length, { xAxisLabel: label, barColor: color });
+    };
+    return {
+      shrink: make(result.shrinkScores, '縮小スキル寄与', '#10b981'),
+      scoreup: make(result.scoreUpScores, 'スコアアップ寄与', '#6366f1'),
+    };
+  });
+
+  // --- MC シミュレーション実行（旧 runMC、明示ボタンのみで実行）---
+  async function runMC() {
+    const snapshot = calc;
+    const song = selectedSong;
+    if (!snapshot || !song) return;
+
+    running = true;
+
+    const iterations = Math.max(1, Math.floor(Number(mcIterationsValue) || MC_ITERATIONS));
+
+    const scoreOptions: ScoreOptions = {
+      scoreUpAssist,
+      scoreUpBadgeRate: Number(scoreUpBadgeRate) || 0,
+      maxShrinkCoverage: maxShrinkCoverageOpt,
+      maxScoreUpCoverage: maxScoreUpCoverageOpt,
+    };
+
+    const result = await runSimulation(snapshot.team, snapshot.notes, iterations, (pct) => {
+      const percent = Math.round(pct * 100);
+      progressPercent = percent;
+      progressText = `計算中... ${percent}%`;
+    }, undefined, scoreOptions);
+
+    simulationResult = result;
+    mcIterationsUsed = iterations;
+    expectedScore = calcExpectedScore(snapshot.team, snapshot.notes, song.notes_count || snapshot.notes.length, scoreOptions);
+
+    hasRunOnce = true;
+    running = false;
+  }
+</script>
+
+<details id="breakdown-section" class="bg-white dark:bg-slate-800 rounded-lg shadow p-4 group" open>
+  <summary class="cursor-pointer text-sm font-bold text-gray-700 dark:text-slate-200 flex items-center justify-between select-none mb-3">
+    <span>📊 スキル詳細</span>
+    <svg class="w-4 h-4 text-gray-400 dark:text-slate-500 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+  </summary>
+  <section id="score-breakdown" class:hidden={!calc}>
+    <div class="space-y-1">
+      <div id="shrink-coverage-row" class="flex justify-between text-sm" class:hidden={!shrink}>
+        <span class="text-gray-500 dark:text-slate-400">縮小カバー率（最大発動時）</span>
+        <span id="shrink-coverage-val" class="font-medium text-orange-600">{shrink?.coverageText ?? ''}</span>
+      </div>
+      <div id="shrink-expected-row" class="flex justify-between text-sm" class:hidden={!shrink}>
+        <span class="text-gray-500 dark:text-slate-400">縮小カバー率（期待値）</span>
+        <span id="shrink-expected-val" class="font-medium text-orange-600">{shrink?.expectedText ?? ''}</span>
+      </div>
+    </div>
+    <p id="shrink-exclusion-note" class="text-xs text-gray-400 dark:text-slate-500 mt-2" class:hidden={!(calc && calc.exclusion.totalExcluded > 0)}>※ 最初の<span id="shrink-exclusion-count" class="font-medium">{calc?.exclusion.totalExcluded ?? 0}</span>ノーツは縮小の計算対象外です</p>
+    <div id="shrink-offset-row" class="flex items-center justify-end gap-1 mt-2 text-xs text-gray-500 dark:text-slate-400" class:hidden={!shrink}>
+      <label for="shrink-offset-input">先頭</label>
+      <input type="number" id="shrink-offset-input" bind:value={shrinkOffset} min="0" step="1" class="w-12 border border-gray-300 dark:border-slate-600 rounded px-1 py-0.5 text-right" />
+      <span>秒除外</span>
+    </div>
+    <div id="skill-per-card-section" class="mt-4 border-t pt-3" class:hidden={!skillRows}>
+      <table class="w-full text-xs">
+        <thead>
+          <tr class="text-gray-500 dark:text-slate-400 border-b">
+            <th class="text-left py-1 px-1">スロット</th>
+            <th class="text-left py-1 px-1">衣装名</th>
+            <th class="text-left py-1 px-1">スキル</th>
+            <th class="text-right py-1 px-1">スキル期待値</th>
+            <th class="text-right py-1 px-1">スキル最大発動回数</th>
+            <th class="text-right py-1 px-1">スキル論理最高値</th>
+          </tr>
+        </thead>
+        <tbody id="skill-per-card-body">
+          {#if skillRows}
+            {#each skillRows.rows as row (row.i)}
+              <tr class="border-t">
+                <td class="py-1 px-1 text-[10px] {row.slotCls}">{SLOT_LABELS[row.i]}</td>
+                <td class="py-1 px-1">
+                  <div>{row.cardname}</div>
+                  <div class="text-[10px] text-gray-400 dark:text-slate-500">{row.name}</div>
+                </td>
+                <td class="py-1 px-1">{row.skillType}</td>
+                <td class="py-1 px-1 text-right">{row.exp > 0 ? row.exp.toLocaleString() : '-'}</td>
+                <td class="py-1 px-1 text-right">{row.activations > 0 ? row.activations.toLocaleString() : '-'}</td>
+                <td class="py-1 px-1 text-right">{row.max > 0 ? row.max.toLocaleString() : '-'}</td>
+              </tr>
+            {/each}
+          {/if}
+        </tbody>
+        <tfoot id="skill-per-card-foot">
+          {#if skillRows}
+            <tr class="border-t-2 border-gray-300 dark:border-slate-600 font-bold">
+              <td colspan="3" class="py-1 px-1 text-right text-gray-700 dark:text-slate-200">合計</td>
+              <td class="py-1 px-1 text-right">{skillRows.totalExp.toLocaleString()}</td>
+              <td class="py-1 px-1 text-right">{skillRows.totalActivations.toLocaleString()}</td>
+              <td class="py-1 px-1 text-right">{skillRows.totalMax.toLocaleString()}</td>
+            </tr>
+          {/if}
+        </tfoot>
+      </table>
+      <p class="text-xs text-gray-400 dark:text-slate-500 mt-2">※ 複数の判定縮小スキルが共存する場合、値は按分されます</p>
+    </div>
+  </section>
+  <p id="breakdown-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6" class:hidden={!!calc}>楽曲と衣装を設定するとスキル詳細が表示されます</p>
+</details>
+
+<section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4">
+  <div class="grid grid-cols-2 gap-4 text-center">
+    <div>
+      <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest">理論最低</div>
+      <div id="score-min" class="text-base md:text-lg font-bold text-gray-700 dark:text-slate-200 mt-1">{scoreMinText}</div>
+    </div>
+    <div>
+      <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest">理論最高</div>
+      <div id="score-max" class="text-base md:text-lg font-bold text-gray-700 dark:text-slate-200 mt-1">{scoreMaxText}</div>
+    </div>
+  </div>
+</section>
+
+<div class="space-y-2">
+  <div class="flex items-center justify-end gap-2 flex-wrap">
+    <label for="mc-iterations-input" class="text-xs text-gray-500 dark:text-slate-400">シミュレーション回数</label>
+    <input
+      id="mc-iterations-input"
+      type="number"
+      min="1"
+      step="1"
+      class="w-28 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+      bind:value={mcIterationsValue}
+    />
+    <span class="text-xs text-gray-500 dark:text-slate-400">回</span>
+    <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-slate-300 cursor-pointer select-none" title="ON にすると縮小スキルの確率判定を常に成功扱いにし、縮小カバー率が最大値となる前提で MC シミュレーションを実行します">
+      <input type="checkbox" id="opt-max-shrink-coverage" class="rounded" bind:checked={maxShrinkCoverageOpt} />
+      <span>縮小全発動</span>
+    </label>
+    <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-slate-300 cursor-pointer select-none" title="ON にするとスコアアップスキル（タイマー型含む）の確率判定を常に成功扱いにし、スコアアップが理論最大発動回数となる前提で MC シミュレーションを実行します">
+      <input type="checkbox" id="opt-max-scoreup-coverage" class="rounded" bind:checked={maxScoreUpCoverageOpt} />
+      <span>スコアアップ全発動</span>
+    </label>
+  </div>
+  <button id="btn-calculate" type="button" class="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold text-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled={calcDisabled} onclick={runMC}>
+    {running ? '計算中...' : hasRunOnce ? 'シミュレーション計算' : '🧮 シミュレーション計算'}
+  </button>
+  <p id="calc-disabled-reason" class="text-xs text-center text-amber-600">{calcDisabledReason}</p>
+  <div id="progress-container" class:hidden={!running}>
+    <div class="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2">
+      <div id="progress-bar" class="bg-indigo-600 h-2 rounded-full transition-all" style="width: {progressPercent}%"></div>
+    </div>
+    <p id="progress-text" class="text-xs text-gray-500 dark:text-slate-400 mt-1 text-center">{progressText}</p>
+  </div>
+</div>
+
+<section class="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-lg shadow p-4 md:p-6">
+  <div class="text-[10px] text-gray-500 dark:text-slate-400 uppercase tracking-widest text-center">平均スコア</div>
+  <div id="final-result" class="text-3xl md:text-5xl font-bold text-indigo-700 text-center mt-1">{simulationResult ? simulationResult.mean.toLocaleString() : '---'}</div>
+  <div class="mt-3 text-center">
+    <span class="text-[10px] text-gray-500 dark:text-slate-400">試行回数: </span>
+    <span id="mc-iterations" class="text-xs md:text-sm font-bold text-gray-700 dark:text-slate-200">{mcIterationsUsed != null ? mcIterationsUsed.toLocaleString() : '-'}</span>
+  </div>
+</section>
+
+<section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4">
+  <h2 class="text-sm font-bold text-gray-700 dark:text-slate-200 mb-3">🎲 シミュレーション統計</h2>
+  <section id="mc-results" class:hidden={!simulationResult}>
+    <table class="w-full text-sm">
+      <tbody>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">期待最低値</td><td id="mc-min-bound" class="text-right py-1">{simulationResult ? simulationResult.minScore.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">最小</td><td id="mc-min" class="text-right py-1">{simulationResult ? simulationResult.mcMin.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">平均</td><td id="mc-mean" class="text-right py-1 font-bold">{simulationResult ? simulationResult.mean.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">中央値</td><td id="mc-median" class="text-right py-1">{simulationResult ? simulationResult.median.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">最大</td><td id="mc-max" class="text-right py-1">{simulationResult ? simulationResult.mcMax.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">期待最高値</td><td id="mc-max-bound" class="text-right py-1">{simulationResult ? simulationResult.maxScore.toLocaleString() : ''}</td></tr>
+        <tr class="border-t"><td class="text-gray-500 dark:text-slate-400 py-1">標準偏差</td><td id="mc-stddev" class="text-right py-1">{simulationResult ? simulationResult.stddev.toLocaleString() : ''}</td></tr>
+        <tr><td class="text-gray-500 dark:text-slate-400 py-1">90パーセンタイル</td><td id="mc-p90" class="text-right py-1">{simulationResult ? simulationResult.p90.toLocaleString() : ''}</td></tr>
+      </tbody>
+    </table>
+    <div id="histogram-container" class="mt-4">{#if simulationResult}{@html mainHistogram}{/if}</div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+      <div>
+        <div class="text-xs text-gray-600 dark:text-slate-300 mb-1">縮小スキル寄与量の分布</div>
+        <div id="histogram-shrink">{#if contribHistograms}{#if contribHistograms.shrink}{@html contribHistograms.shrink}{:else}<span class="text-gray-400 dark:text-slate-500 text-xs">データなし</span>{/if}{/if}</div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-600 dark:text-slate-300 mb-1">スコアアップスキル寄与量の分布</div>
+        <div id="histogram-scoreup">{#if contribHistograms}{#if contribHistograms.scoreup}{@html contribHistograms.scoreup}{:else}<span class="text-gray-400 dark:text-slate-500 text-xs">データなし</span>{/if}{/if}</div>
+      </div>
+    </div>
+  </section>
+  <p id="mc-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6" class:hidden={!!simulationResult}>計算を実行するとシミュレーション結果が表示されます</p>
+</section>
+
+<div class="bg-white dark:bg-slate-800 rounded-lg shadow">
+  <div class="flex border-b overflow-x-auto" role="tablist" aria-label="結果タブ">
+    {#each TABS as t (t.key)}
+      <button
+        type="button"
+        data-tab={t.key}
+        class="result-tab px-3 py-2.5 text-xs font-medium whitespace-nowrap border-b-2 dark:text-slate-400 hover:text-indigo-600 transition-colors {activeTab === t.key ? 'border-indigo-500 text-indigo-700 bg-indigo-50' : 'border-transparent text-gray-500'}"
+        onclick={() => { activeTab = t.key; }}
+      >{t.label}</button>
+    {/each}
+  </div>
+
+  <div id="tab-panel-expected" data-tab-panel class="p-4" class:hidden={activeTab !== 'expected'}>
+    <section id="expected-score" class:hidden={!expectedScore}>
+      <p class="text-[11px] text-gray-500 dark:text-slate-400 mb-3">外部サイト準拠の単純期待値（シミュレーションの確率的揺れを含まない決定論的な値）</p>
+      <table class="w-full text-sm">
+        <tbody>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">属性値による楽曲スコア</td><td id="exp-base" class="text-right py-1">{expectedScore ? expectedScore.baseScore.toLocaleString() : ''}</td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">スコアアップ期待値</td><td id="exp-scoreup" class="text-right py-1">{expectedScore ? expectedScore.scoreUpExpected.toLocaleString() : ''}</td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1">判定縮小期待値</td><td id="exp-shrink" class="text-right py-1">{expectedScore ? expectedScore.shrinkExpected.toLocaleString() : ''}</td></tr>
+          <tr class="border-t"><td class="text-gray-500 dark:text-slate-400 py-1">ライブ終了時スコア</td><td id="exp-liveend" class="text-right py-1">{expectedScore ? expectedScore.liveEndScore.toLocaleString() : ''}</td></tr>
+          <tr><td class="text-gray-500 dark:text-slate-400 py-1 font-bold">最終リザルト</td><td id="exp-final" class="text-right py-1 font-bold">{expectedScore ? expectedScore.finalScore.toLocaleString() : ''}</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <p id="expected-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6" class:hidden={!!expectedScore}>計算を実行すると算術期待値が表示されます</p>
+  </div>
+
+  <div id="tab-panel-skills" data-tab-panel class="p-4" class:hidden={activeTab !== 'skills'}>
+    <section id="skill-stats" class:hidden={!(simulationResult && simulationResult.cardStats.length > 0)}>
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="text-gray-500 dark:text-slate-400 border-b">
+              <th class="text-left py-1">衣装名</th>
+              <th class="text-left py-1">スキル</th>
+              <th class="text-right py-1">発動率</th>
+              <th class="text-right py-1">平均発動</th>
+              <th class="text-right py-1">スコア寄与</th>
+            </tr>
+          </thead>
+          <tbody id="skill-stats-body">
+            {#if simulationResult}
+              {#each simulationResult.cardStats as cs}
+                <tr class="border-t">
+                  <td class="py-1">{cs.cardname}</td>
+                  <td class="py-1">{cs.skillType}</td>
+                  <td class="py-1 text-right">{cs.theoreticalRate}%</td>
+                  <td class="py-1 text-right">{cs.avgActivations.toFixed(1)}回</td>
+                  <td class="py-1 text-right">+{Math.round(cs.avgScoreContribution).toLocaleString()}</td>
+                </tr>
+              {/each}
+            {/if}
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <p id="skills-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6" class:hidden={!!(simulationResult && simulationResult.cardStats.length > 0)}>計算を実行するとスキル発動統計が表示されます</p>
+  </div>
+
+  <div id="tab-panel-area" data-tab-panel class="p-4" class:hidden={activeTab !== 'area'}>
+    <section id="area-values-section" class:hidden={!area}>
+      <table class="w-full text-xs">
+        <thead>
+          <tr class="text-gray-500 dark:text-slate-400">
+            <th class="text-left py-1">属性</th>
+            <th class="text-right py-1">白ノート</th>
+            <th class="text-right py-1">色ノート</th>
+            <th class="text-right py-1">合計</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="py-1 text-red-500 font-medium">Shout</td><td id="area-s-white" class="text-right py-1">{area ? area.s.white.toLocaleString() : ''}</td><td id="area-s-color" class="text-right py-1">{area ? area.s.color.toLocaleString() : ''}</td><td id="area-s-total" class="text-right py-1 font-bold">{area ? (area.s.white + area.s.color).toLocaleString() : ''}</td></tr>
+          <tr><td class="py-1 text-green-500 font-medium">Beat</td><td id="area-b-white" class="text-right py-1">{area ? area.b.white.toLocaleString() : ''}</td><td id="area-b-color" class="text-right py-1">{area ? area.b.color.toLocaleString() : ''}</td><td id="area-b-total" class="text-right py-1 font-bold">{area ? (area.b.white + area.b.color).toLocaleString() : ''}</td></tr>
+          <tr><td class="py-1 text-blue-500 font-medium">Melody</td><td id="area-m-white" class="text-right py-1">{area ? area.m.white.toLocaleString() : ''}</td><td id="area-m-color" class="text-right py-1">{area ? area.m.color.toLocaleString() : ''}</td><td id="area-m-total" class="text-right py-1 font-bold">{area ? (area.m.white + area.m.color).toLocaleString() : ''}</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <p id="area-placeholder" class="text-xs text-gray-400 dark:text-slate-500 text-center py-6" class:hidden={!!area}>楽曲と衣装を設定すると楽曲属性面積値が表示されます</p>
+  </div>
+</div>


### PR DESCRIPTION
Phase 2.4 後半。理論値・MC シミュレーション・縮小カバー率・期待値/スキル/面積タブを Runes 子コンポーネントに抽出。MutationObserver と innerHTML 代入を全廃（ヒストグラムは {@html}）。決定的編成の前後ダンプ diff で MC 平均（乱数）以外の全表示値が完全一致。親は 1040 → 約 480 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)