### PR TITLE
feat: 開催中イベント(記念日2026)の対象7曲に楽曲許可リストを設定

### DIFF
--- a/src/data/allowed-songs.json
+++ b/src/data/allowed-songs.json
@@ -1,4 +1,4 @@
 {
-  "note": "表示を許可する楽曲 ID のリスト。空配列の場合は制限なし (全件表示)。ID は /songs/ の URL (/songs/{id}/) や tests/fixtures/songs.json から確認できる。",
-  "allowedIds": []
+  "note": "表示を許可する楽曲 ID のリスト。空配列の場合は制限なし (全件表示)。ID は /songs/ の URL (/songs/{id}/) や tests/fixtures/songs.json から確認できる。開催中イベントの対象楽曲を登録する用途で運用する。",
+  "allowedIds": [67, 68, 72, 76, 135, 146, 147]
 }

--- a/tests/card-compare.test.ts
+++ b/tests/card-compare.test.ts
@@ -66,10 +66,21 @@ test.describe('衣装比較ページ', () => {
     await expect(page.getByTestId('compare-detail')).toBeHidden();
   });
 
-  test('楽曲セレクタの初期選択が DIAMOND FUSION', async ({ page }) => {
+  test('楽曲セレクタの初期選択が既定曲（DIAMOND FUSION）または最大ノーツ曲', async ({ page }) => {
     const select = page.getByLabel(/楽曲/);
     await expect(select).toBeVisible({ timeout: 20000 });
-    const label = await select.locator('option:checked').textContent();
-    expect(label).toContain('DIAMOND FUSION');
+    const optionTexts = await select.locator('option').allTextContents();
+    const checked = (await select.locator('option:checked').textContent()) ?? '';
+
+    // 既定曲ロジック: DIAMOND FUSION が候補にあれば優先、なければノーツ数最大の曲。
+    // 許可リスト (allowed-songs.json) で DIAMOND FUSION が除外されている場合は後者になる。
+    if (optionTexts.some((t) => t.includes('DIAMOND FUSION'))) {
+      expect(checked).toContain('DIAMOND FUSION');
+    } else {
+      const parseNotes = (t: string) =>
+        Number((t.match(/([\d,]+)\s*ノーツ/)?.[1] ?? '0').replace(/,/g, ''));
+      const maxNotes = Math.max(...optionTexts.map(parseNotes));
+      expect(parseNotes(checked)).toBe(maxNotes);
+    }
   });
 });


### PR DESCRIPTION
## 概要

開催中イベント「IDOLiSH7記念日2026」(ID 236, 2026-06-10〜06-17) の対象楽曲7曲を `src/data/allowed-songs.json` の `allowedIds` に登録。これにより楽曲一覧・スコア計算・衣装比較・ホームの楽曲がこの7曲に絞り込まれる。

| 曲名 | ID |
|------|----|
| Dancing∞BEAT | 67 |
| マロウブルー | 68 |
| Boys&Girls | 72 |
| MEDiUM | 76 |
| Crz Love | 135 |
| BE WITH YOU | 146 |
| Resonant Pulses | 147 |

すべて EXPERT+。ID は GViz の実楽曲データ (song_name 照合) から取得。

## 変更内容

- `src/data/allowed-songs.json`: `allowedIds` に7曲を登録、note に運用用途を追記
- `tests/card-compare.test.ts`: DIAMOND FUSION が許可リスト外になると既定曲がフォールバック（最大ノーツ曲）になるため、初期選択テストを「DIAMOND FUSION があれば優先、なければ最大ノーツ曲」を検証する形に更新

## 検証

- dev サーバーの `/songs/` 生応答が「7曲を表示」/ song ID 67,68,72,76,135,146,147 のみであることを確認
- `npx playwright test tests/card-compare.test.ts` 9件すべて通過（更新したテスト含む）

## 補足

`allowed-songs.json` はサイト全体に効くグローバルな楽曲許可リストで、イベントID 236 に紐付くデータではない。「イベント詳細ページに対象楽曲として表示」は別実装が必要（未対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)