### PR TITLE
fix: 衣装比較のスキル表示で判定強化/判定ガードの括弧表記を除外

### DIFF
--- a/src/components/compare/CompareDetailPanel.svelte
+++ b/src/components/compare/CompareDetailPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { formatScore, type CardStrengthEntry } from '../../lib/score/cardStrength';
+  import { skillTypeShortLabel } from '../../lib/score/skillFormatter';
   import { ATTR_HEX } from '../../lib/constants';
   import { cardThumbUrl } from '../../lib/ui';
 
@@ -95,7 +96,7 @@
           <tr>
             <td class="text-gray-500 pr-2 py-1">スキル</td>
             {#each entries as entry (entry.card.ID)}
-              <td class="px-2 py-1 text-center whitespace-nowrap">{entry.skill?.originalType ?? entry.card.ap_skill_type ?? 'スキルなし'}</td>
+              <td class="px-2 py-1 text-center whitespace-nowrap">{skillTypeShortLabel(entry.skill?.originalType ?? entry.card.ap_skill_type)}</td>
             {/each}
           </tr>
           <tr>

--- a/src/components/compare/ScoreUpChart.svelte
+++ b/src/components/compare/ScoreUpChart.svelte
@@ -2,6 +2,7 @@
   import { formatScore, type CardStrengthEntry, type ScoreUpSortKey } from '../../lib/score/cardStrength';
   import { ATTR_HEX } from '../../lib/constants';
   import { cardThumbUrl } from '../../lib/ui';
+  import { skillTypeShortLabel } from '../../lib/score/skillFormatter';
   import { bonusBadgeHtml, type EventBonusTier } from '../../lib/data/eventBonusTiers';
 
   type Props = {
@@ -61,7 +62,7 @@
           <span class="text-[10px] text-gray-500 mt-0.5 leading-tight text-center break-words w-full">
             期待 {formatScore(entry.totalScore)}<br />
             最大 {formatScore(entry.maxTotalScore)}<br />
-            {entry.skill?.originalType ?? entry.card.ap_skill_type ?? 'スキルなし'}
+            {skillTypeShortLabel(entry.skill?.originalType ?? entry.card.ap_skill_type)}
           </span>
           {@html bonusBadgeHtml(tierOf(entry))}
         </button>

--- a/src/lib/score/skillFormatter.ts
+++ b/src/lib/score/skillFormatter.ts
@@ -63,6 +63,19 @@ export function formatSkillEffectMax(card: Card): { level: 1 | 2 | 3 | 4 | 5; te
   return { level, text };
 }
 
+/**
+ * スキル種別を一覧表示用の短いラベルに変換する。
+ * 判定強化(BAD→Perfect) / 判定ガード(MISS→Perfect) は括弧表記が長く
+ * 固定幅カラムでレイアウトが崩れるため、括弧部分を除いた表記を返す。
+ * それ以外の種別（タイマー区別を含む）はそのまま返す。
+ */
+export function skillTypeShortLabel(skillType: string | null | undefined): string {
+  if (!skillType) return 'スキルなし';
+  if (skillType === SKILL_TYPE.BAD_TO_PERFECT) return '判定強化';
+  if (skillType === SKILL_TYPE.MISS_TO_PERFECT) return '判定ガード';
+  return skillType;
+}
+
 export interface SkillBadge {
   /** セル表示用の短縮ラベル */
   label: string;


### PR DESCRIPTION
## 概要

衣装比較（card-compare）画面で、サムネイル下に表示されるスキル種別 `判定強化(BAD→Perfect)` / `判定ガード(MISS→Perfect)` の括弧部分が長く、固定幅カラム（`break-words`）で折り返してレイアウトが崩れていた問題を修正。

括弧を除いた `判定強化` / `判定ガード` を表示するようにした。

## 変更内容

- `src/lib/score/skillFormatter.ts`: `skillTypeShortLabel()` を追加
  - `判定強化(BAD→Perfect)` → `判定強化`、`判定ガード(MISS→Perfect)` → `判定ガード`
  - それ以外の種別（`スコアアップ（タイマー）` / `判定縮小（タイマー）` 等のタイマー区別を含む）はそのまま返す
- `src/components/compare/ScoreUpChart.svelte`: サムネイル下のスキル表示を新ヘルパー経由に
- `src/components/compare/CompareDetailPanel.svelte`: 詳細比較パネルの「スキル」行も同様に統一

括弧を機械的に全除去するとタイマー区別まで消えるため、対象を上記2種別に限定。

## 検証

- `npm run dev` (HMR) でサムネイル下・詳細比較パネルともに `判定強化` の1行表示になり崩れが解消することを確認
- `npx playwright test tests/card-compare.test.ts` 9件すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)