### PR TITLE
refactor(score-calc): 親コンポーネントを Runes ベースに刷新し onMount を最小化

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Card } from '../lib/data/fetchCardsJson';
-  import type { Song } from '../lib/data/fetchSongsJson';
-  import type { FixedBroach } from '../lib/data/fetchFixedBroachsJson';
-  import { buildLiveTierMap } from '../lib/data/eventBonusTiers';
-  import type { EventBonusTier, EventForBonus } from '../lib/data/eventBonusTiers';
+  import { fetchCardsJson, type Card } from '../lib/data/fetchCardsJson';
+  import { fetchSongsJson, filterValidSongs, filterAllowedSongs, SONG_NOTE_GROUP_KEYS, type Song } from '../lib/data/fetchSongsJson';
+  import { fetchFixedBroachsJson, type FixedBroach } from '../lib/data/fetchFixedBroachsJson';
+  import { buildLiveTierMap, type EventBonusTier, type EventForBonus } from '../lib/data/eventBonusTiers';
   import { attrDonutSvg } from '../lib/donutChart';
   import { ATTR_HEX } from '../lib/constants';
   import { STORAGE_KEYS, loadJson, saveJson } from '../lib/storage';
   import { refreshData } from '../lib/data/clientRefresh';
-  import { fetchCardsJson } from '../lib/data/fetchCardsJson';
-  import { fetchSongsJson, filterValidSongs, filterAllowedSongs, SONG_NOTE_GROUP_KEYS } from '../lib/data/fetchSongsJson';
-  import { fetchFixedBroachsJson } from '../lib/data/fetchFixedBroachsJson';
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
   import { createEmptyDeckState, swapSlots, clampSharedBroachs, setCard, clearSlot, SLOT_LABELS } from '../lib/score/deckState';
   import { DEFAULT_SCOREUP_BADGE_RATE } from '../lib/score/constants';
@@ -19,18 +15,13 @@
   import DeckSlots from './score/DeckSlots.svelte';
   import CardDetailTable from './score/CardDetailTable.svelte';
   import ScoreCalcResults from './score/ScoreCalcResults.svelte';
-  type Props = {
-    cards: Card[];
-    songs: Song[];
-    broachs: FixedBroach[];
-    events: EventForBonus[];
-    base: string;
-  };
+  type Props = { cards: Card[]; songs: Song[]; broachs: FixedBroach[]; events: EventForBonus[]; base: string };
 
   let { cards: initialCards, songs: initialSongs, broachs: initialBroachs, events: initialEvents, base }: Props = $props();
 
   const deckState = $state(createEmptyDeckState());
   let allCardsState = $state<Card[]>(initialCards);
+  let allSongsState = $state<Song[]>(initialSongs);
   let allBroachsState = $state<FixedBroach[]>(initialBroachs);
   let selectedSong = $state<Song | null>(null);
 
@@ -38,8 +29,27 @@
   let scoreUpAssist = $state(false);
   let scoreUpBadgeRate = $state(DEFAULT_SCOREUP_BADGE_RATE);
 
-  let rootEl: HTMLDivElement;
   let picker: CardPickerModal | undefined;
+
+  const defaultTierMap = buildLiveTierMap(initialEvents);
+  function defaultTierFor(card: Card | null): EventBonusTier {
+    return card?.ID != null ? (defaultTierMap.get(card.ID) ?? 'none') : 'none';
+  }
+
+  // 楽曲セレクト用の派生値（選択中の曲 optgroup + カテゴリ別 optgroup）
+  const pickedSongs = $derived.by(() => {
+    const pickedIds = new Set(loadJson<number[]>(STORAGE_KEYS.SELECTED_SONGS, []));
+    return allSongsState.filter(s => s.id != null && pickedIds.has(s.id)).sort((a, b) => (a.duration || 0) - (b.duration || 0));
+  });
+  const categorizedSongs = $derived.by(() => {
+    const groups = new Map<string, Song[]>();
+    for (const s of allSongsState) {
+      const cat = s.category || 'その他';
+      if (!groups.has(cat)) groups.set(cat, []);
+      groups.get(cat)!.push(s);
+    }
+    return [...groups];
+  });
 
   // 楽曲サマリー表示用の派生値
   const songAttrCounts = $derived.by(() => {
@@ -54,302 +64,163 @@
     }
     return { s, b, m };
   });
