### PR TITLE
fix: 衣装比較スコアアップグラフのバー下端が揃わない問題を修正

### DIFF
--- a/src/components/compare/ScoreUpChart.svelte
+++ b/src/components/compare/ScoreUpChart.svelte
@@ -27,7 +27,9 @@
   <p class="text-sm text-gray-500 py-10 text-center">対象の衣装がありません</p>
 {:else}
   <div class="overflow-x-auto">
-    <div class="flex items-end gap-3 px-3 pt-5 pb-3 min-w-max">
+    <!-- items-start でバー上端を揃える。バー下のサムネ/ラベル/バッジは可変高だが、
+         バーより下にあるため下端揃え (items-end) のようにバー位置へ波及しない。 -->
+    <div class="flex items-start gap-3 px-3 pt-5 pb-3 min-w-max">
       {#each entries as entry (entry.card.ID)}
         {@const selected = entry.card.ID != null && selectedIds.includes(entry.card.ID)}
         <button


### PR DESCRIPTION
## 概要

衣装比較ページ（スコアアップタブ）の積み上げ棒グラフで、衣装によってバーの下端が揃わずガタつく問題を修正。

## 原因

`ScoreUpChart.svelte` のバー行が `flex items-end`（下端揃え）だったため、バーより下にある可変高さの要素 — スキル名が長い場合の下部ラベル折り返しや特効バッジの有無 — が下端揃えによってバー位置へ波及していた。

DOM 実測で、スキル種別ラベルが「判定強化」の衣装だけバー下端が他より **最大 12px** 下にずれることを確認。

## 修正

バー行を `items-end` → `items-start` に変更。バーより上の要素（スコアラベル）は単一行で固定高のため、上端揃えにすることでずれの発生源（ラベル/バッジ）をバー位置から切り離し、全 718 本のバー下端が共通 baseline（spread 0）に揃う。

## 検証

- DOM 実測: 修正前 spread 12px → 修正後 spread 0px（718 本すべて下端 550px）
- 衣装比較 E2E (`tests/card-compare.test.ts`) 12 件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)