### PR TITLE
feat: スコア計算の編成・スコアを画像(PNG)で共有

### DIFF
--- a/docs/adr/0023-score-deck-share-image.md
+++ b/docs/adr/0023-score-deck-share-image.md
@@ -1,0 +1,25 @@
+# 0023: スコア計算の編成・スコアを画像で共有
+
+- 日付: 2026-06-16
+- ステータス: 承認
+
+## 背景
+
+スコア計算ページには編成シェア URL コピー（`deckShareUrl`）は既にあったが、SNS 等にそのまま貼れる画像での共有手段がなかった。イベント詳細では `EventShareImage`（`modern-screenshot` の `domToPng`）で DOM を PNG 化する仕組みが既にある。
+
+## 決定
+
+スコア計算ページに「📷 画像」ボタンを追加し、編成＋スコア表示領域を PNG としてダウンロードできるようにする。
+
+- 既存依存 `modern-screenshot` の `domToPng` を流用（新規依存なし）
+- キャプチャ対象は計算機ルート要素 `#score-share-target`（楽曲サマリー・オプション・デッキ編成・カード明細・結果を含む）
+- 操作ボタン行とカード選択モーダルには `data-noshot` 属性を付け、`domToPng` の `filter` で画像から除外
+- ファイル名は `i7-score-{曲名}.png`。空編成時は URL 共有と同じ `isDeckEmpty` ガードで抑止
+
+## 検討した代替案
+
+- **`EventShareImage` コンポーネントをそのまま設置** — ボタン意匠が大きく既存の小さな操作ボタン行と不揃いになるため、同じ `domToPng` ロジックを用いた小型ボタンを自前で追加
+- **キャプチャ専用の整形パネルを別途用意** — MVP では実画面をそのまま撮る方式で十分。整形は今後の課題
+- **Canvas で手描き** — 実装コストが高く、`domToPng` で実 DOM を撮れば十分なため不採用
+
+詳細は [docs/superpowers/specs/2026-06-16-score-deck-share-image-design.md](../superpowers/specs/2026-06-16-score-deck-share-image-design.md) を参照。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@
 | [0020](0020-abolish-dark-mode.md) | ダークモードの廃止（段階的） | 承認 |
 | [0021](0021-event-songs-pinned-select.md) | 楽曲許可リストを「イベント対象楽曲」のピン留めに転換 | 承認 |
 | [0022](0022-collection-dashboard.md) | 所持コレクションダッシュボードの追加 | 承認 |
+| [0023](0023-score-deck-share-image.md) | スコア計算の編成・スコアを画像で共有 | 承認 |

--- a/docs/superpowers/specs/2026-06-16-score-deck-share-image-design.md
+++ b/docs/superpowers/specs/2026-06-16-score-deck-share-image-design.md
@@ -1,0 +1,27 @@
+# スコア計算 編成・スコアの画像共有 設計
+
+- 日付: 2026-06-16
+- 関連 ADR: [0023](../../adr/0023-score-deck-share-image.md)
+
+## 目的
+
+スコア計算ページの編成＋スコアを PNG 画像として保存し、SNS 等で共有できるようにする。URL 共有（`deckShareUrl` の「🔗 URLコピー」）は既存のため、本件は画像共有のみを追加する。
+
+## 実装
+
+`ScoreCalc.svelte` に追加:
+- 計算機ルート `<div>` に `id="score-share-target"` を付与（楽曲サマリー・オプション・デッキ編成・カード明細・結果を含む）
+- 操作ボタン行 `<div class="relative flex gap-2">` と `CardPickerModal` ラッパに `data-noshot` 属性
+- `📷 画像` ボタン（`#btn-share-image`）を URL コピーボタンの隣に追加
+- `shareDeckImage()`:
+  - 空編成は `isDeckEmpty(buildStateObject())` で抑止（URL 共有と同一ガード）
+  - `modern-screenshot` の `domToPng(node, { scale: 2, backgroundColor: '#fff', filter })` で生成。`filter` は `data-noshot` を持つ要素を除外
+  - `i7-score-{曲名}.png` としてダウンロード。`imageBusy` で二重実行防止
+
+新規依存なし（`modern-screenshot` は `EventShareImage` で既に使用）。
+
+## 検証結果
+
+- `astro check` 0 errors
+- dev サーバーで `#btn-share-image` クリック → `domToPng` が `data:image/png`（約1MB）を生成し `i7-score-{曲名}.png` のダウンロードが発火、操作ボタン行（`data-noshot`）が除外されることを `evaluate_script` で確認
+- 初回失敗は dev の Vite 依存再最適化 504（`modern-screenshot`）によるもので、dev 再起動後に成功。コード起因ではない

--- a/src/components/ScoreCalc.svelte
+++ b/src/components/ScoreCalc.svelte
@@ -75,6 +75,7 @@
   // ボタンの一時フィードバック表示
   let deckSaved = $state(false);
   let shareCopied = $state(false);