-  const songChartSvg = $derived(
-    selectedSong
-      ? attrDonutSvg(selectedSong.shout_ratio || 0, selectedSong.beat_ratio || 0, selectedSong.melody_ratio || 0, { sizeClass: 'w-20 h-20' })
-      : ''
-  );
+  const songChartSvg = $derived(selectedSong
+    ? attrDonutSvg(selectedSong.shout_ratio || 0, selectedSong.beat_ratio || 0, selectedSong.melody_ratio || 0, { sizeClass: 'w-20 h-20' })
+    : '');
 
   // 保存デッキ読込ドロップダウン（null = 閉じている）
   type LoadDeckItem = { id: string; name: string; dateLabel: string; cardCount: number };
   let loadDeckItems = $state<LoadDeckItem[] | null>(null);
 
-  // ピッカー / DeckSlots のコールバック実体は onMount 閉包内で代入される
-  let handlePickImpl: (slot: number, card: Card) => void = () => {};
-  let handleClearImpl: (slot: number) => void = () => {};
-  let handleSwapImpl: (a: number, b: number) => void = () => {};
-  let handleDeckChangedImpl: () => void = () => {};
-  let saveStateImpl: () => void = () => {};
-  let loadDeckImpl: (id: string) => void = () => {};
-  function handlePick(slot: number, card: Card) { handlePickImpl(slot, card); }
-  function handleClear(slot: number) { handleClearImpl(slot); }
+  // ボタンの一時フィードバック表示
+  let deckSaved = $state(false);
+  let shareCopied = $state(false);
+
+  function handleSongChange(e: Event) {
+    const id = Number((e.currentTarget as HTMLSelectElement).value);
+    selectedSong = allSongsState.find(s => s.id === id) || null;
+    saveState();
+  }
+  function handlePick(slot: number, card: Card) { setCard(deckState, slot, card, defaultTierFor(card), allBroachsState); saveState(); }
+  function handleClear(slot: number) { clearSlot(deckState, slot); saveState(); }
   function handleSlotClick(slot: number) { picker!.open(slot, SLOT_LABELS[slot]); }
