### PR TITLE
feat: スコア計算に「所持ブローチ縛り」トグルを追加 (Phase 2)

### DIFF
--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -11,6 +11,9 @@
   import { encodeDeckToParams, decodeParamsToDeck, isDeckEmpty } from '../lib/score/deckShareUrl';
   import { createEmptyDeckState, swapSlots, clampSharedBroachs, setCard, clearSlot, SLOT_LABELS } from '../lib/score/deckState';
   import { DEFAULT_SCOREUP_BADGE_RATE } from '../lib/score/constants';
+  import { broachViolations } from '../lib/score/broachInventory';
+  import { SHARED_BROACHS } from '../lib/data/sharedBroachs';
+  import { allBroachCounts, reloadBroachCountsFromStorage, totalOwnedBroachs } from '../lib/stores/broachCounts.svelte';
   import CardPickerModal from './score/CardPickerModal.svelte';
   import DeckSlots from './score/DeckSlots.svelte';
   import CardDetailTable from './score/CardDetailTable.svelte';
@@ -28,6 +31,14 @@
   // スキルオプション
   let scoreUpAssist = $state(false);
   let scoreUpBadgeRate = $state(DEFAULT_SCOREUP_BADGE_RATE);
+
+  // 所持ブローチ縛り (共通ブローチの選択肢を登録した所持数で制限。フレンド枠は対象外)
+  let ownedBroachLimit = $state(false);
+  const broachCounts = $derived(allBroachCounts());
+  const violationNames = $derived(
+    broachViolations(deckState.sharedBroachs, broachCounts)
+      .map((id) => SHARED_BROACHS.find((sb) => sb.id === id)?.name ?? `#${id}`)
+  );
 
   let picker: CardPickerModal | undefined;
 
@@ -95,6 +106,7 @@
       sharedBroachs: deckState.sharedBroachs.map(a => [...a]),
       skillLevels: [...deckState.skillLevels],
       badgeRate: Number(scoreUpBadgeRate) || 0,
+      ownedBroachLimit,
     };
   }
 
@@ -123,6 +135,7 @@
     }
     for (let i = 0; i < 6; i++) clampSharedBroachs(deckState, i, allBroachsState);
     if (typeof state.badgeRate === 'number') scoreUpBadgeRate = state.badgeRate;
+    if (typeof state.ownedBroachLimit === 'boolean') ownedBroachLimit = state.ownedBroachLimit;
   }
 
   function saveState() { saveJson(STORAGE_KEYS.SCORE_CALC_STATE, buildStateObject()); }
