### PR TITLE
fix: 編成組合計算のスコアアップバッジ初期値を16に統一

### DIFF
--- a/src/components/MaxScoreFinder.svelte
+++ b/src/components/MaxScoreFinder.svelte
@@ -15,6 +15,7 @@
     type SearchResult,
   } from '../lib/score/maxScoreFinder';
   import { startWorkerSearch, type SearchPoolRun } from '../lib/score/searchWorkerPool';
+  import { DEFAULT_SCOREUP_BADGE_RATE } from '../lib/score/constants';
   import { buildLiveTierMap, isEventLive } from '../lib/data/eventBonusTiers';
   import type { EventBonusTier, EventForBonus } from '../lib/data/eventBonusTiers';
   import { ATTR_HEX } from '../lib/constants';
@@ -49,7 +50,7 @@
   let selectedSongId = $state<number | null>(null);
   let evalMode = $state<'expected' | 'max'>('expected');
   let scoreUpAssist = $state(false);
-  let scoreUpBadgeRate = $state(0);
+  let scoreUpBadgeRate = $state(DEFAULT_SCOREUP_BADGE_RATE);
   let ownedOnly = $state(false);
   let shrinkPairOnly = $state(false);
   let useOwnedBroachs = $state(false);


### PR DESCRIPTION
## 概要

編成組合計算 (`MaxScoreFinder.svelte`) のスコアアップバッジ倍率の初期値が `0` ハードコードで、スコア計算画面 (`16`) と不一致だった。`DEFAULT_SCOREUP_BADGE_RATE` 定数を参照する形に揃え、デフォルト値をグローバル定数で一元管理する。

## 変更内容

- `MaxScoreFinder.svelte`
  - `DEFAULT_SCOREUP_BADGE_RATE` (`src/lib/score/constants.ts`) を import
  - `scoreUpBadgeRate` 初期値を `$state(0)` → `$state(DEFAULT_SCOREUP_BADGE_RATE)`

## 影響

- 両スコア画面 (ScoreCalc / MaxScoreFinder) が同じ定数 (= 16) を初期値として参照
- 当該値は localStorage 永続化していないため既存ユーザーへの影響なし

## 検証

- `npm run dev` で編成組合計算ページの SCOREUPバッジ欄が初期値 `16` で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)