### PR TITLE
docs: スクリプトの用途明記と CLAUDE.md の命名規約・構成更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,8 @@ IDOLiSH7 カードデータベースの Astro 6 静的サイト（Cloudflare Wor
 
 | モジュール | 役割 |
 |-----------|------|
-| `src/lib/cardListRenderer.ts` | カード一覧のフィルタリング・ソート・ページネーション・所持数管理 |
+| `src/lib/cardListData.ts` | カード一覧の行データ型 (`CardListItem`) 定義。フィルタ/ソート/ページネーションの実装は `src/components/CardList.svelte` |
+| `src/lib/cardFilter.ts` | カード名・キャラ名の部分一致検索述語（`cardTextMatches`） |
 | `src/lib/donutChart.ts` | 属性比率のドーナツチャート描画 |
 | `src/lib/storage.ts` | localStorage ラッパー。キー一覧は `STORAGE_KEYS` で集中管理（新しいキー追加時はここに追記） |
 | `src/lib/ui.ts` | UI 共通ヘルパー |
@@ -147,6 +148,17 @@ IDOLiSH7 カードデータベースの Astro 6 静的サイト（Cloudflare Wor
 | `skillFormatter.ts` | スキル表示文字列の生成 |
 | `shrinkExclusion.ts` | 縮小スキルの並び順検証ロジック |
 | `specDiagrams.ts` | スキル仕様可視化用ダイアグラム生成 |
+| `deckState.ts` | デッキ編成状態（`DeckState`、6 スロット: 0=センター, 1-4=メンバー, 5=フレンド。表示順は `DISPLAY_ORDER`） |
+| `maxScoreFinder.ts` | 編成組合計算（max-score-finder）の総当たり探索ロジック。UI / Worker 両方から import される純粋モジュール |
+| `maxScoreFinder.worker.ts` | 探索 Web Worker。chunk を受けて `maxScoreFinder.ts` の `evaluateChunk` に委譲 |
+| `searchWorkerPool.ts` | 探索 Worker プール制御（Worker 生成・chunk dispatch・進捗集約・abort・terminate） |
+
+スコア計算系コンポーネントの構成:
+
+| ディレクトリ | 内容 |
+|-------------|------|
+| `src/components/score/` | `ScoreCalc.svelte` / `MaxScoreFinder.svelte` の子コンポーネント群（`CardPickerModal` / `DeckSlots` / `CardDetailTable` / `ScoreCalcResults` / `SearchResults` 等） |
+| `src/components/ui/` | 汎用バッジ（`RarityBadge` / `AttributeBadge`） |
 
 ### Page Patterns
 