-  function handleSwap(a: number, b: number) { handleSwapImpl(a, b); }
-  function handleDeckChanged() { handleDeckChangedImpl(); }
-  function handleBadgeRateInput() { saveStateImpl(); }
-  function handleLoadDeckClick(id: string) { loadDeckImpl(id); }
+  function handleSwap(a: number, b: number) { swapSlots(deckState, a, b); saveState(); }
+
+  function buildStateObject() {
+    return {
+      songId: selectedSong?.id ?? null,
+      deckIds: deckState.cards.map(c => c?.ID ?? null),
+      bonusTiers: [...deckState.bonusTiers],
+      trained: [...deckState.trained],
+      sharedBroachs: deckState.sharedBroachs.map(a => [...a]),
+      skillLevels: [...deckState.skillLevels],
+      badgeRate: Number(scoreUpBadgeRate) || 0,
+    };
+  }
+
+  function applyState(state: any) {
+    if (state.songId != null) {
+      const song = allSongsState.find(s => s.id === state.songId);
+      if (song) selectedSong = song;
+    } else {
+      selectedSong = null;
+    }
+    for (let i = 0; i < 6; i++) {
+      if (Array.isArray(state.bonusTiers)) deckState.bonusTiers[i] = state.bonusTiers[i] || 'none';
+      if (Array.isArray(state.trained)) deckState.trained[i] = state.trained[i] !== false;
+      if (Array.isArray(state.sharedBroachs)) deckState.sharedBroachs[i] = Array.isArray(state.sharedBroachs[i]) ? state.sharedBroachs[i] : [];
+      if (Array.isArray(state.skillLevels)) {
+        const lv = state.skillLevels[i];
+        deckState.skillLevels[i] = (lv >= 1 && lv <= 5) ? lv : 5;
+      }
+    }
+    deckState.cards = [null, null, null, null, null, null];
+    if (Array.isArray(state.deckIds)) {
+      for (let i = 0; i < 6; i++) {
+        const id = state.deckIds[i];
+        if (id != null) deckState.cards[i] = allCardsState.find(c => c.ID === id) || null;
+      }
+    }
+    for (let i = 0; i < 6; i++) clampSharedBroachs(deckState, i, allBroachsState);
+    if (typeof state.badgeRate === 'number') scoreUpBadgeRate = state.badgeRate;
+  }
+
+  function saveState() { saveJson(STORAGE_KEYS.SCORE_CALC_STATE, buildStateObject()); }
+
+  function restoreState() {
+    const state = loadJson<ReturnType<typeof buildStateObject> | null>(STORAGE_KEYS.SCORE_CALC_STATE, null);
+    if (state) applyState(state);
+  }
+
+  function tryRestoreFromUrl(): boolean {
+    if (typeof window === 'undefined' || !window.location.search) return false;
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('dv')) return false;
+    const decoded = decodeParamsToDeck(params);
+    if (!decoded) return false;
+    applyState(decoded);
+    saveState();
+    window.history.replaceState(null, '', window.location.pathname);
+    return true;
+  }
+
+  async function shareDeckUrl() {
+    const state = buildStateObject();
+    if (isDeckEmpty(state)) { alert('編成が空です。楽曲や衣装を選んでから共有してください。'); return; }
+    const params = encodeDeckToParams(state);
+    const url = `${window.location.origin}${base}score-calc/?${params.toString()}`;
+    let copied = false;
+    try {
+      if (navigator.clipboard?.writeText) { await navigator.clipboard.writeText(url); copied = true; }
+    } catch { copied = false; }
+    if (copied) {
+      shareCopied = true;
+      setTimeout(() => { shareCopied = false; }, 2000);
+    } else {
+      window.prompt('URL を選択してコピーしてください', url);
+    }
+  }
+
+  type SavedDeck = { id: string; name: string; createdAt: number; updatedAt: number; state: ReturnType<typeof buildStateObject> };
+
+  function loadSavedDecks(): SavedDeck[] { return loadJson<SavedDeck[]>(STORAGE_KEYS.SAVED_DECKS, []); }
+
+  function writeSavedDecks(decks: SavedDeck[]) { saveJson(STORAGE_KEYS.SAVED_DECKS, decks); }
+
+  function saveDeck() {
+    const hasCards = deckState.cards.some(c => c !== null);
+    if (!hasCards) { alert('デッキに衣装を1枚以上セットしてください'); return; }
+
+    const existing = loadSavedDecks();
+    const defaultName = `デッキ ${existing.length + 1}`;
+    const name = prompt('デッキ名を入力してください', defaultName);
+    if (!name) return;
+
+    const now = Date.now();
+    existing.push({ id: now.toString(36), name: name.trim() || defaultName, createdAt: now, updatedAt: now, state: buildStateObject() });
+    writeSavedDecks(existing);
+
+    deckSaved = true;
+    setTimeout(() => { deckSaved = false; }, 1500);
+  }
+
+  function showLoadDropdown() {
+    if (loadDeckItems !== null) { hideLoadDropdown(); return; }
+    const decks = loadSavedDecks();
+    loadDeckItems = decks.slice().reverse().map(d => ({
+      id: d.id,
+      name: d.name,
+      dateLabel: new Date(d.updatedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
+      cardCount: (d.state.deckIds || []).filter((id: number | null) => id != null).length,
+    }));
+  }
+
+  function hideLoadDropdown() { loadDeckItems = null; }
+
+  function loadDeck(deckId: string) {
+    const target = loadSavedDecks().find(d => d.id === deckId);
+    if (!target) return;
+    applyState(target.state);
+    saveState();
+    hideLoadDropdown();
+  }
 
   onMount(() => {
-    let allSongs: Song[] = initialSongs;
-    const allEventsForBonus: EventForBonus[] = initialEvents;
+    if (!tryRestoreFromUrl()) restoreState();
 
-    const defaultTierMap = buildLiveTierMap(allEventsForBonus);
+    refreshData('cards', fetchCardsJson, (fresh) => {
+      allCardsState = fresh as Card[];
+      deckState.cards = deckState.cards.map(c => c ? allCardsState.find(fc => fc.ID === c.ID) || null : null);
+    });
+    refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
+      allSongsState = fresh as Song[];
+      if (selectedSong) selectedSong = allSongsState.find(s => s.id === selectedSong!.id) || null;
+    });
+    refreshData('broachs', fetchFixedBroachsJson, (fresh) => {
+      allBroachsState = fresh as FixedBroach[];
+    });
 
-    function defaultTierFor(card: Card | null): EventBonusTier {
-      if (!card || card.ID == null) return 'none';
-      return defaultTierMap.get(card.ID) ?? 'none';
-    }
-
-    const _q = <T extends HTMLElement = HTMLElement>(id: string): T => rootEl.querySelector<T>(`#${id}`) as T;
-
-    handlePickImpl = (slot, card) => {
-      setCard(deckState, slot, card, defaultTierFor(card), allBroachsState);
-      saveState();
-    };
-    handleClearImpl = (slot) => {
-      clearSlot(deckState, slot);
-      saveState();
-    };
-    handleSwapImpl = (a, b) => {
-      swapSlots(deckState, a, b);
-      saveState();
-    };
-    handleDeckChangedImpl = () => {
-      saveState();
-    };
-    saveStateImpl = () => {
-      saveState();
-    };
-
-    function getSelectedSongIds(): Set<number> {
-      return new Set(loadJson<number[]>(STORAGE_KEYS.SELECTED_SONGS, []));
-    }
-
-    function rebuildSongSelect() {
-      const sel = _q<HTMLSelectElement>('song-select');
-      while (sel.children.length > 1) sel.removeChild(sel.lastChild!);
-      const pickedIds = getSelectedSongIds();
-      const pickedSongs = allSongs
-        .filter(s => s.id != null && pickedIds.has(s.id))
-        .sort((a, b) => (a.duration || 0) - (b.duration || 0));
-      if (pickedSongs.length > 0) {
-        const optgroup = document.createElement('optgroup');
-        optgroup.label = `選択中の曲（${pickedSongs.length}曲・秒数順）`;
-        for (const s of pickedSongs) {
-          const opt = document.createElement('option');
-          opt.value = String(s.id);
-          opt.textContent = `${s.song_name} (${s.difficulty || ''}) - ${s.duration || '?'}秒`;
-          optgroup.appendChild(opt);
-        }
-        sel.appendChild(optgroup);
-      }
-      const groups = new Map<string, Song[]>();
-      for (const s of allSongs) {
-        const cat = s.category || 'その他';
-        if (!groups.has(cat)) groups.set(cat, []);
-        groups.get(cat)!.push(s);
-      }
-      for (const [cat, songs] of groups) {
-        const optgroup = document.createElement('optgroup');
-        optgroup.label = cat;
-        for (const s of songs) {
-          const opt = document.createElement('option');
-          opt.value = String(s.id);
-          opt.textContent = `${s.song_name} (${s.difficulty || ''})`;
-          optgroup.appendChild(opt);
-        }
-        sel.appendChild(optgroup);
-      }
-    }
-
-    function initSongSelect() {
-      rebuildSongSelect();
-      const sel = _q<HTMLSelectElement>('song-select');
-      sel.addEventListener('change', () => {
-        const id = Number(sel.value);
-        selectedSong = allSongs.find(s => s.id === id) || null;
-        saveState();
-      });
-    }
-
-    function buildStateObject() {
-      return {
-        songId: selectedSong?.id ?? null,
-        deckIds: deckState.cards.map(c => c?.ID ?? null),
-        bonusTiers: [...deckState.bonusTiers],
-        trained: [...deckState.trained],
-        sharedBroachs: deckState.sharedBroachs.map(a => [...a]),
-        skillLevels: [...deckState.skillLevels],
-        badgeRate: Number(scoreUpBadgeRate) || 0,
-      };
-    }
-
-    function applyState(state: any) {
-      if (state.songId != null) {
-        const song = allSongs.find(s => s.id === state.songId);
-        if (song) {
-          selectedSong = song;
-          _q<HTMLSelectElement>('song-select').value = String(song.id);
-        }
-      } else {
-        selectedSong = null;
-        _q<HTMLSelectElement>('song-select').value = '';
-      }
-      if (Array.isArray(state.bonusTiers)) {
-        for (let i = 0; i < 6; i++) {
-          deckState.bonusTiers[i] = state.bonusTiers[i] || 'none';
-        }
-      }
-      if (Array.isArray(state.trained)) {
-        for (let i = 0; i < 6; i++) {
-          deckState.trained[i] = state.trained[i] !== false;
-        }
-      }
-      if (Array.isArray(state.sharedBroachs)) {
-        for (let i = 0; i < 6; i++) {
-          deckState.sharedBroachs[i] = Array.isArray(state.sharedBroachs[i]) ? state.sharedBroachs[i] : [];
-        }
-      }
-      if (Array.isArray(state.skillLevels)) {
-        for (let i = 0; i < 6; i++) {
-          const lv = state.skillLevels[i];
-          deckState.skillLevels[i] = (lv >= 1 && lv <= 5) ? lv : 5;
-        }
-      }
-      deckState.cards = [null, null, null, null, null, null];
-      if (Array.isArray(state.deckIds)) {
-        for (let i = 0; i < 6; i++) {
-          const id = state.deckIds[i];
-          if (id != null) {
-            deckState.cards[i] = allCardsState.find(c => c.ID === id) || null;
-          }
-        }
-      }
-      for (let i = 0; i < 6; i++) {
-        clampSharedBroachs(deckState, i, allBroachsState);
-      }
-      if (typeof state.badgeRate === 'number') {
-        scoreUpBadgeRate = state.badgeRate;
-      }
-    }
-
-    function saveState() {
-      saveJson(STORAGE_KEYS.SCORE_CALC_STATE, buildStateObject());
-    }
-
-    function restoreState() {
-      const state = loadJson<ReturnType<typeof buildStateObject> | null>(STORAGE_KEYS.SCORE_CALC_STATE, null);
-      if (state) applyState(state);
-    }
-
-    function tryRestoreFromUrl(): boolean {
-      if (typeof window === 'undefined') return false;
-      const search = window.location.search;
-      if (!search) return false;
-      const params = new URLSearchParams(search);
-      if (!params.has('dv')) return false;
-      const decoded = decodeParamsToDeck(params);
-      if (!decoded) return false;
-      applyState(decoded);
-      saveState();
-      window.history.replaceState(null, '', window.location.pathname);
-      return true;
-    }
-
-    async function shareDeckUrl() {
-      const state = buildStateObject();
-      if (isDeckEmpty(state)) {
-        alert('編成が空です。楽曲や衣装を選んでから共有してください。');
-        return;
-      }
-      const params = encodeDeckToParams(state);
-      const url = `${window.location.origin}${base}score-calc/?${params.toString()}`;
-      const btn = _q<HTMLButtonElement>('btn-share-url');
-      const originalLabel = btn.textContent;
-      let copied = false;
-      try {
-        if (navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(url);
-          copied = true;
-        }
-      } catch {
-        copied = false;
-      }
-      if (copied) {
-        btn.textContent = '✅ コピーしました';
-        btn.disabled = true;
-        setTimeout(() => {
-          btn.textContent = originalLabel;
-          btn.disabled = false;
-        }, 2000);
-      } else {
-        window.prompt('URL を選択してコピーしてください', url);
-      }
-    }
-
-    type SavedDeck = {
-      id: string;
-      name: string;
-      createdAt: number;
-      updatedAt: number;
-      state: ReturnType<typeof buildStateObject>;
-    };
-
-    function loadSavedDecks(): SavedDeck[] {
-      return loadJson<SavedDeck[]>(STORAGE_KEYS.SAVED_DECKS, []);
-    }
-
-    function writeSavedDecks(decks: SavedDeck[]) {
-      saveJson(STORAGE_KEYS.SAVED_DECKS, decks);
-    }
-
-    function saveDeck() {
-      const hasCards = deckState.cards.some(c => c !== null);
-      if (!hasCards) { alert('デッキに衣装を1枚以上セットしてください'); return; }
-
-      const existing = loadSavedDecks();
-      const defaultName = `デッキ ${existing.length + 1}`;
-      const name = prompt('デッキ名を入力してください', defaultName);
-      if (!name) return;
-
-      const now = Date.now();
-      const newDeck: SavedDeck = {
-        id: now.toString(36),
-        name: name.trim() || defaultName,
-        createdAt: now,
-        updatedAt: now,
-        state: buildStateObject(),
-      };
-      existing.push(newDeck);
-      writeSavedDecks(existing);
-
-      const btn = _q('btn-save-deck');
-      const orig = btn.textContent;
-      btn.textContent = '保存しました';
-      btn.classList.add('bg-green-100', 'text-green-700');
-      btn.classList.remove('bg-indigo-100', 'text-indigo-700');
-      setTimeout(() => {
-        btn.textContent = orig;
-        btn.classList.remove('bg-green-100', 'text-green-700');
-        btn.classList.add('bg-indigo-100', 'text-indigo-700');
-      }, 1500);
-    }
-
-    function showLoadDropdown() {
-      if (loadDeckItems !== null) { hideLoadDropdown(); return; }
-      const decks = loadSavedDecks();
-      loadDeckItems = decks.slice().reverse().map(d => ({
-        id: d.id,
-        name: d.name,
-        dateLabel: new Date(d.updatedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
-        cardCount: (d.state.deckIds || []).filter((id: number | null) => id != null).length,
-      }));
-    }
-
-    function hideLoadDropdown() {
-      loadDeckItems = null;
-    }
-
-    loadDeckImpl = (deckId: string) => {
-      const decks = loadSavedDecks();
-      const target = decks.find(d => d.id === deckId);
-      if (!target) return;
-      applyState(target.state);
-      saveState();
-      hideLoadDropdown();
-    };
-
-    // body-level dropdown-close handler (documented)
+    // dropdown 外側クリックで閉じる（document レベル）
     const bodyClickHandler = (e: MouseEvent) => {
       if (loadDeckItems !== null &&
           !(e.target as HTMLElement).closest('#load-deck-dropdown') &&
@@ -357,52 +228,33 @@
         hideLoadDropdown();
       }
     };
-
-    initSongSelect();
-
-    _q('btn-save-deck').addEventListener('click', saveDeck);
-    _q('btn-load-deck').addEventListener('click', showLoadDropdown);
-    _q('btn-share-url').addEventListener('click', shareDeckUrl);
     document.addEventListener('click', bodyClickHandler);
-
-    if (!tryRestoreFromUrl()) {
-      restoreState();
-    }
-
-    refreshData('cards', fetchCardsJson, (fresh) => {
-      allCardsState = fresh as Card[];
-      deckState.cards = deckState.cards.map(c => c ? allCardsState.find(fc => fc.ID === c.ID) || null : null);
-    });
-
-    refreshData('songs', async () => filterAllowedSongs(filterValidSongs(await fetchSongsJson())), (fresh) => {
-      allSongs = fresh as Song[];
-      if (selectedSong) {
-        selectedSong = allSongs.find(s => s.id === selectedSong!.id) || null;
-      }
-      rebuildSongSelect();
-      if (selectedSong) {
-        _q<HTMLSelectElement>('song-select').value = String(selectedSong.id);
-      }
-    });
-
-    refreshData('broachs', fetchFixedBroachsJson, (fresh) => {
-      allBroachsState = fresh as FixedBroach[];
-    });
-
-    return () => {
-      document.removeEventListener('click', bodyClickHandler);
-    };
+    return () => document.removeEventListener('click', bodyClickHandler);
   });
 </script>
 