@@ -206,6 +219,7 @@
   }
 
   onMount(() => {
+    reloadBroachCountsFromStorage();
     if (!tryRestoreFromUrl()) restoreState();
 
     refreshData('cards', fetchCardsJson, (fresh) => {
@@ -300,6 +314,10 @@
           <input type="number" id="opt-scoreup-badge-rate" class="w-20 border border-gray-300 dark:border-slate-600 rounded px-2 py-1 text-sm" min="0" max="100" step="1" bind:value={scoreUpBadgeRate} oninput={saveState} />
           <span class="text-xs text-gray-500 dark:text-slate-400">%</span>
         </label>
+        <label class="flex items-center gap-2">
+          <input type="checkbox" id="opt-owned-broach-limit" class="rounded" bind:checked={ownedBroachLimit} onchange={saveState} />
+          <span>所持ブローチ縛り（共通ブローチを登録した所持数の範囲で選択。フレンド枠は対象外）</span>
+        </label>
       </div>
       <p class="text-[11px] text-gray-400 dark:text-slate-500 mt-2">バッジ倍率: 0 で未装着、例: 15 → ×1.15</p>
     </div>
@@ -332,7 +350,13 @@
           </div>
         </div>
       </div>
-      <DeckSlots deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} onSlotClick={handleSlotClick} onSwap={handleSwap} onChanged={saveState} />
+      <DeckSlots deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} onSlotClick={handleSlotClick} onSwap={handleSwap} onChanged={saveState} ownedBroachLimit={ownedBroachLimit} broachCounts={broachCounts} />
+      {#if ownedBroachLimit && totalOwnedBroachs() === 0}
+        <p class="mt-2 text-xs text-amber-600">共通ブローチが未登録です。<a class="underline" href={`${base}shared-broach/`}>共通ブローチ登録ページ</a>で所持数を登録してください。</p>
+      {/if}
+      {#if ownedBroachLimit && violationNames.length > 0}
+        <p class="mt-2 text-xs text-red-600">⚠️ 所持数を超える共通ブローチが装備されています: {violationNames.join('、')}（装備はそのまま残ります。選び直すと所持数の範囲に制限されます）</p>
+      {/if}
     </section>
 
     <CardDetailTable deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} scoreUpAssist={scoreUpAssist} />

--- a/src/components/score/DeckSlots.svelte
+++ b/src/components/score/DeckSlots.svelte
@@ -12,11 +12,12 @@
   import type { SharedBroach } from '../../lib/data/sharedBroachs';
   import { ATTR_HEX } from '../../lib/constants';
   import { normalizeAttribute } from '../../lib/score/types';
+  import { countUsedBroachs } from '../../lib/score/broachInventory';
   import { cardThumbUrl } from '../../lib/ui';
   import RarityBadge from '../ui/RarityBadge.svelte';
   import AttributeBadge from '../ui/AttributeBadge.svelte';
 
-  let { deckState, selectedSong, allBroachs, onSlotClick, onSwap, onChanged }: {
+  let { deckState, selectedSong, allBroachs, onSlotClick, onSwap, onChanged, ownedBroachLimit = false, broachCounts = {} }: {
     deckState: DeckState;            // 親の $state proxy（カード配置等の mutate は親側）
     selectedSong: Song | null;
     allBroachs: FixedBroach[];
@@ -26,6 +27,10 @@
     onSwap: (a: number, b: number) => void;
     /** スロット内の select/checkbox 変更。値の更新は子が deckState に直接行い、この通知で親が再計算+保存する */
     onChanged: () => void;
+    /** 所持ブローチ縛り: 自チーム枠 (slot 0-4) の共通ブローチ選択肢を所持数で制限する */
+    ownedBroachLimit?: boolean;
+    /** broachId(文字列) → 所持数 (ownedBroachLimit 時に使用) */
+    broachCounts?: Record<string, number>;
   } = $props();
 
   let gridEl: HTMLDivElement;
@@ -148,6 +153,17 @@
     if (sb.melody) stats.push(`M+${sb.melody}`);
     const cond = sb.targetAttribute ? `${sb.targetAttribute}属性` : '';
     return cond ? `${sb.name} (${cond} ${stats.join('/')})` : `${sb.name} (${stats.join('/')})`;
+  }
+
+  /** 所持ブローチ縛り時の選択肢。slot 5 (フレンド) と OFF 時は全種を返す */
+  function selectableBroachs(slot: number, idx: number): SharedBroach[] {
+    if (!ownedBroachLimit || slot === 5) return SHARED_BROACHS;
+    const used = countUsedBroachs(deckState.sharedBroachs, slot, idx);
+    const current = deckState.sharedBroachs[slot]?.[idx] ?? 0;
+    return SHARED_BROACHS.filter((sb) => {
+      if (sb.id === current) return true; // 選択中は常に残す
+      return (broachCounts[String(sb.id)] ?? 0) - (used.get(sb.id) ?? 0) > 0;
+    });
   }
 
   function bonusTierSelectClass(tier: EventBonusTier): string {
@@ -384,7 +400,7 @@
                 onchange={(e) => onSharedBroachChange(e, i, s)}
               >
                 <option value={0}>共通ブローチ{maxShared > 1 ? (s + 1) : ''}を選択</option>
-                {#each SHARED_BROACHS as sb (sb.id)}
+                {#each selectableBroachs(i, s) as sb (sb.id)}
                   <option value={sb.id}>{sharedBroachOptionLabel(sb)}</option>
                 {/each}
               </select>

--- a/src/lib/score/broachInventory.ts
+++ b/src/lib/score/broachInventory.ts
@@ -1,0 +1,35 @@
+/**
+ * 共通ブローチ所持数と装備状況の突合ヘルパ。
+ * 所持制約の対象は自チーム 5 枠 (slot 0-4) のみ。フレンド枠 (slot 5) は対象外。
+ */
+
+/** slot 0-4 で使用中の共通ブローチ個数を broachId ごとに数える */
+export function countUsedBroachs(
+  sharedBroachs: number[][],
+  excludeSlot?: number,
+  excludeIdx?: number,
+): Map<number, number> {
+  const used = new Map<number, number>();
+  for (let slot = 0; slot <= 4; slot++) {
+    const arr = sharedBroachs[slot] ?? [];
+    for (let idx = 0; idx < arr.length; idx++) {
+      if (slot === excludeSlot && idx === excludeIdx) continue;
+      const id = arr[idx];
+      if (!id) continue;
+      used.set(id, (used.get(id) ?? 0) + 1);
+    }
+  }
+  return used;
+}
+
+/** 所持数を超過して装備されている broachId のリスト (slot 0-4 のみ対象) */
+export function broachViolations(
+  sharedBroachs: number[][],
+  counts: Record<string, number>,
+): number[] {
+  const over: number[] = [];
+  for (const [id, n] of countUsedBroachs(sharedBroachs)) {
+    if (n > (counts[String(id)] ?? 0)) over.push(id);
+  }
+  return over;
+}

--- a/tests/unit/score/broachInventory.test.ts
+++ b/tests/unit/score/broachInventory.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { countUsedBroachs, broachViolations } from '../../../src/lib/score/broachInventory';
+
+describe('broachInventory (共通ブローチ在庫突合)', () => {
+  it('countUsedBroachs: slot 0-4 のみ数え、フレンド枠(5)は無視する', () => {
+    const shared = [[1], [1, 2], [], [], [3], [1, 1]];
+    const used = countUsedBroachs(shared);
+    expect(used.get(1)).toBe(2);
+    expect(used.get(2)).toBe(1);
+    expect(used.get(3)).toBe(1);
+  });
+
+  it('countUsedBroachs: excludeSlot/excludeIdx で対象セレクト自身を除外できる', () => {
+    const shared = [[1], [1, 2], [], [], [], []];
+    const used = countUsedBroachs(shared, 1, 0);
+    expect(used.get(1)).toBe(1);
+  });
+
+  it('countUsedBroachs: 0 (未選択) は数えない', () => {
+    const used = countUsedBroachs([[0, 1], [], [], [], [], []]);
+    expect(used.get(1)).toBe(1);
+    expect(used.has(0)).toBe(false);
+  });
+
+  it('countUsedBroachs: 配列が欠けたスロットを許容する', () => {
+    const used = countUsedBroachs([[1]]);
+    expect(used.get(1)).toBe(1);
+  });
+
+  it('broachViolations: 所持数超過の broachId を返す', () => {
+    const shared = [[1, 1], [1], [], [2], [], []];
+    expect(broachViolations(shared, { '1': 2, '2': 1 })).toEqual([1]);
+    expect(broachViolations(shared, { '1': 3, '2': 1 })).toEqual([]);
+  });
+
+  it('broachViolations: 未登録 (counts 空) で装備があれば全て違反になる', () => {
+    expect(broachViolations([[1], [], [], [], [], []], {})).toEqual([1]);
+  });
+
+  it('broachViolations: フレンド枠の装備は違反にならない', () => {
+    expect(broachViolations([[], [], [], [], [], [1, 1]], {})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

ADR 0004 の Phase 2（Phase 1: #291 の続き）。

- スキルオプションに「**所持ブローチ縛り**」チェックボックスを追加（`i7_score_calc_state` に永続化）
- ON 時、自チーム 5 枠（センター + メンバー4）の共通ブローチ選択肢を「登録した所持数 −（他スロットでの使用数）」の残量があるものに制限。選択中の値は常に選択肢に残す
- フレンド枠（slotIndex 5）は他人のカードのため対象外（従来どおり全 26 種・同種重複可）
- 未登録時は登録ページへの案内、所持数超過の保存デッキ読込時は警告表示のみ（装備は自動クリアしない）
- 在庫突合ロジックは純粋モジュール `src/lib/score/broachInventory.ts` に切り出し、Vitest 7 件追加（236 件全 PASS）

dev サーバーで選択肢の絞り込み・在庫消費・警告・OFF 時の従来挙動・永続化を実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)