@@ -259,6 +271,13 @@ Tailwind CSS v4 integrated via `@tailwindcss/vite` plugin (not the legacy `@astr
 ユーザー可視テキスト（HTML、ラベル、alert/placeholder、aria-label、SVG `<title>` など）では「カード」ではなく **「衣装」** を用いる。アイドリッシュセブンの用語に揃えるため。
 
 内部識別子（コード中の変数名・関数名・ファイル名・URL パス・localStorage キーなど）は引き続き `card` を使用する（例: `cards/[id].astro`、`i7_card_counts`、`fetchCardsJson.ts`、`CardList.svelte`）。
+
+## 命名規約
+
+- イベント変数は `event`（ループ内の短縮は `ev` まで可。`evt` 等は使わない）
+- ブローチは内部識別子で `broach`（本リポジトリの慣用綴り。`brooch` に直さない）。固有ブローチ = `FixedBroach`（カード紐付き）、共有ブローチ = `SHARED_BROACHS`（`src/lib/data/sharedBroachs.ts`）
+- スロット index は `slotIndex`（0=センター, 1-4=メンバー, 5=フレンド。表示順は `DISPLAY_ORDER`）
+- デッキ編成状態は `DeckState`（`src/lib/score/deckState.ts`）を使い、個別配列を新設しない
 
 ## 衣装表示参考
 

--- a/scripts/apply-dark-variants.mjs
+++ b/scripts/apply-dark-variants.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * 既存 Tailwind クラスに dark: バリアントを系統的に追加する一回限りのスクリプト。
- *
- *   node scripts/apply-dark-variants.mjs
+ * 既存 Tailwind クラスに dark: バリアントを系統的に一括追加するコードモッドスクリプト。
+ * 実行: node scripts/apply-dark-variants.mjs
+ * 頻度: 一回限り（ダークテーマ導入時に使用済み。dark: バリアントの一括追加が再度必要になった場合のみ再利用）
  *
  * 各マッピングについて、
  *   1. クラス文字列 (class="...", class:foo="...") の中で対象トークン X を検出

--- a/scripts/extract-test-fixtures.ts
+++ b/scripts/extract-test-fixtures.ts
@@ -1,7 +1,8 @@
 /**
- * tests/fixtures/ 配下に全カード・全楽曲・全固定ブローチのスナップショット JSON を生成するワンショットスクリプト。
- *
- * 実行: npm run extract-fixtures
+ * Google Sheets から全カード・全楽曲・全固定ブローチを取得し、tests/fixtures/ 配下に
+ * テスト用スナップショット JSON を生成する。
+ * 実行: npm run extract-fixtures （= tsx scripts/extract-test-fixtures.ts）
+ * 頻度: 必要時のみ（スプレッドシートのスキーマ変更・フィクスチャ更新が必要なときに再実行）
  *
  * 出力物:
  *   - tests/fixtures/cards.json   全カードデータ

--- a/scripts/fetch-song-images.mjs
+++ b/scripts/fetch-song-images.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * IDOLiSH7 Wiki から楽曲カバー画像をクローリングし、
- * Google Spreadsheet の楽曲IDをファイル名として保存するスクリプト。
- *
- * Usage: node scripts/fetch-song-images.mjs
+ * IDOLiSH7 Wiki (idolish7.miraheze.org) から不足している楽曲ジャケット画像をクローリングし、
+ * Google Spreadsheet の楽曲 ID をファイル名として public/assets/songs/ に保存する。
+ * 実行: node scripts/fetch-song-images.mjs
+ * 頻度: GitHub Actions cron から定期実行（.github/workflows/fetch-new-songs.yml、毎時 00 分 UTC）。手動実行も可
  */
 
 import { writeFile, mkdir } from 'node:fs/promises';

--- a/scripts/generate-pwa-icons.mjs
+++ b/scripts/generate-pwa-icons.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * PWA アイコン PNG を public/ 配下に生成する。
- *
- *   node scripts/generate-pwa-icons.mjs
+ * PWA アイコン PNG を public/ 配下に生成する（sharp 依存）。
+ * 実行: node scripts/generate-pwa-icons.mjs
+ * 頻度: 必要時のみ（favicon.svg / アイコンデザインを変更したときだけ再生成。生成済み PNG は commit 済み）
  *
  * 出力ファイル:
  *   - public/pwa-192x192.png

--- a/scripts/refetch-card-images.mjs
+++ b/scripts/refetch-card-images.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 /**
- * verify-card-images.mjs の出力を元に、
- * 差分のあったカード画像をコピー元から再取得してローカルを上書きする。
+ * verify-card-images.mjs の出力を元に、差分のあったカード画像をコピー元
+ * (i7.step-on-dream.net) から再取得してローカル (public/assets/) を上書きする。
+ * 実行: node scripts/refetch-card-images.mjs --type th --from tmp/verify-th.json （詳細は下記 Usage）
+ * 頻度: 必要時のみ（verify-card-images.mjs で不一致を検出したときの手動修復用）
  *
  * 安全のため、次の条件を満たすもののみ上書きする:
  *   - HTTP 200

--- a/scripts/verify-card-images.mjs
+++ b/scripts/verify-card-images.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 /**
- * ローカルのカード画像がコピー元サーバーと一致するかを網羅的に検証する。
+ * ローカルのカード画像 (public/assets/cards | th_cards) がコピー元サーバー
+ * (i7.step-on-dream.net) と一致するかを網羅的に検証する。
+ * 実行: node scripts/verify-card-images.mjs [options] （結果は --out で JSON 出力し refetch-card-images.mjs に渡せる）
+ * 頻度: 必要時のみ（画像破損・プレースホルダー混入が疑われるときの手動検証用）
  *
  * - デフォルトは Content-Length 比較（HEAD のみ）で高速にサイズ不一致を検出
  * - --hash で全ファイルを GET して SHA-256 比較（厳密だが重い）


### PR DESCRIPTION
Phase 4.2 / 4.3。scripts/ 6 ファイルに用途・実行方法・頻度のヘッダを追記。CLAUDE.md の stale 記述（cardListRenderer.ts）を修正し、Phase 1〜3 で追加されたモジュール・コンポーネント構成と命名規約セクションを追記。ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)