### PR TITLE
refactor(data): eventsForBonus 変換を fetchEventsCsv に共通化し re-export を整理

### DIFF
--- a/src/lib/data/fetchEventsCsv.ts
+++ b/src/lib/data/fetchEventsCsv.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { EventForBonus } from './eventBonusTiers';
 
 export interface EventSpecialTier {
   cardIds: number[];
@@ -134,6 +135,19 @@ export async function fetchEventsCsv(): Promise<EventRow[]> {
     silver: readTier(r, 2),
     bronze: readTier(r, 3),
   })).filter(e => e.id > 0 && e.eventname && e.start_date && e.end_date);
+}
+
+/** EventRow をクライアントへ渡す特効ボーナス用の最小形に変換する（各ページで重複していた map を集約） */
+export function toEventForBonus(e: EventRow): EventForBonus & { eventname: string } {
+  return {
+    id: e.id,
+    eventname: e.eventname,
+    start_date: e.start_date,
+    end_date: e.end_date,
+    gold: e.gold.cardIds,
+    silver: e.silver.cardIds,
+    bronze: e.bronze.cardIds,
+  };
 }
 
 const EFFECT_LABEL: Record<string, string> = {

--- a/src/lib/score/constants.ts
+++ b/src/lib/score/constants.ts
@@ -32,5 +32,3 @@ export const DEFAULT_CENTER_SKILL_RATE = 6;
 export const TRAIN_BONUS: Record<string, number> = {
   UR: 1800,
 };
-
-export { EVENT_BONUS_MULTIPLIER } from '../data/eventBonusTiers';

--- a/src/lib/score/teamBuilder.ts
+++ b/src/lib/score/teamBuilder.ts
@@ -12,9 +12,9 @@ import {
 } from './types';
 import {
   CENTER_SKILL_RATES, DEFAULT_CENTER_SKILL_RATE,
-  EVENT_BONUS_MULTIPLIER, TRAIN_BONUS,
+  TRAIN_BONUS,
 } from './constants';
-import type { EventBonusTier } from '../data/eventBonusTiers';
+import { EVENT_BONUS_MULTIPLIER, type EventBonusTier } from '../data/eventBonusTiers';
 import { resolveDeckBroachs, calcBroachScoreBonus } from './broachResolver';
 import { SKILL_TYPE } from '../data/fetchCardsJson';
 import { SHARED_BROACHS } from '../data/sharedBroachs';

--- a/src/pages/cards/index.astro
+++ b/src/pages/cards/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import CardList from '../../components/CardList.svelte';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
-import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
+import { fetchEventsCsv, toEventForBonus } from '../../lib/data/fetchEventsCsv.ts';
 import { CARD_THUMB_BASE_URL, PAGE_SIZE } from '../../lib/constants';
 
 const [allCards, allEvents] = await Promise.all([
@@ -11,14 +11,7 @@ const [allCards, allEvents] = await Promise.all([
 ]);
 const skillTypes = [...new Set(allCards.map((c: any) => c.ap_skill_type).filter(Boolean))].sort() as string[];
 
-const eventsForBonus = allEvents.map(e => ({
-  id: e.id,
-  start_date: e.start_date,
-  end_date: e.end_date,
-  gold: e.gold.cardIds,
-  silver: e.silver.cardIds,
-  bronze: e.bronze.cardIds,
-}));
+const eventsForBonus = allEvents.map(toEventForBonus);
 
 const base = import.meta.env.BASE_URL;
 ---

--- a/src/pages/score-calc/index.astro
+++ b/src/pages/score-calc/index.astro
@@ -4,7 +4,7 @@ import ScoreCalc from '../../components/ScoreCalc.svelte';
 import { fetchCardsJson } from '../../lib/data/fetchCardsJson.ts';
 import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../lib/data/fetchSongsJson.ts';
 import { fetchFixedBroachsJson } from '../../lib/data/fetchFixedBroachsJson.ts';
-import { fetchEventsCsv } from '../../lib/data/fetchEventsCsv.ts';
+import { fetchEventsCsv, toEventForBonus } from '../../lib/data/fetchEventsCsv.ts';
 
 const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchCardsJson(),
@@ -15,14 +15,7 @@ const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
 
 const allSongs = filterAllowedSongs(filterValidSongs(allSongsRaw));
 
-const eventsForBonus = allEvents.map(e => ({
-  id: e.id,
-  start_date: e.start_date,
-  end_date: e.end_date,
-  gold: e.gold.cardIds,
-  silver: e.silver.cardIds,
-  bronze: e.bronze.cardIds,
-}));
+const eventsForBonus = allEvents.map(toEventForBonus);
 
 const base = import.meta.env.BASE_URL;
 ---

--- a/src/pages/score-calc/max-score-finder/index.astro
+++ b/src/pages/score-calc/max-score-finder/index.astro
@@ -4,7 +4,7 @@ import MaxScoreFinder from '../../../components/MaxScoreFinder.svelte';
 import { fetchCardsJson } from '../../../lib/data/fetchCardsJson';
 import { fetchSongsJson, filterValidSongs, filterAllowedSongs } from '../../../lib/data/fetchSongsJson';
 import { fetchFixedBroachsJson } from '../../../lib/data/fetchFixedBroachsJson';
-import { fetchEventsCsv } from '../../../lib/data/fetchEventsCsv';
+import { fetchEventsCsv, toEventForBonus } from '../../../lib/data/fetchEventsCsv';
 
 const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
   fetchCardsJson(),
@@ -15,15 +15,7 @@ const [allCards, allSongsRaw, allBroachs, allEvents] = await Promise.all([
 
 const allSongs = filterAllowedSongs(filterValidSongs(allSongsRaw));
 
-const eventsForBonus = allEvents.map(e => ({
-  id: e.id,
-  eventname: e.eventname,
-  start_date: e.start_date,
-  end_date: e.end_date,
-  gold: e.gold.cardIds,
-  silver: e.silver.cardIds,
-  bronze: e.bronze.cardIds,
-}));
+const eventsForBonus = allEvents.map(toEventForBonus);
 
 const base = import.meta.env.BASE_URL;
 


### PR DESCRIPTION
Phase 4.1。3 つの .astro ページで重複していた EventRow → EventForBonus 変換を toEventForBonus に集約（型のみ import で fs 依存はビルド時のまま）。EVENT_BONUS_MULTIPLIER の re-export 残骸も廃止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)