### PR TITLE
fix: 衣装比較のサムネイルを card.cardID から card.ID に修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,10 @@ IDOLiSH7 カードデータベースの Astro 6 静的サイト（Cloudflare Wor
 
 | 種別 | ディレクトリ | URL パターン |
 |------|-------------|-------------|
-| フルサイズ画像 | `public/assets/cards/` | `{BASE_URL}assets/cards/{cardID}.png` |
-| サムネイル画像 | `public/assets/th_cards/` | `{BASE_URL}assets/th_cards/{cardID}.png` |
+| フルサイズ画像 | `public/assets/cards/` | `{BASE_URL}assets/cards/{ID}.png` |
+| サムネイル画像 | `public/assets/th_cards/` | `{BASE_URL}assets/th_cards/{ID}.png` |
+
+> ⚠️ **`Card.ID` と `Card.cardID` は別物**（`fetchCardsJson.ts` で別フィールド）。画像ファイル名・カード詳細パス (`cards/{id}/`)・localStorage の所持数キー・特効ティア照合など、**カードを指す ID はすべて `Card.ID`** を使う。`cardID` は固有ブローチ照合（`FixedBroach.card_id === Card.cardID`）など限られた用途専用で、画像やルーティングに使うと別カードを指してしまう。画像 URL は文字列を直書きせず `cardImageUrl(card.ID)` / `cardThumbUrl(card.ID)`（`src/lib/ui.ts`）を使うこと。
 
 画像・イベント DB はゲームサーバー (`i7.step-on-dream.net`) から GitHub Actions の cron ワークフローで自動取得され、PR として追加される:
 

--- a/src/components/compare/CompareDetailPanel.svelte
+++ b/src/components/compare/CompareDetailPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { formatScore, type CardStrengthEntry } from '../../lib/score/cardStrength';
-  import { ATTR_HEX, CARD_THUMB_BASE_URL } from '../../lib/constants';
+  import { ATTR_HEX } from '../../lib/constants';
+  import { cardThumbUrl } from '../../lib/ui';
 
   type Props = {
     entries: CardStrengthEntry[];
@@ -51,7 +52,7 @@
               <th class="px-2 py-1 text-center font-medium">
                 <div class="flex flex-col items-center gap-0.5">
                   <img
-                    src={`${CARD_THUMB_BASE_URL}/${entry.card.cardID}.png`}
+                    src={cardThumbUrl(entry.card.ID ?? '')}
                     alt={entry.card.cardname || ''}
                     loading="lazy"
                     class="w-10 h-10 rounded border-2 object-cover"

--- a/src/components/compare/ScoreUpChart.svelte
+++ b/src/components/compare/ScoreUpChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { formatScore, type CardStrengthEntry } from '../../lib/score/cardStrength';
-  import { ATTR_HEX, CARD_THUMB_BASE_URL } from '../../lib/constants';
+  import { ATTR_HEX } from '../../lib/constants';
+  import { cardThumbUrl } from '../../lib/ui';
   import { bonusBadgeHtml, type EventBonusTier } from '../../lib/data/eventBonusTiers';
 
   type Props = {
@@ -30,6 +31,7 @@
           type="button"
           class="flex flex-col items-center w-16 shrink-0 cursor-pointer"
           data-testid="scoreup-bar"
+          data-card-id={entry.card.ID ?? ''}
           title={entry.card.cardname}
           onclick={() => onToggle(entry)}
         >
@@ -39,7 +41,7 @@
             <span class="block w-full bg-indigo-500 dark:bg-indigo-400" style={`height:${px(entry.baseScore)}px`}></span>
           </span>
           <img
-            src={`${CARD_THUMB_BASE_URL}/${entry.card.cardID}.png`}
+            src={cardThumbUrl(entry.card.ID ?? '')}
             alt={entry.card.cardname || ''}
             loading="lazy"
             class="w-12 h-12 mt-1.5 rounded border-[3px] object-cover"

--- a/src/components/compare/ShrinkChart.svelte
+++ b/src/components/compare/ShrinkChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { shrinkTieKey, type CardStrengthEntry } from '../../lib/score/cardStrength';
-  import { ATTR_HEX, CARD_THUMB_BASE_URL } from '../../lib/constants';
+  import { ATTR_HEX } from '../../lib/constants';
+  import { cardThumbUrl } from '../../lib/ui';
   import { bonusBadgeHtml, type EventBonusTier } from '../../lib/data/eventBonusTiers';
 
   type Props = {
@@ -68,7 +69,7 @@
                 onclick={() => onToggle(entry)}
               >
                 <img
-                  src={`${CARD_THUMB_BASE_URL}/${entry.card.cardID}.png`}
+                  src={cardThumbUrl(entry.card.ID ?? '')}
                   alt={entry.card.cardname || ''}
                   loading="lazy"
                   class="w-12 h-12 rounded border-[3px] object-cover"

--- a/tests/card-compare.test.ts
+++ b/tests/card-compare.test.ts
@@ -19,6 +19,16 @@ test.describe('衣装比較ページ', () => {
     await expect(page.getByTestId('shrink-col').first()).toBeVisible({ timeout: 20000 });
   });
 
+  test('棒のサムネイルが card.ID ベースの th_cards 画像を指す', async ({ page }) => {
+    const bar = page.getByTestId('scoreup-bar').first();
+    await bar.waitFor({ timeout: 20000 });
+    const cardId = await bar.getAttribute('data-card-id');
+    const src = await bar.locator('img').getAttribute('src');
+    // cardID ではなく ID ベースであること（過去のフィールド取り違えバグの再発防止）
+    expect(cardId).toBeTruthy();
+    expect(src).toMatch(new RegExp(`/assets/th_cards/${cardId}\\.png$`));
+  });
+
   test('棒をクリックすると詳細比較パネルが開閉する', async ({ page }) => {
     const bar = page.getByTestId('scoreup-bar').first();
     await bar.waitFor({ timeout: 20000 });


### PR DESCRIPTION
## 原因

`Card` には `ID` と `cardID` という別フィールドがあり、サムネイル画像は `ID` で命名されている（アプリ全体が `cardThumbUrl(card.ID)` を使用）。しかし衣装比較の 3 コンポーネントだけが `card.cardID` で URL を組み立てていたため、別カードの画像／404 を表示していた。

## 修正

- `ScoreUpChart` / `ShrinkChart` / `CompareDetailPanel` のサムネイル src を `cardThumbUrl(entry.card.ID)` に統一（インライン文字列結合を廃止）
- E2E に「棒のサムネイル src が `data-card-id`(=`card.ID`) と一致する」アサーションを追加（取り違え再発防止）
- `CLAUDE.md` の Card Images 節を実体（`{ID}`）に修正し、`ID` と `cardID` の使い分け注意を明記

## 確認

- E2E 6 件パス（新アサーション含む）/ `astro check` 型エラー 0
- dev サーバーで先頭バーのサムネイルが `th_cards/{ID}.png` を指し画像が正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)