+  let imageBusy = $state(false);
 
   function handleSongChange(id: number | null) {
     selectedSong = id != null ? allSongsState.find(s => s.id === id) || null : null;
@@ -162,6 +163,34 @@
     }
   }
 
+  // 編成＋スコアを PNG 画像として保存（data-noshot を付けた操作ボタン類は除外）
+  async function shareDeckImage() {
+    if (imageBusy) return;
+    if (isDeckEmpty(buildStateObject())) { alert('編成が空です。楽曲や衣装を選んでから画像化してください。'); return; }
+    const node = document.getElementById('score-share-target');
+    if (!node) return;
+    imageBusy = true;
+    try {
+      const { domToPng } = await import('modern-screenshot');
+      const dataUrl = await domToPng(node, {
+        scale: 2,
+        backgroundColor: '#ffffff',
+        filter: (n: Node) => !(n instanceof HTMLElement && n.hasAttribute('data-noshot')),
+      });
+      const a = document.createElement('a');
+      a.href = dataUrl;
+      a.download = `i7-score-${selectedSong?.song_name ?? 'deck'}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch (e) {
+      console.error(e);
+      alert('画像の生成に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      imageBusy = false;
+    }
+  }
+
   type SavedDeck = { id: string; name: string; createdAt: number; updatedAt: number; state: ReturnType<typeof buildStateObject> };
 
   function loadSavedDecks(): SavedDeck[] { return loadJson<SavedDeck[]>(STORAGE_KEYS.SAVED_DECKS, []); }
@@ -240,7 +269,7 @@
   });
 </script>
 
-<div>
+<div id="score-share-target">
   <!-- 楽曲サマリーバー（全幅・横長） -->
   <section class="bg-white rounded-lg shadow p-4 mb-4">
     <div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-4 items-start">
@@ -318,10 +347,11 @@
     <section class="bg-white rounded-lg shadow p-4">
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-sm font-bold text-gray-700">🎴 デッキ編成</h2>
-        <div class="relative flex gap-2">
+        <div class="relative flex gap-2" data-noshot>
           <button id="btn-save-deck" type="button" class="text-xs px-2 py-1 {deckSaved ? 'bg-green-100 text-green-700' : 'bg-indigo-100 text-indigo-700'} rounded hover:bg-indigo-200 transition-colors" onclick={saveDeck}>{deckSaved ? '保存しました' : '保存'}</button>
           <button id="btn-load-deck" type="button" class="text-xs px-2 py-1 bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors" onclick={showLoadDropdown}>読込</button>
           <button id="btn-share-url" type="button" class="text-xs px-2 py-1 bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors" aria-label="編成シェア URL をコピー" disabled={shareCopied} onclick={shareDeckUrl}>{shareCopied ? '✅ コピーしました' : '🔗 URLコピー'}</button>
+          <button id="btn-share-image" type="button" class="text-xs px-2 py-1 bg-sky-100 text-sky-700 rounded hover:bg-sky-200 transition-colors disabled:opacity-60" aria-label="編成とスコアを画像で保存" disabled={imageBusy} onclick={shareDeckImage}>{imageBusy ? '生成中…' : '📷 画像'}</button>
           <div id="load-deck-dropdown" class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto" class:hidden={loadDeckItems === null}>
             {#if loadDeckItems !== null}
               {#if loadDeckItems.length === 0}
@@ -355,5 +385,7 @@
     <ScoreCalcResults deckState={deckState} selectedSong={selectedSong} allBroachs={allBroachsState} scoreUpAssist={scoreUpAssist} scoreUpBadgeRate={scoreUpBadgeRate} />
   </div>
 
-  <CardPickerModal bind:this={picker} allCards={allCardsState} onPick={handlePick} onClear={handleClear} />
+  <div data-noshot>
+    <CardPickerModal bind:this={picker} allCards={allCardsState} onPick={handlePick} onClear={handleClear} />
+  </div>
 </div>


### PR DESCRIPTION
## 概要

スコア計算ページに「📷 画像」ボタンを追加し、編成＋スコア表示領域を PNG としてダウンロードできるようにした（ADR 0023）。URL 共有（🔗 URLコピー）は既存。

- 既存依存 `modern-screenshot` の `domToPng` を流用（新規依存なし）
- キャプチャ対象は計算機ルート `#score-share-target`（楽曲・オプション・デッキ編成・カード明細・結果）
- 操作ボタン行とカード選択モーダルに `data-noshot` を付け `filter` で画像から除外
- ファイル名 `i7-score-{曲名}.png`、空編成は `isDeckEmpty` で抑止

## 検証

- `astro check` 0 errors
- dev で `domToPng` が `data:image/png`（約1MB）を生成しダウンロード発火、`data-noshot` 要素が除外されることを確認（初回の 504 は dev の Vite 依存再最適化によるもので dev 再起動後に成功・コード起因ではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)