### PR TITLE
refactor: cardDistribution テストの Card モックから unknown キャストを排除

### DIFF
--- a/tests/unit/score/cardDistribution.test.ts
+++ b/tests/unit/score/cardDistribution.test.ts
@@ -7,6 +7,7 @@ import {
   cardScorePmf,
   valueToThreshold,
 } from '../../../src/lib/score/cardDistribution';
+import { allCards } from '../../fixtures';
 
 function skill(partial: Partial<CardSkill>): CardSkill {
   return {
@@ -26,7 +27,7 @@ function skill(partial: Partial<CardSkill>): CardSkill {
 
 function entry(partial: Partial<CardStrengthEntry>): CardStrengthEntry {
   return {
-    card: { ID: '1' } as unknown as CardStrengthEntry['card'],
+    card: allCards[0],
     attribute: 'Shout',
     appeal: { Shout: 0, Beat: 0, Melody: 0 },
     appealTotal: 0,


### PR DESCRIPTION
## 概要

PR #345 で `cardDistribution.test.ts` の Card 部分モックを `{ ID: '1' } as unknown as CardStrengthEntry['card']` に修正したが、`unknown` 経由の二重キャストを避けたいとの要望により、実カードフィクスチャ（`allCards[0]`）を使う形に変更する。

`cardDistribution.ts` の関数群（`binomialPmf` / `reachProbability` / `cardScorePmf` / `valueToThreshold`）は `card` フィールドを一切参照しないため、実データで型・テストとも問題ない。

## 確認

- `npm run typecheck`: 0 errors
- `npm run test:unit -- cardDistribution`: 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)