-<div bind:this={rootEl}>
+<div>
   <!-- 楽曲サマリーバー（全幅・横長） -->
   <section class="bg-white dark:bg-slate-800 rounded-lg shadow p-4 mb-4">
     <div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-4 items-start">
       <div class="min-w-0">
         <label for="song-select" class="block text-xs font-bold text-gray-700 dark:text-slate-200 mb-2">🎵 楽曲</label>
-        <select id="song-select" class="w-full border border-gray-300 dark:border-slate-600 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400">
+        <select id="song-select" class="w-full border border-gray-300 dark:border-slate-600 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" value={selectedSong?.id != null ? String(selectedSong.id) : ''} onchange={handleSongChange}>
           <option value="">楽曲を選択</option>
+          {#if pickedSongs.length > 0}
+            <optgroup label={`選択中の曲（${pickedSongs.length}曲・秒数順）`}>
+              {#each pickedSongs as s (s.id)}
+                <option value={String(s.id)}>{s.song_name} ({s.difficulty || ''}) - {s.duration || '?'}秒</option>
+              {/each}
+            </optgroup>
+          {/if}
+          {#each categorizedSongs as [cat, songs] (cat)}
+            <optgroup label={cat}>
+              {#each songs as s}
+                <option value={String(s.id)}>{s.song_name} ({s.difficulty || ''})</option>
+              {/each}
+            </optgroup>
+          {/each}
         </select>
         <div id="song-info" class="mt-3" class:hidden={!selectedSong}>
           <dl class="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 text-xs">
@@ -445,7 +297,7 @@
         </label>
         <label class="flex items-center gap-2">
           <span class="text-xs text-gray-500 dark:text-slate-400 whitespace-nowrap">SCOREUPバッジ倍率</span>
-          <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm" min="0" max="100" step="1" bind:value={scoreUpBadgeRate} oninput={handleBadgeRateInput} />
+          <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm" min="0" max="100" step="1" bind:value={scoreUpBadgeRate} oninput={saveState} />
           <span class="text-xs text-gray-500 dark:text-slate-400">%</span>
         </label>
       </div>
@@ -458,16 +310,16 @@
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-sm font-bold text-gray-700 dark:text-slate-200">🎴 デッキ編成</h2>
         <div class="relative flex gap-2">
-          <button id="btn-save-deck" type="button" class="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded hover:bg-indigo-200 transition-colors">保存</button>
-          <button id="btn-load-deck" type="button" class="text-xs px-2 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-slate-200 rounded hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors">読込</button>
-          <button id="btn-share-url" type="button" class="text-xs px-2 py-1 bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors" aria-label="編成シェア URL をコピー">🔗 URLコピー</button>
+          <button id="btn-save-deck" type="button" class="text-xs px-2 py-1 {deckSaved ? 'bg-green-100 text-green-700' : 'bg-indigo-100 text-indigo-700'} rounded hover:bg-indigo-200 transition-colors" onclick={saveDeck}>{deckSaved ? '保存しました' : '保存'}</button>
+          <button id="btn-load-deck" type="button" class="text-xs px-2 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-slate-200 rounded hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors" onclick={showLoadDropdown}>読込</button>
+          <button id="btn-share-url" type="button" class="text-xs px-2 py-1 bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors" aria-label="編成シェア URL をコピー" disabled={shareCopied} onclick={shareDeckUrl}>{shareCopied ? '✅ コピーしました' : '🔗 URLコピー'}</button>
           <div id="load-deck-dropdown" class="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto" class:hidden={loadDeckItems === null}>
             {#if loadDeckItems !== null}
               {#if loadDeckItems.length === 0}
                 <div class="p-3 text-xs text-gray-400 dark:text-slate-500 text-center">保存されたデッキがありません</div>
               {:else}
                 {#each loadDeckItems as d (d.id)}
-                  <div class="load-deck-item flex items-center justify-between px-3 py-2 hover:bg-indigo-50 cursor-pointer border-b border-gray-100 dark:border-slate-800 last:border-0" data-deck-id={d.id} onclick={() => handleLoadDeckClick(d.id)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleLoadDeckClick(d.id); }}>
+                  <div class="load-deck-item flex items-center justify-between px-3 py-2 hover:bg-indigo-50 cursor-pointer border-b border-gray-100 dark:border-slate-800 last:border-0" data-deck-id={d.id} onclick={() => loadDeck(d.id)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') loadDeck(d.id); }}>
                     <div class="min-w-0 flex-1">
                       <div class="text-xs font-medium text-gray-700 dark:text-slate-200 truncate">{d.name}</div>
                       <div class="text-[10px] text-gray-400 dark:text-slate-500">{d.dateLabel} / {d.cardCount}枚</div>
@@ -480,7 +332,7 @@
           </div>
         </div>
       </div>
-      <DeckSlots deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} onSlotClick={handleSlotClick} onSwap={handleSwap} onChanged={handleDeckChanged} />
+      <DeckSlots deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} onSlotClick={handleSlotClick} onSwap={handleSwap} onChanged={saveState} />
     </section>
 
     <CardDetailTable deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} scoreUpAssist={scoreUpAssist} />


### PR DESCRIPTION
Phase 2.5（最終）。楽曲選択の宣言化・永続化系関数の最上位化・ボタン宣言化により、_q / rootEl / querySelector / innerHTML を全廃。onMount は refreshData + URL/state 復元 + document click のみ。ScoreCalc.svelte は 1831 行（Phase 2 開始前）→ 344 行。localStorage / 共有 URL 形式は不変（E2E 永続化 3 件 PASS）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)