### PR TITLE
fix: cardDistribution テストの型キャスト修正で CI の typecheck を復旧

### DIFF
--- a/tests/unit/score/cardDistribution.test.ts
+++ b/tests/unit/score/cardDistribution.test.ts
@@ -26,7 +26,7 @@ function skill(partial: Partial<CardSkill>): CardSkill {
 
 function entry(partial: Partial<CardStrengthEntry>): CardStrengthEntry {
   return {
-    card: { ID: '1' } as CardStrengthEntry['card'],
+    card: { ID: '1' } as unknown as CardStrengthEntry['card'],
     attribute: 'Shout',
     appeal: { Shout: 0, Beat: 0, Melody: 0 },
     appealTotal: 0,


### PR DESCRIPTION
## 概要

`tests/unit/score/cardDistribution.test.ts:29` の Card 部分モック `{ ID: '1' } as CardStrengthEntry['card']` が TS2352 で型エラーになり、CI の「Type check & unit tests」ジョブが 38e9d00（2026-06-18）以降 main で失敗し続けていた（CI は PR でのみ走るため main 上では気付かれず）。

現在開いている Dependabot PR 6件（#336〜#341）もこの既存エラーを引き継いで CI が赤になっており、マージできない状態だった。

## 修正

TypeScript の提案どおり `unknown` を経由してキャストする（テスト用の最小モックのため）。

- `npm run typecheck`（astro check）: 0 errors
- `npm run test:unit`: 325 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)