### PR TITLE
test: CI に単体テストカバレッジ 95% ゲートを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    name: Type check & unit tests
+    name: Type check & unit tests (coverage gate)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -22,7 +22,25 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run typecheck
-      - run: npm run test:unit
+      # src/lib の単体テストカバレッジを計測。4 指標いずれかが 95% 未満なら exit≠0 で fail する
+      - run: npm run coverage
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            node -e '
+              const t = require("./coverage/coverage-summary.json").total;
+              const row = (k) => `| ${k} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`;
+              const md = [
+                "## 単体テストカバレッジ (src/lib)",
+                "",
+                "| 指標 | % | covered/total |",
+                "|------|---|---------------|",
+                row("statements"), row("branches"), row("functions"), row("lines"),
+              ].join("\n");
+              require("fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
+            '
+          fi
 
   build:
     name: Production build

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # build output
 dist/
 
+# coverage
+coverage/
+
 # astro
 .astro/
 

--- a/docs/adr/0032-unit-test-coverage-gate.md
+++ b/docs/adr/0032-unit-test-coverage-gate.md
@@ -1,0 +1,33 @@
+# 0032: 単体テストカバレッジ 95% ゲートを CI に導入
+
+- 日付: 2026-06-30
+- ステータス: 承認
+
+## 背景
+
+CI（`.github/workflows/ci.yml` の `quality` ジョブ）は `npm run typecheck` と `npm run test:unit`（Vitest）を実行していたが、**カバレッジを計測していなかった**。スコア計算エンジンなどロジックの回帰を、テスト追加忘れで素通りさせるリスクがあった。
+
+導入前の `src/lib/**` 実測カバレッジは Statements 76.5% / Branches 67.2% / Functions 68.2% / Lines 77.3%。領域別では `score/` が約 90% と高い一方、`data/`（GViz/CSV フェッチャ）・`stores/`（Svelte ストア）・DOM/Worker 依存ファイルがほぼ未カバーだった。
+
+## 決定
+
+Vitest の v8 カバレッジ計測を導入し、**`src/lib/**` 全体に対するグローバルしきい値 95%（Statements / Branches / Functions / Lines の 4 指標すべて）を下回ったら CI を fail させるゲート**を `quality` ジョブに追加する。
+
+- カバレッジ provider は `@vitest/coverage-v8`。しきい値は `vitest.config.ts` の `coverage.thresholds` に 95×4 を設定（グローバル集計に対して適用）。
+- 分母（include）は `src/lib/**` 全体。DOM・I/O・Worker・ストアも対象から除外しない。
+- テスト環境は node を既定とし、DOM が必要なファイル（`storage` / `stores/*` / `clientRefresh`）のみ per-file `// @vitest-environment jsdom` を付与。Svelte 5 runes ストアのコンパイルのため `vitest.config.ts` に `@sveltejs/vite-plugin-svelte` を統合。
+- Worker（`maxScoreFinder.worker.ts`）はメッセージ処理を純粋関数 `createWorkerHandler` に切り出してテストし、Worker グローバルへの結線のみブートストラップとして残す。`searchWorkerPool` は `Worker` のモックでテストする。
+- **本質的に到達不能な防御的分岐**（実引数で発生し得ない null/フォールバック、SSR 専用分岐、Worker ブートストラップ等）に限り、`/* v8 ignore */` コメントで個別に除外し、各除外に理由をコメントで明記する（一律の glob 除外はしない）。
+- CI は `npm run test:unit` を `npm run coverage`（= `vitest run --coverage`）に置き換え、`coverage-summary.json` から `$GITHUB_STEP_SUMMARY` にカバレッジ表を出力する。
+
+導入後の `src/lib/**` 実測は Statements 99.9% / Branches 98.6% / Functions 100% / Lines 100%（620 tests）。
+
+## 検討した代替案
+
+- **可視化のみ（ゲートなし）／段階導入（ratchet）** — まず現状値を計測・表示し、回帰だけ防ぐ案。回帰検知力が弱く、95% という明確な品質基準を即時に課す方針を優先して却下。
+- **分母を `score/` やテスト済みモジュールのみに限定** — 95% 達成は容易だが、新規未テストファイル（特に `data/` や DOM/Worker）を検知できない穴が残るため、`src/lib/**` 全体を分母に採用。
+- **Branches だけ別しきい値（例 85%）** — Branches は導入前 67% と最も低く工数が大きいが、回帰検知力を最大化するため 4 指標一律 95% を採用。到達困難な分岐は個別 `/* v8 ignore */` で対応する方針とした。
+- **per-file しきい値** — 型定義のみ・SSR 専用など一部ファイルが構造的に 95% へ届かず運用が硬直するため、グローバル集計に対するしきい値を採用。
+- **E2E（Playwright）を CI に追加** — UI/動的ルートの検証には有用だが本 ADR のスコープ外（単体テストの回帰防止）とし、別途検討。
+
+設計詳細は [docs/superpowers/specs/2026-06-30-ci-coverage-gate-design.md](../superpowers/specs/2026-06-30-ci-coverage-gate-design.md) を参照。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@
 | [0029](0029-max-finder-event-select.md) | 編成組合計算で過去のハイスコアイベントを選択可能にする | 承認 |
 | [0030](0030-upgrade-astro7-svelte9.md) | astro 7 / @astrojs/svelte 9 へのメジャーアップグレードと CSS 圧縮の Vite 一本化 | 承認 |
 | [0031](0031-seo-structured-data.md) | SEO メタデータ／構造化データの強化 | 承認 |
+| [0032](0032-unit-test-coverage-gate.md) | 単体テストカバレッジ 95% ゲートを CI に導入 | 承認 |

--- a/docs/superpowers/specs/2026-06-30-ci-coverage-gate-design.md
+++ b/docs/superpowers/specs/2026-06-30-ci-coverage-gate-design.md
@@ -1,0 +1,47 @@
+# CI に単体テストカバレッジ 95% ゲートを追加する — 設計
+
+- 日付: 2026-06-30
+- 関連 ADR: [0032](../../adr/0032-unit-test-coverage-gate.md)
+
+## 背景・目的
+
+CI（`.github/workflows/ci.yml` の `quality` ジョブ）は typecheck と Vitest 単体テストを実行していたが、カバレッジを計測していなかった。ロジックの回帰をテスト追加忘れで素通りさせるリスクがあったため、`src/lib/**` を分母とした **4 指標（Statements / Branches / Functions / Lines）すべて 95% 未満で PR を fail させるゲート**を導入する。
+
+導入前ベースライン（`src/lib/**`）: Statements 76.5% / Branches 67.2% / Functions 68.2% / Lines 77.3%。
+
+## 決定事項
+
+- 分母（include）: `src/lib/**` 全体。DOM・I/O・Worker・ストアも除外しない。
+- しきい値: 4 指標すべて 95%、グローバル集計に適用。下回ったら CI fail。
+- 到達不能な防御的分岐に限り `/* v8 ignore */` で個別除外（理由コメント必須、一律 glob 除外なし）。
+
+## 実装方針
+
+### カバレッジ基盤
+- `@vitest/coverage-v8` / `jsdom` を devDependencies に追加。
+- `vitest.config.ts`: `@sveltejs/vite-plugin-svelte` を plugins に統合（runes ストアのコンパイル用）、`coverage` に `provider: v8` / `include: ['src/lib/**']` / `exclude: ['**/*.d.ts']` / reporters（text-summary, text, html, json-summary）/ `thresholds` 95×4。
+- `package.json` に `"coverage": "vitest run --coverage"`。`.gitignore` に `coverage/`。
+
+### テスト戦略（テスト容易性で 3 分類）
+- **純粋ロジック（node）**: `ui` / `donutChart` / `gviz`（parse 系）/ `fetchEventsCsv`（parse 系）/ `eventBonusTiers` / `skillFormatter` / `histogram` / `simulation`（エッジ・MC オプション）/ `types` 等。
+- **DOM 依存（per-file jsdom）**: `storage` / `stores/*.svelte.ts` / `clientRefresh`。先頭に `// @vitest-environment jsdom`。
+- **モック依存**: フェッチャの I/O は `vi.stubGlobal('fetch')`、`fetchEventsCsv` は `vi.mock('node:fs/promises')`、Worker プールは `Worker` モック。
+
+### 最小リファクタ
+- `maxScoreFinder.worker.ts`: `onmessage` 本体を純粋関数 `createWorkerHandler(post)` に切り出し、Worker グローバルへの結線のみブートストラップ（`typeof self` ガード + `/* v8 ignore */`）として残す。
+- `clientRefresh.ts`: 未使用デッドコード `hideIndicator` を削除。
+
+### CI 配線
+- `quality` ジョブの `npm run test:unit` を `npm run coverage` に置換。
+- `coverage-summary.json` から `$GITHUB_STEP_SUMMARY` にカバレッジ表を出力（`if: always()`）。
+
+## 結果
+
+導入後（`src/lib/**`）: Statements 99.9% / Branches 98.6% / Functions 100% / Lines 100%、620 tests pass。ゲートは閾値 95 で exit 0、閾値超過時に exit≠0 + `ERROR: Coverage for branches ... does not meet global threshold` を出力することを確認済み。
+
+## 検証
+
+1. `npm run coverage` がローカルで成功し 4 指標 ≥95%。
+2. 閾値を意図的に超過させると `vitest run --coverage` が exit≠0 で fail（ゲート実効性）。
+3. 既存 + 追加テストが全 pass、`npm run typecheck` が pass。
+4. ADR を追加し `docs/adr/README.md` を更新。

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,64 @@
         "@astrojs/check": "^0.9.9",
         "@playform/compress": "0.2.3",
         "@playwright/test": "^1.61.1",
+        "@vitest/coverage-v8": "^4.1.9",
+        "jsdom": "^29.1.1",
         "serve": "^14.2.6",
         "sharp": "^0.35.2",
         "tsx": "^4.22.4",
         "vitest": "^4.1.9"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.9",
@@ -428,6 +481,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.3.tgz",
@@ -575,6 +651,146 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
@@ -666,6 +882,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/colour": {
@@ -2760,6 +2994,37 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -3200,6 +3465,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/astro": {
@@ -4294,6 +4581,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4468,19 +4765,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk-template/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/character-entities-html4": {
@@ -4947,6 +5231,27 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
@@ -5603,6 +5908,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -5812,6 +6130,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -5856,6 +6181,52 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -5864,6 +6235,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -5875,6 +6253,73 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -6167,9 +6612,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-      "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -6193,6 +6638,22 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-to-hast": {
@@ -6877,6 +7338,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7217,6 +7688,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scule": {
@@ -7577,6 +8061,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/svelte": {
       "version": "5.56.4",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
@@ -7651,6 +8148,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.1",
@@ -7754,6 +8258,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7765,6 +8289,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -8331,6 +8881,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
@@ -9064,6 +9624,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -9072,6 +9645,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -9149,6 +9757,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:ui": "playwright test --ui",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
+    "coverage": "vitest run --coverage",
     "typecheck": "astro check --minimumSeverity warning",
     "extract-fixtures": "tsx scripts/extract-test-fixtures.ts"
   },
@@ -27,6 +28,8 @@
     "@astrojs/check": "^0.9.9",
     "@playform/compress": "0.2.3",
     "@playwright/test": "^1.61.1",
+    "@vitest/coverage-v8": "^4.1.9",
+    "jsdom": "^29.1.1",
     "serve": "^14.2.6",
     "sharp": "^0.35.2",
     "tsx": "^4.22.4",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -60,6 +60,7 @@ export const RARITY_BADGE_CLASSES: Record<string, string> = {
   R: 'bg-gray-400', N: 'bg-gray-300', GROUP: 'bg-pink-400',
 };
 
+/* v8 ignore next -- BASE_URL は実行環境で常に定義され ?? '' のフォールバックへ到達しない */
 const BASE = ((import.meta as { env?: { BASE_URL?: string } }).env?.BASE_URL ?? '').replace(/\/$/, '');
 export const CARD_IMAGE_BASE_URL = `${BASE}/assets/cards`;
 export const CARD_THUMB_BASE_URL = `${BASE}/assets/th_cards`;

--- a/src/lib/data/clientRefresh.ts
+++ b/src/lib/data/clientRefresh.ts
@@ -48,12 +48,6 @@ function showIndicator(message: string, type: 'loading' | 'success') {
   }
 }
 
-function hideIndicator() {
-  if (indicatorEl) {
-    indicatorEl.classList.replace('opacity-100', 'opacity-0');
-  }
-}
-
 // --- キャッシュ ---
 
 function readCache<T>(key: DataKey, maxAgeMs: number): T[] | null {

--- a/src/lib/data/fetchEventsCsv.ts
+++ b/src/lib/data/fetchEventsCsv.ts
@@ -124,6 +124,7 @@ export async function fetchEventsCsv(): Promise<EventRow[]> {
   }
 
   return rows.slice(1).map(r => ({
+    /* v8 ignore next -- iId=0 で行が存在すれば r[0] は常に定義され ?? 0 へ到達しない */
     id: Number(r[iId] ?? 0),
     eventname: (r[iName] ?? '').trim(),
     eventtype: (r[iType] ?? '').trim(),
@@ -172,6 +173,7 @@ export function formatEffectSummary(tier: EventSpecialTier): string {
   ];
   for (const [key, v] of map) {
     if (v > 0 && tier.effect.includes(key)) {
+      /* v8 ignore next -- key は固定の effect キーのみで EFFECT_LABEL に必ず存在し ?? key へ到達しない */
       parts.push(`${EFFECT_LABEL[key] ?? key} +${v}%`);
     }
   }

--- a/src/lib/data/fetchSongsJson.ts
+++ b/src/lib/data/fetchSongsJson.ts
@@ -140,6 +140,7 @@ export function filterValidSongs(songs: Song[]): Song[] {
  * 曲選択ドロップダウンで「イベント対象楽曲」グループとして先頭に出す。
  */
 export function getEventSongIds(): number[] {
+  /* v8 ignore next 3 -- event-songs.json の eventSongIds は実 config で常に配列のため : [] へ到達しない */
   return Array.isArray(eventSongsConfig.eventSongIds)
     ? (eventSongsConfig.eventSongIds as number[])
     : [];

--- a/src/lib/data/gviz.ts
+++ b/src/lib/data/gviz.ts
@@ -38,6 +38,7 @@ export function extractCellValue(cell: GVizCell | null | undefined): string | nu
   // GViz Date型: "Date(2024,0,15)" のようなパターン
   if (typeof v === 'string' && /^Date\(\d+,\d+,\d+/.test(v)) {
     const m = v.match(/Date\((\d+),(\d+),(\d+)/);
+    /* v8 ignore next -- 直前の test() が一致した値は match も必ず一致するため if(m) の偽側は到達不能 */
     if (m) return new Date(Number(m[1]), Number(m[2]), Number(m[3])).toISOString().split('T')[0];
   }
   return v;

--- a/src/lib/score/broachAssignment.ts
+++ b/src/lib/score/broachAssignment.ts
@@ -34,6 +34,7 @@ export function countDeckAttrs(deck: (Card | null)[]): Record<AttributeName, num
   for (const c of deck) {
     if (!c) continue;
     const a = normalizeAttribute(c.attribute);
+    /* v8 ignore next -- normalizeAttribute の戻り型が全て counts のキーのため else 到達不能 */
     if (a in counts) counts[a]++;
   }
   return counts;

--- a/src/lib/score/cardStrength.ts
+++ b/src/lib/score/cardStrength.ts
@@ -118,6 +118,7 @@ export function calcCardStrengthAppeal(
     let aS = s, aB = b, aM = m;
     for (const rb of resolved.get(0) ?? []) {
       if (!rb.active || rb.broach.broach_type === 9) continue;
+      /* v8 ignore next -- resolveDeckBroachs が multiplier を常に number 設定するため ?? 1 へ到達しない */
       const mult = rb.multiplier ?? 1;
       aS += (rb.broach.shout || 0) * mult;
       aB += (rb.broach.beat || 0) * mult;

--- a/src/lib/score/deckSkillDistribution.ts
+++ b/src/lib/score/deckSkillDistribution.ts
@@ -75,6 +75,7 @@ export function buildDeckSkillDistribution(
 
     const colorIdx = DISPLAY_ORDER.indexOf(slotIndex);
     const color = SERIES_COLORS[colorIdx % SERIES_COLORS.length];
+    /* v8 ignore next -- slotIndex は直前で baseAppeal に登録済みのため ?? 0 へ到達しない */
     const base = baseAppeal.get(slotIndex) ?? 0;
     const effectiveAppeal = Math.round(base * assistFactor * badgeFactor);
     const contribRatio = totalBase > 0 ? base / totalBase : 0;

--- a/src/lib/score/histogram.ts
+++ b/src/lib/score/histogram.ts
@@ -36,6 +36,7 @@ export function renderHistogramSvg(
   }
 
   const maxCount = Math.max(...bins);
+  /* v8 ignore next 3 -- scores 非空かつ range>0 なら必ず最低1ビンが加算され maxCount>=1 となる */
   if (maxCount === 0) {
     return '<span class="text-gray-400 text-xs">データなし</span>';
   }

--- a/src/lib/score/maxScoreFinder.worker.ts
+++ b/src/lib/score/maxScoreFinder.worker.ts
@@ -3,6 +3,9 @@
  * max-score-finder 探索 Worker。
  * init で SearchContext を構築し、chunk を受けるたびに evaluateChunk を実行して
  * progress / result を返す。ロジックはすべて maxScoreFinder.ts (テスト済み) に委譲する。
+ *
+ * メッセージ処理本体は createWorkerHandler に切り出し（単体テスト対象）、
+ * Worker グローバルへの結線のみブートストラップとして残す。
  */
 import {
   createSearchContext,
@@ -12,43 +15,56 @@ import {
   type SearchContext,
 } from './maxScoreFinder';
 
+export type WorkerPost = (msg: FinderWorkerResponse) => void;
+
+/**
+ * Worker メッセージハンドラを生成する。ctx / aborted を closure に閉じ込め、
+ * post 関数経由で応答を返す純粋な関数として単体テストできる。
+ */
+export function createWorkerHandler(post: WorkerPost): (msg: FinderWorkerRequest) => Promise<void> {
+  let ctx: SearchContext | null = null;
+  let aborted = false;
+
+  return async (msg: FinderWorkerRequest): Promise<void> => {
+    if (msg.type === 'init') {
+      ctx = createSearchContext(msg.input);
+      aborted = false;
+      post({ type: 'ready' });
+      return;
+    }
+
+    if (msg.type === 'abort') {
+      aborted = true;
+      return;
+    }
+
+    // msg.type === 'chunk'
+    if (!ctx) return;
+    try {
+      const result = await evaluateChunk(ctx, msg.descriptor, {
+        onTick: async (evaluatedDelta, localBest) => {
+          post({ type: 'progress', evaluatedDelta, localBestScore: localBest?.score ?? null });
+          // マクロタスクで yield してメッセージループに制御を返し、
+          // キュー済みの abort メッセージを処理させる (Promise.resolve() では不可)
+          await new Promise((r) => setTimeout(r, 0));
+          return aborted;
+        },
+      });
+      post({ type: 'result', topK: result.topK, evaluated: result.evaluated, aborted: result.aborted });
+    } catch (err) {
+      // async onmessage 内の throw は self.onerror を発火させないため、構造化してメインに通知する
+      post({ type: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  };
+}
+
+/* v8 ignore start -- Worker ブートストラップ（実 Worker 環境専用、node 単体テスト不可） */
 declare const self: DedicatedWorkerGlobalScope;
-
-let ctx: SearchContext | null = null;
-let aborted = false;
-
-const post = (msg: FinderWorkerResponse): void => self.postMessage(msg);
-
-self.onmessage = async (e: MessageEvent<FinderWorkerRequest>) => {
-  const msg = e.data;
-
-  if (msg.type === 'init') {
-    ctx = createSearchContext(msg.input);
-    aborted = false;
-    post({ type: 'ready' });
-    return;
-  }
-
-  if (msg.type === 'abort') {
-    aborted = true;
-    return;
-  }
-
-  // msg.type === 'chunk'
-  if (!ctx) return;
-  try {
-    const result = await evaluateChunk(ctx, msg.descriptor, {
-      onTick: async (evaluatedDelta, localBest) => {
-        post({ type: 'progress', evaluatedDelta, localBestScore: localBest?.score ?? null });
-        // マクロタスクで yield してメッセージループに制御を返し、
-        // キュー済みの abort メッセージを処理させる (Promise.resolve() では不可)
-        await new Promise((r) => setTimeout(r, 0));
-        return aborted;
-      },
-    });
-    post({ type: 'result', topK: result.topK, evaluated: result.evaluated, aborted: result.aborted });
-  } catch (err) {
-    // async onmessage 内の throw は self.onerror を発火させないため、構造化してメインに通知する
-    post({ type: 'error', message: err instanceof Error ? err.message : String(err) });
-  }
-};
+// node 単体テストで import しても落ちないよう Worker グローバル存在時のみ結線する
+if (typeof self !== 'undefined' && typeof self.postMessage === 'function') {
+  const handle = createWorkerHandler((msg) => self.postMessage(msg));
+  self.onmessage = (e: MessageEvent<FinderWorkerRequest>) => {
+    void handle(e.data);
+  };
+}
+/* v8 ignore stop */

--- a/src/lib/score/simulation.ts
+++ b/src/lib/score/simulation.ts
@@ -179,6 +179,7 @@ function calcShrinkActivationCount(
   notesCount: number,
   excludeHeadCount: number,
 ): number {
+  /* v8 ignore next -- 全呼出元が count>0 を保証しており count<=0 でここへ到達しない */
   if (skill.count <= 0) return 0;
   if (isShrinkTimer(skill)) {
     return team.songDuration > 0 ? Math.floor(team.songDuration / skill.count) : 0;

--- a/src/lib/score/teamBuilder.ts
+++ b/src/lib/score/teamBuilder.ts
@@ -36,6 +36,7 @@ export function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 
   const value = sl.value;
   const rate = sl.rate;
 
+  /* v8 ignore next -- resolveEffectiveSkillLevel が count/per truthy のレベルのみ返すため null 到達不能 */
   if (count == null || per == null) return null;
 
   const isTimer = type === SKILL_TYPE.SCOREUP_TIMER || type === SKILL_TYPE.SHRINK_TIMER;
@@ -48,6 +49,7 @@ export function parseSkill(card: Card, slotIndex: number, skillLevel: 1 | 2 | 3 
     cardIndex: slotIndex,
     skillType,
     originalType: type,
+    /* v8 ignore next 3 -- count/per/value は usable レベルで truthy 保証済みのため || 0 の偽側へ到達しない */
     count: count || 0,
     per: per || 0,
     value: value || 0,
@@ -115,6 +117,7 @@ export function computeTeam(
   for (const c of deck) {
     if (!c) continue;
     const a = normalizeAttribute(c.attribute);
+    /* v8 ignore next -- normalizeAttribute の戻り型が全て attrCounts のキーのため else 到達不能 */
     if (a in attrCounts) attrCounts[a]++;
   }
 
@@ -152,6 +155,7 @@ export function computeTeam(
       if (!rb.active) continue;
       // 種類9（スコアUP）はステータスではなくスコア直接加算なのでここではスキップ
       if (rb.broach.broach_type === 9) continue;
+      /* v8 ignore next -- resolveDeckBroachs が multiplier を常に number 設定するため ?? 1 へ到達しない */
       const mult = rb.multiplier ?? 1;
       bShout += (rb.broach.shout || 0) * mult;
       bBeat += (rb.broach.beat || 0) * mult;

--- a/src/lib/songNoteBreakdown.ts
+++ b/src/lib/songNoteBreakdown.ts
@@ -78,6 +78,7 @@ export function buildNoteBreakdown(song: Song): NoteBreakdown {
 
     rows.push({
       key,
+      /* v8 ignore next 2 -- key は SONG_NOTE_GROUP_KEYS 固定で両 map に必ず存在し ?? 側へ到達しない */
       label: STAGE_LABELS[key] ?? key,
       multiplier: LIGHT_MULTIPLIER[key] ?? 1,
       shoutWhite, shoutColor,

--- a/tests/unit/data/clientRefresh.test.ts
+++ b/tests/unit/data/clientRefresh.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { refreshData } from '../../../src/lib/data/clientRefresh';
+
+const CACHE_PREFIX = 'i7_fresh_';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('refreshData', () => {
+  it('有効なキャッシュがあれば fetchFn を呼ばず onUpdate にキャッシュを渡す', async () => {
+    sessionStorage.setItem(
+      CACHE_PREFIX + 'cards',
+      JSON.stringify({ data: [{ id: 1 }], ts: Date.now() }),
+    );
+    const fetchFn = vi.fn(async () => [{ id: 999 }]);
+    const onUpdate = vi.fn();
+    await refreshData('cards', fetchFn, onUpdate);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it('キャッシュなしならフェッチして onUpdate・キャッシュ書込・インジケータ表示', async () => {
+    const fresh = [{ id: 2 }];
+    const onUpdate = vi.fn();
+    await refreshData('songs', async () => fresh, onUpdate);
+    expect(onUpdate).toHaveBeenCalledWith(fresh);
+    // sessionStorage に書き込まれている
+    const cached = JSON.parse(sessionStorage.getItem(CACHE_PREFIX + 'songs')!);
+    expect(cached.data).toEqual(fresh);
+    // 成功インジケータが DOM に出る
+    const el = document.getElementById('data-freshness-indicator');
+    expect(el?.textContent).toBe('最新データに更新済み');
+    // 3秒後にフェードアウト
+    vi.advanceTimersByTime(3000);
+    expect(el?.className).toContain('opacity-0');
+  });
+
+  it('期限切れキャッシュはミス扱いでフェッチする', async () => {
+    sessionStorage.setItem(
+      CACHE_PREFIX + 'broachs',
+      JSON.stringify({ data: [{ id: 1 }], ts: Date.now() - 10 * 60 * 1000 }),
+    );
+    const fetchFn = vi.fn(async () => [{ id: 2 }]);
+    await refreshData('broachs', fetchFn, vi.fn(), { maxAgeMs: 5 * 60 * 1000 });
+    expect(fetchFn).toHaveBeenCalled();
+  });
+
+  it('壊れたキャッシュ JSON はミス扱い', async () => {
+    sessionStorage.setItem(CACHE_PREFIX + 'cards', '{broken');
+    const fetchFn = vi.fn(async () => [{ id: 3 }]);
+    await refreshData('cards', fetchFn, vi.fn());
+    expect(fetchFn).toHaveBeenCalled();
+  });
+
+  it('フェッチ失敗時は onUpdate を呼ばず握りつぶす', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onUpdate = vi.fn();
+    await refreshData('cards', async () => { throw new Error('network'); }, onUpdate);
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/data/clientRefreshBranches.test.ts
+++ b/tests/unit/data/clientRefreshBranches.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { refreshData } from '../../../src/lib/data/clientRefresh';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('refreshData: 並行フェッチでの pendingCount 分岐 (L92, L105)', () => {
+  it('2 件同時フェッチでは 2 件目の pendingCount===1 が false、先終了側の ===0 も false', async () => {
+    // fetchFn を手動 resolve できる Promise にして 2 件を同時 in-flight にする。
+    let resolveA!: (v: unknown[]) => void;
+    let resolveB!: (v: unknown[]) => void;
+    const fetchA = vi.fn(() => new Promise<unknown[]>((res) => { resolveA = res; }));
+    const fetchB = vi.fn(() => new Promise<unknown[]>((res) => { resolveB = res; }));
+
+    const onA = vi.fn();
+    const onB = vi.fn();
+
+    // どちらもキャッシュミス → 両方が pendingCount をインクリメント
+    const pA = refreshData('cards', fetchA as never, onA);
+    const pB = refreshData('songs', fetchB as never, onB);
+
+    // この時点で pendingCount=2 (2 件目の `=== 1` は false 経路を通過済み)
+    // 先に A を終了させる → pendingCount は 2→1 (`=== 0` が false の経路を通過)
+    resolveA([{ id: 1 }]);
+    await pA;
+    expect(onA).toHaveBeenCalledWith([{ id: 1 }]);
+
+    // B を終了 → pendingCount 1→0 で成功インジケータが出る
+    resolveB([{ id: 2 }]);
+    await pB;
+    expect(onB).toHaveBeenCalledWith([{ id: 2 }]);
+
+    const el = document.getElementById('data-freshness-indicator');
+    expect(el?.textContent).toBe('最新データに更新済み');
+  });
+});

--- a/tests/unit/data/eventBadges.test.ts
+++ b/tests/unit/data/eventBadges.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { bonusBadgeHtml, type EventBonusTier } from '../../../src/lib/data/eventBonusTiers';
+import { formatEffectSummary, type EventSpecialTier } from '../../../src/lib/data/fetchEventsCsv';
+
+describe('bonusBadgeHtml', () => {
+  it('tier が gold ならバッジ HTML（selectClasses と短縮ラベルを含む）', () => {
+    const html = bonusBadgeHtml('gold');
+    expect(html).toContain('bg-yellow-100');
+    expect(html).toContain('>金</span>');
+  });
+
+  it('tier が bronze / silver でもそれぞれの色クラスを含む', () => {
+    expect(bonusBadgeHtml('bronze')).toContain('bg-amber-100');
+    expect(bonusBadgeHtml('silver')).toContain('bg-gray-200');
+  });
+
+  it('none / null / undefined は空文字', () => {
+    expect(bonusBadgeHtml('none')).toBe('');
+    expect(bonusBadgeHtml(null)).toBe('');
+    expect(bonusBadgeHtml(undefined)).toBe('');
+  });
+
+  it('定義に無い tier は空文字（防御）', () => {
+    expect(bonusBadgeHtml('unknown' as EventBonusTier)).toBe('');
+  });
+});
+
+describe('formatEffectSummary', () => {
+  const base: EventSpecialTier = {
+    cardIds: [], costumeIds: [], effect: [],
+    param_up: 0, item_up: 0, bpt_up: 0, ept_up: 0, gpt_up: 0, score_up: 0,
+  };
+
+  it('effect に含まれかつ値が正の項目のみを " / " 区切りで返す', () => {
+    const tier: EventSpecialTier = {
+      ...base,
+      effect: ['param', 'score'],
+      param_up: 50,
+      score_up: 30,
+      item_up: 20, // effect に無いので除外される
+    };
+    expect(formatEffectSummary(tier)).toBe('パラメータ +50% / スコア +30%');
+  });
+
+  it('値が 0 の項目は effect にあっても除外', () => {
+    const tier: EventSpecialTier = { ...base, effect: ['param'], param_up: 0 };
+    expect(formatEffectSummary(tier)).toBe('');
+  });
+
+  it('全 6 種別のラベルを正しく出す', () => {
+    const tier: EventSpecialTier = {
+      ...base,
+      effect: ['param', 'item', 'bpt', 'ept', 'gpt', 'score'],
+      param_up: 1, item_up: 2, bpt_up: 3, ept_up: 4, gpt_up: 5, score_up: 6,
+    };
+    expect(formatEffectSummary(tier)).toBe(
+      'パラメータ +1% / アイテム +2% / 基礎Pt +3% / イベントPt +4% / グレードPt +5% / スコア +6%',
+    );
+  });
+
+  it('該当なしなら空文字', () => {
+    expect(formatEffectSummary(base)).toBe('');
+  });
+});

--- a/tests/unit/data/fetchCardsJson.test.ts
+++ b/tests/unit/data/fetchCardsJson.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchCardsJson, getApSkillLevel, type Card } from '../../../src/lib/data/fetchCardsJson';
+
+const COLS = ['ap_skill_type', 'ap_skill_req', 'name', 'groupname'];
+
+function row(values: Partial<Record<(typeof COLS)[number], string | null>>): { c: ({ v: string | null } | null)[] } {
+  return { c: COLS.map((k) => (k in values ? { v: values[k] ?? null } : { v: null })) };
+}
+
+function stubFetch(rows: ReturnType<typeof row>[]): void {
+  const payload = {
+    version: '1',
+    status: 'ok',
+    table: { cols: COLS.map((label) => ({ id: label, label, type: 'string' })), rows },
+  };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => `google.visualization.Query.setResponse(${JSON.stringify(payload)});`,
+    })),
+  );
+}
+
+/** MIN_EXPECTED_CARDS=100 を満たすため埋め草行を作る */
+function padRows(specific: ReturnType<typeof row>[]): ReturnType<typeof row>[] {
+  const filler = Array.from({ length: 100 }, () => row({ name: 'ダミー' }));
+  return [...specific, ...filler];
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('getApSkillLevel', () => {
+  it('指定レベルの count/per/value/rate を取り出す', () => {
+    const card = {
+      ap_skill_3_count: 10, ap_skill_3_per: 50, ap_skill_3_value: 200, ap_skill_3_rate: 1.5,
+    } as unknown as Card;
+    expect(getApSkillLevel(card, 3)).toEqual({ count: 10, per: 50, value: 200, rate: 1.5 });
+  });
+
+  it('未設定フィールドは undefined', () => {
+    expect(getApSkillLevel({} as Card, 1)).toEqual({
+      count: undefined, per: undefined, value: undefined, rate: undefined,
+    });
+  });
+});
+
+describe('fetchCardsJson (fetch モック)', () => {
+  it('件数が MIN_EXPECTED_CARDS 未満なら throw', async () => {
+    stubFetch([row({ name: 'A' })]);
+    await expect(fetchCardsJson()).rejects.toThrow(/不足/);
+  });
+
+  it('ap_skill_type の表記揺れを正規化する（MISS→GOOD）', async () => {
+    stubFetch(padRows([row({ ap_skill_type: 'MISS→GOOD' })]));
+    const cards = await fetchCardsJson();
+    expect(cards[0].ap_skill_type).toBe('MISS→Good');
+  });
+
+  it('スコアアップは発動条件を括弧付きにする', async () => {
+    stubFetch(padRows([row({ ap_skill_type: 'スコアアップ', ap_skill_req: 'タイマー' })]));
+    const cards = await fetchCardsJson();
+    expect(cards[0].ap_skill_type).toBe('スコアアップ（タイマー）');
+  });
+
+  it('判定領域を→判定縮小に正規化し、発動条件を括弧付きにする', async () => {
+    stubFetch(padRows([row({ ap_skill_type: '判定領域を', ap_skill_req: 'コンボ' })]));
+    const cards = await fetchCardsJson();
+    expect(cards[0].ap_skill_type).toBe('判定縮小（コンボ）');
+  });
+
+  it('groupname が null ならキャラ名からグループを解決する', async () => {
+    stubFetch(padRows([row({ name: '七瀬陸' })]));
+    const cards = await fetchCardsJson();
+    expect(cards[0].groupname).toBe('IDOLiSH7');
+  });
+});

--- a/tests/unit/data/fetchEventsCsv.test.ts
+++ b/tests/unit/data/fetchEventsCsv.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fetchEventsCsv } from '../../../src/lib/data/fetchEventsCsv';
+
+vi.mock('node:fs/promises', () => ({ readFile: vi.fn() }));
+
+const setCsv = (csv: string) => vi.mocked(readFile).mockResolvedValue(csv as never);
+
+beforeEach(() => vi.mocked(readFile).mockReset());
+
+const HEADER =
+  'ID,eventname,eventtype,start_date,end_date,special3_member,comment,special1_rID,special1_effect,special1_param_up';
+
+describe('fetchEventsCsv', () => {
+  it('ヘッダのみ（行数<2）なら空配列', async () => {
+    setCsv(HEADER);
+    expect(await fetchEventsCsv()).toEqual([]);
+  });
+
+  it('BOM除去・引用符内カンマ・ID/effectのパースを行う', async () => {
+    const csv =
+      '﻿' + HEADER + '\n' +
+      '1,テストイベント,ハイスコア,2026-06-01,2026-06-08,,"a, b","10, 20, -5, abc","param, score, ",50\n';
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events).toHaveLength(1);
+    const e = events[0];
+    expect(e.id).toBe(1);
+    expect(e.eventname).toBe('テストイベント');
+    expect(e.comment).toBe('a, b'); // 引用符内カンマを保持
+    expect(e.gold.cardIds).toEqual([10, 20]); // 負数・非数値は除外
+    expect(e.gold.effect).toEqual(['param', 'score']); // 末尾空要素は除外
+    expect(e.gold.param_up).toBe(50);
+  });
+
+  it('id<=0 / eventname 空 / 日付欠落の行を除外する', async () => {
+    const csv =
+      HEADER + '\n' +
+      '0,無効,type,2026-06-01,2026-06-08,,,,,\n' +    // id=0
+      '2,,type,2026-06-01,2026-06-08,,,,,\n' +         // eventname 空
+      '3,有効,type,2026-06-01,2026-06-08,,,,,\n';      // 有効
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events.map((e) => e.id)).toEqual([3]);
+  });
+
+  it('引用符のエスケープ("")を1つの引用符に戻す', async () => {
+    const csv =
+      HEADER + '\n' +
+      '4,"He said ""hi""",type,2026-06-01,2026-06-08,,,,,\n';
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events[0].eventname).toBe('He said "hi"');
+  });
+});

--- a/tests/unit/data/fetchEventsCsvBranches.test.ts
+++ b/tests/unit/data/fetchEventsCsvBranches.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fetchEventsCsv, formatEffectSummary, type EventSpecialTier } from '../../../src/lib/data/fetchEventsCsv';
+
+vi.mock('node:fs/promises', () => ({ readFile: vi.fn() }));
+
+const setCsv = (csv: string) => vi.mocked(readFile).mockResolvedValue(csv as never);
+
+beforeEach(() => vi.mocked(readFile).mockReset());
+
+const HEADER =
+  'ID,eventname,eventtype,start_date,end_date,special3_member,comment,special1_rID,special1_effect,special1_param_up';
+
+describe('fetchEventsCsv: CR・単一列フィルタ・非数値・短い行', () => {
+  it('CRLF 改行 (\\r) を読み飛ばして正常にパースする (L60)', () => {
+    const csv =
+      HEADER + '\r\n' +
+      '1,テストイベント,type,2026-06-01,2026-06-08,,,,,\r\n';
+    setCsv(csv);
+    return fetchEventsCsv().then((events) => {
+      expect(events).toHaveLength(1);
+      expect(events[0].eventname).toBe('テストイベント');
+    });
+  });
+
+  it('単一列だけの空でない行は残し、空一列の行は除外する (L71)', async () => {
+    // ヘッダ後に「カンマを含まない 1 セルだけの行」(= length===1) を混ぜる。
+    // 'x' は r[0]!=='' なので残るが id 解決できず最終フィルタで落ちる → events は有効行のみ。
+    const csv =
+      HEADER + '\n' +
+      'x\n' + // length===1, r[0]='x' (!=='') → parseCsv の filter を通過
+      '2,有効,type,2026-06-01,2026-06-08,,,,,\n';
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events.map((e) => e.id)).toEqual([2]);
+  });
+
+  it('param_up が非数値なら toNum で 0 になる (L92)', async () => {
+    const csv =
+      HEADER + '\n' +
+      '3,有効,type,2026-06-01,2026-06-08,,,"10","param","abc"\n'; // param_up='abc'
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events[0].gold.param_up).toBe(0);
+  });
+
+  it('ヘッダより列数が少ない行は各フィールドが既定値にフォールバックする (L127-133)', async () => {
+    // 末尾フィールド (comment 等) を欠いた短い行: r[iComment] 等が undefined → ?? '' / ?? 0
+    const csv =
+      HEADER + '\n' +
+      '4,イベント4,type,2026-06-01,2026-06-08\n'; // special3_member 以降を省略 (短い行)
+    setCsv(csv);
+    const events = await fetchEventsCsv();
+    expect(events).toHaveLength(1);
+    const e = events[0];
+    expect(e.id).toBe(4);
+    expect(e.special3_member).toBe(''); // 欠落 → ?? '' で空文字
+    expect(e.comment).toBe('');         // 欠落 → ?? ''
+    expect(e.gold.cardIds).toEqual([]); // special1_rID 欠落 → 空配列
+  });
+});
+
+describe('formatEffectSummary', () => {
+  const baseTier = (): EventSpecialTier => ({
+    cardIds: [], costumeIds: [], effect: [],
+    param_up: 0, item_up: 0, bpt_up: 0, ept_up: 0, gpt_up: 0, score_up: 0,
+  });
+
+  it('effect に含まれ値 > 0 の項目だけを日本語ラベルで連結する', () => {
+    const tier = { ...baseTier(), effect: ['param', 'score'], param_up: 50, score_up: 30, item_up: 10 };
+    // item は effect に無いので除外、param/score のみ
+    expect(formatEffectSummary(tier)).toBe('パラメータ +50% / スコア +30%');
+  });
+
+  it('該当なしなら空文字', () => {
+    expect(formatEffectSummary(baseTier())).toBe('');
+  });
+});

--- a/tests/unit/data/fetchFixedBroachsJson.test.ts
+++ b/tests/unit/data/fetchFixedBroachsJson.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchFixedBroachsJson } from '../../../src/lib/data/fetchFixedBroachsJson';
+
+/** col 19 列分の GViz 行を作る（index → 値） */
+function row(values: Record<number, string | number | null>): { c: ({ v: string | number | null } | null)[] } {
+  const c: ({ v: string | number | null } | null)[] = new Array(19).fill(null);
+  for (const [i, v] of Object.entries(values)) c[Number(i)] = { v };
+  return { c };
+}
+
+function stubFetch(rows: ReturnType<typeof row>[]): void {
+  const payload = {
+    version: '1',
+    status: 'ok',
+    // ラベルは空（column_ 扱い）。headerOverrides 側のマッピングを検証する
+    table: { cols: new Array(19).fill({ id: '', label: '', type: '' }), rows },
+  };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => `google.visualization.Query.setResponse(${JSON.stringify(payload)});`,
+    })),
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchFixedBroachsJson (fetch モック)', () => {
+  it('headerOverrides に従って列をマッピングし、card_name 有りの行を返す', async () => {
+    stubFetch([
+      row({ 0: 1, 1: 100, 2: 'カードA', 6: 50, 7: 60, 8: 70, 10: 'Shout' }),
+    ]);
+    const broachs = await fetchFixedBroachsJson();
+    expect(broachs).toHaveLength(1);
+    expect(broachs[0]).toMatchObject({
+      id: 1, card_id: 100, card_name: 'カードA', shout: 50, beat: 60, melody: 70, attribute: 'Shout',
+    });
+  });
+
+  it('card_name が null の行は除外する', async () => {
+    stubFetch([
+      row({ 0: 1, 2: 'あり' }),
+      row({ 0: 2 }), // card_name なし
+    ]);
+    const broachs = await fetchFixedBroachsJson();
+    expect(broachs).toHaveLength(1);
+    expect(broachs[0].card_name).toBe('あり');
+  });
+});

--- a/tests/unit/data/fetchSongsJson.test.ts
+++ b/tests/unit/data/fetchSongsJson.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  filterValidSongs,
+  fetchSongsJson,
+  type Song,
+} from '../../../src/lib/data/fetchSongsJson';
+
+/** 指定セル値を持つ GViz 行を作る（cells[index] = { v }） */
+function makeRowCells(values: Record<number, string | number | null>): { c: ({ v: string | number | boolean | null } | null)[] } {
+  const c: ({ v: string | number | boolean | null } | null)[] = new Array(67).fill(null);
+  for (const [idx, v] of Object.entries(values)) {
+    c[Number(idx)] = { v };
+  }
+  return { c };
+}
+
+function stubGvizFetch(rows: ReturnType<typeof makeRowCells>[]): void {
+  const payload = {
+    version: '1',
+    status: 'ok',
+    table: { cols: new Array(67).fill({ id: '', label: '', type: '' }), rows },
+  };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => `google.visualization.Query.setResponse(${JSON.stringify(payload)});`,
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('filterValidSongs', () => {
+  const valid = { category: 'A', artist: 'B', notes_count: 100 } as Song;
+
+  it('category / artist / notes_count がすべて存在する曲のみ残す', () => {
+    const songs = [
+      valid,
+      { category: null, artist: 'B', notes_count: 100 } as Song,
+      { category: 'A', artist: null, notes_count: 100 } as Song,
+      { category: 'A', artist: 'B', notes_count: null } as Song,
+    ];
+    expect(filterValidSongs(songs)).toEqual([valid]);
+  });
+});
+
+describe('fetchSongsJson (fetch モック)', () => {
+  it('GViz テーブルをネスト構造の Song に変換する', async () => {
+    const row = makeRowCells({
+      0: 10, 1: 'カテゴリ', 2: 'アーティスト', 3: '曲名', 6: '★★★', 10: 200, 11: 120,
+      12: 5, 13: 6, 14: 7, 15: 8, 16: 9, 17: 10, // notes_20 グループ
+      60: 1, 61: 2, 62: 3, 63: 4, 64: 5, 65: 6, // 合計
+      66: '2026-06-01',
+    });
+    stubGvizFetch([row]);
+
+    const songs = await fetchSongsJson();
+    expect(songs).toHaveLength(1);
+    const s = songs[0];
+    expect(s.id).toBe(10);
+    expect(s.song_name).toBe('曲名');
+    // stars は文字列なら length に変換
+    expect(s.stars).toBe(3);
+    // ネストグループ
+    expect(s.notes_20).toEqual({
+      shout_white: 5, shout_color: 6, beat_white: 7, beat_color: 8, melody_white: 9, melody_color: 10,
+    });
+    expect(s.total_shout_white).toBe(1);
+    expect(s.updated_at).toBe('2026-06-01');
+  });
+
+  it('song_name が無い行は除外する', async () => {
+    const withName = makeRowCells({ 0: 1, 3: '有効曲' });
+    const withoutName = makeRowCells({ 0: 2 }); // song_name (col3) なし
+    stubGvizFetch([withName, withoutName]);
+
+    const songs = await fetchSongsJson();
+    expect(songs).toHaveLength(1);
+    expect(songs[0].song_name).toBe('有効曲');
+  });
+
+  it('ネストグループの欠損セルは 0 で埋める', async () => {
+    const row = makeRowCells({ 0: 1, 3: '曲' }); // notes_20 のセルなし
+    stubGvizFetch([row]);
+    const songs = await fetchSongsJson();
+    expect(songs[0].notes_20).toEqual({
+      shout_white: 0, shout_color: 0, beat_white: 0, beat_color: 0, melody_white: 0, melody_color: 0,
+    });
+  });
+});

--- a/tests/unit/data/fetchSongsJsonBranches.test.ts
+++ b/tests/unit/data/fetchSongsJsonBranches.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getEventSongIds,
+  firstEventSongId,
+  filterValidSongs,
+  fetchSongsJson,
+  type Song,
+} from '../../../src/lib/data/fetchSongsJson';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchSongsJson: row.c が無い行のフォールバック (L167 || [])', () => {
+  it('c を持たない行は空セル配列として変換され song_name 無しで除外される', () => {
+    const cols = new Array(67).fill({ id: '', label: '', type: '' });
+    const withName = { c: (() => { const a = new Array(67).fill(null); a[0] = { v: 1 }; a[3] = { v: '曲A' }; return a; })() };
+    const noC = {}; // row.c なし → convertRow(row.c || []) の || [] を通す
+    const payload = { version: '1', status: 'ok', table: { cols, rows: [withName, noC] } };
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK',
+      text: async () => `google.visualization.Query.setResponse(${JSON.stringify(payload)});`,
+    })));
+    return fetchSongsJson().then((songs) => {
+      // c なし行は song_name=null → filter で除外され、有効な 1 曲のみ
+      expect(songs).toHaveLength(1);
+      expect(songs[0].song_name).toBe('曲A');
+    });
+  });
+});
+
+describe('filterValidSongs: 各必須フィールド欠落の除外 (L135)', () => {
+  it('notes_count が 0/null の曲を除外する', () => {
+    const valid = { category: 'A', artist: 'B', notes_count: 100 } as Song;
+    const songs = [
+      valid,
+      { category: 'A', artist: 'B', notes_count: 0 } as Song,    // notes_count falsy
+      { category: 'A', artist: 'B', notes_count: null } as Song, // notes_count null
+    ];
+    expect(filterValidSongs(songs)).toEqual([valid]);
+  });
+});
+
+describe('getEventSongIds', () => {
+  it('config の eventSongIds 配列を返す（実データは配列なので非空でも空でも配列）', () => {
+    const ids = getEventSongIds();
+    expect(Array.isArray(ids)).toBe(true);
+  });
+});
+
+describe('firstEventSongId: id=null の曲を除外して既定選択を解決 (L167)', () => {
+  it('id が null の曲は Set に含めず、該当が無ければ null', () => {
+    const songs = [
+      { id: null, category: 'A', artist: 'B', notes_count: 1 } as unknown as Song, // id null → filter で除外
+      { id: -9999, category: 'A', artist: 'B', notes_count: 1 } as Song,            // event 対象外
+    ];
+    // eventSongIds に存在しない id しか無い → null
+    expect(firstEventSongId(songs)).toBeNull();
+  });
+
+  it('eventSongIds に一致する曲があればその id を返す', () => {
+    const eventIds = getEventSongIds();
+    if (eventIds.length === 0) {
+      // config が空ならスキップ相当 (常に null)
+      expect(firstEventSongId([{ id: 1 } as Song])).toBeNull();
+      return;
+    }
+    const target = eventIds[0];
+    const songs = [
+      { id: null } as unknown as Song,    // id null を含めて L167 の除外も通す
+      { id: target } as Song,
+    ];
+    expect(firstEventSongId(songs)).toBe(target);
+  });
+});

--- a/tests/unit/data/gviz.test.ts
+++ b/tests/unit/data/gviz.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { extractCellValue, parseGvizResponse } from '../../../src/lib/data/gviz';
+
+describe('extractCellValue', () => {
+  it('null セル / null 値 / undefined は null', () => {
+    expect(extractCellValue(null)).toBeNull();
+    expect(extractCellValue(undefined)).toBeNull();
+    expect(extractCellValue({ v: null })).toBeNull();
+  });
+
+  it('GViz Date 文字列を YYYY-MM-DD 形式に変換する（月は 0 始まり）', () => {
+    // toISOString ベースのため TZ 依存。実装と同一ロジックで期待値を算出して比較する
+    const expected = new Date(2024, 0, 15).toISOString().split('T')[0];
+    const out = extractCellValue({ v: 'Date(2024,0,15)' });
+    expect(out).toBe(expected);
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // 生文字列のままではないこと（変換が走っていること）
+    expect(out).not.toBe('Date(2024,0,15)');
+  });
+
+  it('数値・真偽値・通常文字列はそのまま返す', () => {
+    expect(extractCellValue({ v: 123 })).toBe(123);
+    expect(extractCellValue({ v: true })).toBe(true);
+    expect(extractCellValue({ v: 'text' })).toBe('text');
+  });
+});
+
+describe('parseGvizResponse', () => {
+  it('JSONP ラッピングを除去してパースする', () => {
+    const payload = { version: '1', status: 'ok', table: { cols: [], rows: [] } };
+    const text = `google.visualization.Query.setResponse(${JSON.stringify(payload)});`;
+    expect(parseGvizResponse(text)).toEqual(payload);
+  });
+
+  it('末尾セミコロンが無くてもパースできる', () => {
+    const payload = { version: '1', status: 'ok', table: { cols: [], rows: [] } };
+    const text = `google.visualization.Query.setResponse(${JSON.stringify(payload)})`;
+    expect(parseGvizResponse(text)).toEqual(payload);
+  });
+
+  it('ラッピングにマッチしなければ throw', () => {
+    expect(() => parseGvizResponse('not a gviz response')).toThrow();
+  });
+});

--- a/tests/unit/data/gvizBranches.test.ts
+++ b/tests/unit/data/gvizBranches.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { extractCellValue, fetchSheetAsJson } from '../../../src/lib/data/gviz';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('extractCellValue: v が undefined (キー欠落) なら null (L34)', () => {
+  it('v プロパティを持たないセルは null', () => {
+    // { v: null } は既存テスト済み。ここは「v キー自体が無い」= undefined 経路を通す。
+    expect(extractCellValue({} as never)).toBeNull();
+  });
+});
+
+describe('fetchSheetAsJson: row.c が無い行のフォールバック (L107)', () => {
+  it('c を持たない行はセル値が null になる', () => {
+    const cols = [{ id: 'a', label: 'name', type: 'string' }];
+    const payload = {
+      version: '1', status: 'ok',
+      table: { cols, rows: [{ c: [{ v: 'あり' }] }, {}] }, // 2 行目は c なし → row.c ? ... : null
+    };
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK',
+      text: async () => `google.visualization.Query.setResponse(${JSON.stringify(payload)});`,
+    })));
+    return fetchSheetAsJson('sid', 1).then((rows) => {
+      expect(rows[0]).toEqual({ name: 'あり' });
+      expect(rows[1]).toEqual({ name: null }); // c なし → null フォールバック
+    });
+  });
+});

--- a/tests/unit/data/gvizFetch.test.ts
+++ b/tests/unit/data/gvizFetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { fetchSheetRaw, fetchSheetAsJson } from '../../../src/lib/data/gviz';
+
+function gvizText(rows: { c: ({ v: unknown } | null)[] }[], cols = [{ id: '', label: '', type: '' }]): string {
+  const payload = { version: '1', status: 'ok', table: { cols, rows } };
+  return `google.visualization.Query.setResponse(${JSON.stringify(payload)});`;
+}
+
+beforeEach(() => {
+  // リトライ待機の setTimeout を即時化
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchSheetRaw (fetch モック)', () => {
+  it('正常レスポンスでテーブルを返す', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK',
+      text: async () => gvizText([{ c: [{ v: 1 }] }]),
+    })));
+    const table = await fetchSheetRaw('sid', 1);
+    expect(table.rows).toHaveLength(1);
+  });
+
+  it('response.ok=false ならリトライ後に throw', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false, status: 500, statusText: 'Server Error', text: async () => '',
+    })));
+    const p = fetchSheetRaw('sid', 1, 1);
+    const assertion = expect(p).rejects.toThrow(/取得に失敗/);
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it('空データ（rows=0）なら throw', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK', text: async () => gvizText([]),
+    })));
+    const p = fetchSheetRaw('sid', 1, 1);
+    const assertion = expect(p).rejects.toThrow(/空/);
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it('1 回失敗→2 回目成功でリトライが効く', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'busy', text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', text: async () => gvizText([{ c: [{ v: 1 }] }]) });
+    vi.stubGlobal('fetch', fetchMock);
+    const p = fetchSheetRaw('sid', 1, 2);
+    await vi.runAllTimersAsync();
+    const table = await p;
+    expect(table.rows).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('fetchSheetAsJson (fetch モック)', () => {
+  it('cols.label をヘッダにし column_ 列はスキップする', async () => {
+    const cols = [{ id: 'a', label: 'name', type: 'string' }, { id: 'b', label: '', type: 'string' }];
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK',
+      text: async () => gvizText([{ c: [{ v: '陸' }, { v: 'skip' }] }], cols),
+    })));
+    const rows = await fetchSheetAsJson('sid', 1);
+    expect(rows[0]).toEqual({ name: '陸' }); // column_1 はスキップ
+  });
+});

--- a/tests/unit/data/rabbitNote.test.ts
+++ b/tests/unit/data/rabbitNote.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadRabbitNotes, saveRabbitNotes } from '../../../src/lib/data/rabbitNote';
+import { STORAGE_KEYS } from '../../../src/lib/storage';
+
+beforeEach(() => localStorage.clear());
+
+describe('rabbitNote', () => {
+  it('未保存なら空オブジェクト', () => {
+    expect(loadRabbitNotes()).toEqual({});
+  });
+
+  it('保存した内容を読み戻せる', () => {
+    const notes = { 七瀬陸: { shout: 1, beat: 2, melody: 3 } };
+    saveRabbitNotes(notes);
+    expect(localStorage.getItem(STORAGE_KEYS.RABBIT_NOTES)).not.toBeNull();
+    expect(loadRabbitNotes()).toEqual(notes);
+  });
+});

--- a/tests/unit/donutChart.test.ts
+++ b/tests/unit/donutChart.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { donutChartSvg, attrDonutSvg } from '../../src/lib/donutChart';
+import { ATTR_HEX } from '../../src/lib/constants';
+
+describe('donutChartSvg', () => {
+  it('全セグメントが 0 ならプレースホルダー "-" を返す', () => {
+    const html = donutChartSvg([
+      { value: 0, color: '#ef4444' },
+      { value: 0, color: '#22c55e' },
+    ]);
+    expect(html).toBe('<span class="text-gray-400 text-xs">-</span>');
+  });
+
+  it('単一セグメントで SVG を生成', () => {
+    const html = donutChartSvg([{ value: 100, color: '#ef4444' }]);
+    expect(html).toContain('<svg viewBox="0 0 36 36"');
+    expect(html).toContain('stroke="#ef4444"');
+    expect(html).toContain('stroke-dasharray=');
+  });
+
+  it('複数セグメントで各色の circle を生成', () => {
+    const html = donutChartSvg([
+      { value: 50, color: '#ef4444' },
+      { value: 30, color: '#22c55e' },
+      { value: 20, color: '#3b82f6' },
+    ]);
+    expect(html).toContain('stroke="#ef4444"');
+    expect(html).toContain('stroke="#22c55e"');
+    expect(html).toContain('stroke="#3b82f6"');
+    // 背景 circle + 3 セグメント = 4 個
+    expect(html.match(/<circle /g)).toHaveLength(4);
+  });
+
+  it('デフォルトオプション (sizeClass / strokeWidth) を適用', () => {
+    const html = donutChartSvg([{ value: 10, color: '#ef4444' }]);
+    expect(html).toContain('class="w-10 h-10"');
+    expect(html).toContain('stroke-width="5"');
+  });
+
+  it('カスタム sizeClass / strokeWidth を適用', () => {
+    const html = donutChartSvg([{ value: 10, color: '#ef4444' }], {
+      sizeClass: 'w-20 h-20',
+      strokeWidth: 2,
+    });
+    expect(html).toContain('class="w-20 h-20"');
+    expect(html).toContain('stroke-width="2"');
+  });
+
+  it('showTitle=false なら title 属性なし', () => {
+    const html = donutChartSvg([{ value: 10, color: '#ef4444', label: 'S' }]);
+    expect(html).not.toContain('title=');
+  });
+
+  it('showTitle=true でセグメントのラベルとパーセントを title に出す', () => {
+    const html = donutChartSvg(
+      [
+        { value: 50, color: '#ef4444', label: 'S' },
+        { value: 50, color: '#22c55e', label: 'B' },
+      ],
+      { showTitle: true },
+    );
+    expect(html).toContain('title="S:50% B:50%"');
+  });
+
+  it('label 未指定でも showTitle で出力できる', () => {
+    const html = donutChartSvg(
+      [
+        { value: 60, color: '#ef4444' },
+        { value: 40, color: '#22c55e' },
+      ],
+      { showTitle: true },
+    );
+    expect(html).toContain(':60%');
+    expect(html).toContain(':40%');
+  });
+
+  it('centerText 未指定なら text 要素なし', () => {
+    const html = donutChartSvg([{ value: 10, color: '#ef4444' }]);
+    expect(html).not.toContain('<text');
+  });
+
+  it('centerText 指定で上段ラベル・下段値の 2 行を生成', () => {
+    const html = donutChartSvg([{ value: 10, color: '#ef4444' }], {
+      centerText: { label: '合計', value: '100' },
+    });
+    expect(html).toContain('合計</text>');
+    expect(html).toContain('100</text>');
+  });
+});
+
+describe('attrDonutSvg', () => {
+  it('S/B/M の 3 属性で属性色の circle を生成し title も付く', () => {
+    const html = attrDonutSvg(60, 30, 10);
+    expect(html).toContain(`stroke="${ATTR_HEX.Shout}"`);
+    expect(html).toContain(`stroke="${ATTR_HEX.Beat}"`);
+    expect(html).toContain(`stroke="${ATTR_HEX.Melody}"`);
+    expect(html).toContain('title="S:60% B:30% M:10%"');
+  });
+
+  it('追加オプションで showTitle を上書きできる', () => {
+    const html = attrDonutSvg(60, 30, 10, { showTitle: false });
+    expect(html).not.toContain('title=');
+  });
+
+  it('全 0 ならプレースホルダー', () => {
+    expect(attrDonutSvg(0, 0, 0)).toContain('-</span>');
+  });
+});

--- a/tests/unit/score/broachAssignmentBranches.test.ts
+++ b/tests/unit/score/broachAssignmentBranches.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import type { FlatNote } from '../../../src/lib/score/types';
+import {
+  calcAttrWeights,
+  countDeckAttrs,
+  broachValue,
+  broachCapacity,
+  assignBroachs,
+  type AttrWeights,
+} from '../../../src/lib/score/broachAssignment';
+import { SHARED_BROACHS } from '../../../src/lib/data/sharedBroachs';
+import { NOTE_RATE, LIGHT_MULTIPLIER } from '../../../src/lib/score/constants';
+import { findCardById } from '../../fixtures';
+
+const urBeat = findCardById(959); // UR / Beat / IDOLiSH7
+const urShout = findCardById(406); // UR / Shout
+
+function note(attribute: FlatNote['attribute'], type: FlatNote['type'], group: string): FlatNote {
+  return { attribute, type, group, excluded: false };
+}
+
+describe('calcAttrWeights', () => {
+  it('既知グループのノーツは NOTE_RATE × LIGHT_MULTIPLIER で重み付けされる', () => {
+    const w = calcAttrWeights([note('Shout', 'color', 'light_4')]);
+    expect(w.Shout).toBeCloseTo(NOTE_RATE.color * LIGHT_MULTIPLIER.light_4, 10);
+    expect(w.Beat).toBe(0);
+    expect(w.Melody).toBe(0);
+  });
+
+  it('LIGHT_MULTIPLIER に無いグループは 0 倍として無視される (line 26 || 0)', () => {
+    const w = calcAttrWeights([note('Beat', 'white', 'unknown_group')]);
+    expect(w.Beat).toBe(0);
+    expect(w.Shout).toBe(0);
+    expect(w.Melody).toBe(0);
+  });
+});
+
+describe('countDeckAttrs', () => {
+  it('属性別カード枚数を集計し、null スロットは無視する', () => {
+    const deck: (Card | null)[] = [urBeat, urShout, null, null, null, null];
+    const counts = countDeckAttrs(deck);
+    expect(counts.Beat).toBe(1);
+    expect(counts.Shout).toBe(1);
+    expect(counts.Melody).toBe(0);
+  });
+});
+
+describe('broachValue', () => {
+  const weights: AttrWeights = { Shout: 1, Beat: 2, Melody: 3 };
+  const attrCounts = { Shout: 2, Beat: 1, Melody: 0 };
+
+  it('無条件ブローチ (ALL750) は倍率 1 で重み付き寄与値を返す', () => {
+    const all750 = SHARED_BROACHS.find(s => s.id === 1)!;
+    expect(broachValue(all750, weights, attrCounts)).toBe((750 * 1 + 750 * 2 + 750 * 3) * 1);
+  });
+
+  it('条件付きブローチ (S属性枚数分Shout+300, id=24) は対象属性枚数を倍率にする', () => {
+    const cond = SHARED_BROACHS.find(s => s.id === 24)!;
+    // targetAttribute=Shout、attrCounts.Shout=2 → 倍率 2
+    expect(broachValue(cond, weights, attrCounts)).toBe((300 * 1) * 2);
+  });
+});
+
+describe('broachCapacity', () => {
+  const hasFixed = (card: Card) => card.cardID === urBeat.cardID;
+
+  it('null スロットは 0', () => {
+    expect(broachCapacity(null, hasFixed)).toBe(0);
+  });
+
+  it('非 UR カードは 0', () => {
+    const sr = findCardById(1622); // SR
+    expect(broachCapacity(sr, hasFixed)).toBe(0);
+  });
+
+  it('UR で固有ブローチ持ちは 1', () => {
+    expect(broachCapacity(urBeat, hasFixed)).toBe(1);
+  });
+
+  it('UR で固有ブローチ無しは 2', () => {
+    expect(broachCapacity(urShout, hasFixed)).toBe(2);
+  });
+});
+
+describe('assignBroachs', () => {
+  const noFixed = () => false;
+  const weights: AttrWeights = { Shout: 1, Beat: 1, Melody: 1 };
+
+  it('所持ブローチを寄与値降順で slot0-4 に貪欲割当し、フレンド枠 (slot5) に最良ブローチを容量分割当てる', () => {
+    // slot0-4 全員 UR・固有なし → 各 cap 2、friend(slot5) も UR → cap 2
+    const deck: (Card | null)[] = [urShout, urShout, urShout, urShout, urShout, urShout];
+    // ALL750 (id1) を 1 個所持
+    const owned: Record<string, number> = { '1': 1 };
+    const sel = assignBroachs(deck, owned, weights, noFixed);
+    // 所持 1 個 → slot0 に 1 個割当 (line 77 / 83-87)
+    expect(sel[0]).toEqual([1]);
+    expect(sel[1]).toEqual([]);
+    // フレンド枠: 全種から最良 (ALL750=id1) を cap2 個 (line 92-104)
+    expect(sel[5]).toEqual([1, 1]);
+  });
+
+  it('寄与値 0 のブローチ (重み全 0 で属性値 0) は展開されない', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    // Shout1100 (id6) は beat/melody=0。weights を Beat/Melody のみ正にすると寄与値 0
+    const beatOnlyWeights: AttrWeights = { Shout: 0, Beat: 1, Melody: 1 };
+    const owned: Record<string, number> = { '6': 1 };
+    const sel = assignBroachs(deck, owned, beatOnlyWeights, noFixed);
+    expect(sel[0]).toEqual([]);
+  });
+
+  it('所持数 0 のブローチはスキップされる', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const owned: Record<string, number> = { '1': 0 };
+    const sel = assignBroachs(deck, owned, weights, noFixed);
+    expect(sel[0]).toEqual([]);
+  });
+
+  it('フレンド枠が非 UR (cap 0) のときフレンド割当は行われない', () => {
+    const sr = findCardById(1622); // SR
+    const deck: (Card | null)[] = [urShout, null, null, null, null, sr];
+    const owned: Record<string, number> = { '1': 5 };
+    const sel = assignBroachs(deck, owned, weights, noFixed);
+    expect(sel[5]).toEqual([]);
+  });
+
+  it('全ブローチの寄与値が 0 のときフレンド枠の best は null のまま (line 102 false 分岐)', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, urShout];
+    const zeroWeights: AttrWeights = { Shout: 0, Beat: 0, Melody: 0 };
+    const sel = assignBroachs(deck, {}, zeroWeights, noFixed);
+    expect(sel[5]).toEqual([]);
+  });
+});

--- a/tests/unit/score/broachResolverBranches.test.ts
+++ b/tests/unit/score/broachResolverBranches.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import type { FixedBroach } from '../../../src/lib/data/fetchFixedBroachsJson';
+import { resolveDeckBroachs, calcBroachScoreBonus } from '../../../src/lib/score/broachResolver';
+import { findCardById, findSongById } from '../../fixtures';
+
+const song = findSongById(2); // MONSTER GENERATiON
+
+/** UR / Beat (IDOLiSH7) */
+const urCard = findCardById(959);
+
+/** 任意の broach_type / フィールドを差し込んだテスト用ブローチ生成 */
+function makeBroach(partial: Partial<FixedBroach>): FixedBroach {
+  return {
+    id: 1,
+    card_id: urCard.cardID,
+    card_name: urCard.cardname,
+    name: 'test',
+    name_other: null,
+    shout: null, beat: null, melody: null,
+    attribute: null, idol: null, group: null,
+    auto: null, song: null, score: null,
+    limit: null, broach_type: null, condition: null,
+    ...partial,
+  };
+}
+
+const deck: (Card | null)[] = [urCard, null, null, null, null, null];
+
+describe('resolveDeckBroachs: switch default (未知の broach_type) は無効 (line 94-95)', () => {
+  it('broach_type=99 は active=false', () => {
+    const resolved = resolveDeckBroachs(deck, [makeBroach({ broach_type: 99 })], song);
+    const slot0 = resolved.get(0) ?? [];
+    expect(slot0).toHaveLength(1);
+    expect(slot0[0].active).toBe(false);
+  });
+});
+
+describe('resolveDeckBroachs: 種類5(IDOL_ATTR_COUNT) idol/attribute 欠落で無効 (line 76)', () => {
+  it('idol が null の type5 は active=false', () => {
+    const b = makeBroach({ broach_type: 5, idol: null, attribute: 'Beat' });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect((resolved.get(0) ?? [])[0].active).toBe(false);
+  });
+
+  it('attribute が null の type5 は active=false', () => {
+    const b = makeBroach({ broach_type: 5, idol: 'IDOLiSH7', attribute: null });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect((resolved.get(0) ?? [])[0].active).toBe(false);
+  });
+});
+
+describe('resolveDeckBroachs: 種類5 のデッキ依存倍率 (multiplier = 同アイドル同属性枚数)', () => {
+  it('同名(IDOLiSH7)・同属性(Beat) のカードが 1 枚 → multiplier=1 で active', () => {
+    // urCard.name は 'IDOLiSH7'、属性 Beat
+    const b = makeBroach({ broach_type: 5, idol: urCard.name, attribute: 'Beat', limit: 1 });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    const rb = (resolved.get(0) ?? [])[0];
+    expect(rb.active).toBe(true);
+    expect(rb.multiplier).toBe(1);
+  });
+});
+
+describe('resolveDeckBroachs: limit が null のとき Infinity 扱い (line 163 ?? Infinity)', () => {
+  it('type6 (ATTRIBUTE_UP_LIMITED) で limit=null のブローチは無制限に有効', () => {
+    const b = makeBroach({ broach_type: 6, beat: 500, limit: null });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    const rb = (resolved.get(0) ?? [])[0];
+    expect(rb.active).toBe(true);
+  });
+});
+
+describe('resolveDeckBroachs: 種類6 のデッキ内上限処理 (limit 超過で active=false)', () => {
+  it('limit=1 の type6 が同一デッキに 2 枚あると 2 枚目は active=false', () => {
+    const urCard2 = findCardById(960); // 別の UR
+    const twoCardDeck: (Card | null)[] = [urCard, urCard2, null, null, null, null];
+    const b1 = makeBroach({ id: 101, card_id: urCard.cardID, broach_type: 6, beat: 500, limit: 1 });
+    const b2 = makeBroach({ id: 102, card_id: urCard2.cardID, broach_type: 6, beat: 500, limit: 1 });
+    const resolved = resolveDeckBroachs(twoCardDeck, [b1, b2], song);
+    const actives = [...resolved.values()].flat().filter(rb => rb.active);
+    expect(actives).toHaveLength(1);
+  });
+});
+
+describe('checkBroachCondition の各種ケース', () => {
+  it('種類7(ALL_ATTRIBUTES): 3 属性そろわないデッキでは無効', () => {
+    // urCard は Beat 単独 → 全属性そろわず
+    const b = makeBroach({ broach_type: 7, beat: 500, limit: 2 });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect((resolved.get(0) ?? [])[0].active).toBe(false);
+  });
+
+  it('種類8(AUTO_ONLY): 常に無効', () => {
+    const b = makeBroach({ broach_type: 8, beat: 500 });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect((resolved.get(0) ?? [])[0].active).toBe(false);
+  });
+
+  it('種類4(GROUP): group が null のとき無効', () => {
+    const b = makeBroach({ broach_type: 4, group: null, beat: 500 });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect((resolved.get(0) ?? [])[0].active).toBe(false);
+  });
+});
+
+describe('calcBroachScoreBonus: score が falsy の type9 は 0 加算 (line 208 || 0)', () => {
+  it('score=null の type9 は 0', () => {
+    const b = makeBroach({ broach_type: 9, song: 'MONSTER GENERATiON', score: null });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect(calcBroachScoreBonus(resolved)).toBe(0);
+  });
+
+  it('score=1000 の type9 (曲一致) は 1000', () => {
+    const b = makeBroach({ broach_type: 9, song: 'MONSTER GENERATiON', score: 1000 });
+    const resolved = resolveDeckBroachs(deck, [b], song);
+    expect(calcBroachScoreBonus(resolved)).toBe(1000);
+  });
+});

--- a/tests/unit/score/cardSkillSingle.test.ts
+++ b/tests/unit/score/cardSkillSingle.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import {
+  computeTeam, flattenNotes, computeShrinkExclusion, computeGroupSizes,
+  calcCardSkillExpected, calcCardSkillMax,
+} from '../../../src/lib/score/engine';
+import { findCardById, findSongById } from '../../fixtures';
+
+const song = findSongById(2);
+const notesCount = song.notes_count!;
+const SEED = 42;
+
+const timerScoreUp = findCardById(1172); // タイマー scoreUp count=16秒 per=47 value=7200
+const comboScoreUp = findCardById(410);  // コンボ scoreUp count=16 per=46 value=6403
+const shrinkCard = findCardById(2618);   // 判定縮小 Perfect
+const noSkillCard = findCardById(2484);  // BAD→Perfect (寄与なし)
+
+const deckOf = (c: Card, slot = 0): (Card | null)[] => {
+  const d: (Card | null)[] = [null, null, null, null, null, null];
+  d[slot] = c;
+  return d;
+};
+
+describe('calcCardSkillExpected', () => {
+  it('タイマー scoreUp: floor(maxAct × per/100 × value) = 20304', () => {
+    const team = computeTeam(deckOf(timerScoreUp), [], song);
+    const notes = flattenNotes(song, SEED);
+    expect(calcCardSkillExpected(team, notes, notesCount, 0)).toBe(20304);
+  });
+
+  it('コンボ scoreUp: floor(26 × 0.46 × 6403) = 76579', () => {
+    const team = computeTeam(deckOf(comboScoreUp), [], song);
+    const notes = flattenNotes(song, SEED);
+    expect(calcCardSkillExpected(team, notes, notesCount, 0)).toBe(76579);
+  });
+
+  it('判定縮小カード: 正の期待値を返す', () => {
+    const team = computeTeam(deckOf(shrinkCard), [], song);
+    const ex = computeShrinkExclusion(team, computeGroupSizes(song));
+    const notes = flattenNotes(song, SEED, ex);
+    expect(calcCardSkillExpected(team, notes, notesCount, 0)).toBeGreaterThan(0);
+  });
+
+  it('カード未配置スロットは 0', () => {
+    const team = computeTeam(deckOf(timerScoreUp), [], song);
+    expect(calcCardSkillExpected(team, flattenNotes(song, SEED), notesCount, 3)).toBe(0);
+  });
+
+  it('スキル非所持カードは 0', () => {
+    const team = computeTeam(deckOf(noSkillCard), [], song);
+    expect(calcCardSkillExpected(team, flattenNotes(song, SEED), notesCount, 0)).toBe(0);
+  });
+
+  it('notesCount=0（denom<=0）は 0', () => {
+    const team = computeTeam(deckOf(comboScoreUp), [], song);
+    expect(calcCardSkillExpected(team, flattenNotes(song, SEED), 0, 0)).toBe(0);
+  });
+});
+
+describe('calcCardSkillMax', () => {
+  it('タイマー scoreUp: 6 × 7200 = 43200', () => {
+    const team = computeTeam(deckOf(timerScoreUp), [], song);
+    expect(calcCardSkillMax(team, flattenNotes(song, SEED), notesCount, 0)).toBe(43200);
+  });
+
+  it('コンボ scoreUp: 26 × 6403 = 166478', () => {
+    const team = computeTeam(deckOf(comboScoreUp), [], song);
+    expect(calcCardSkillMax(team, flattenNotes(song, SEED), notesCount, 0)).toBe(166478);
+  });
+
+  it('判定縮小カード: 正の最大値を返す', () => {
+    const team = computeTeam(deckOf(shrinkCard), [], song);
+    const ex = computeShrinkExclusion(team, computeGroupSizes(song));
+    const notes = flattenNotes(song, SEED, ex);
+    expect(calcCardSkillMax(team, notes, notesCount, 0)).toBeGreaterThan(0);
+  });
+
+  it('未配置スロット / notesCount=0 は 0', () => {
+    const team = computeTeam(deckOf(comboScoreUp), [], song);
+    expect(calcCardSkillMax(team, flattenNotes(song, SEED), notesCount, 3)).toBe(0);
+    expect(calcCardSkillMax(team, flattenNotes(song, SEED), 0, 0)).toBe(0);
+  });
+});

--- a/tests/unit/score/cardStrengthBranches.test.ts
+++ b/tests/unit/score/cardStrengthBranches.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import type { FixedBroach } from '../../../src/lib/data/fetchFixedBroachsJson';
+import type { Song } from '../../../src/lib/data/fetchSongsJson';
+import {
+  buildCardStrengthEntry,
+  calcBaseScore,
+  calcCardStrengthAppeal,
+} from '../../../src/lib/score/cardStrength';
+
+const EMPTY_GROUP = {
+  shout_white: 0, shout_color: 0, beat_white: 0, beat_color: 0, melody_white: 0, melody_color: 0,
+};
+
+/** 全グループそろった基本曲 */
+function makeSong(over: Partial<Song> = {}): Song {
+  return {
+    id: 999, song_name: 'テスト曲', difficulty: 'EXPERT', duration: 113, notes_count: 493,
+    notes_20: { ...EMPTY_GROUP, shout_white: 10, melody_color: 20 },
+    light_2: { ...EMPTY_GROUP }, light_3: { ...EMPTY_GROUP }, light_4: { ...EMPTY_GROUP },
+    light_5: { ...EMPTY_GROUP }, light_6: { ...EMPTY_GROUP },
+    chorus_light_5: { ...EMPTY_GROUP },
+    chorus_light_6: { ...EMPTY_GROUP, melody_white: 5 },
+    ...over,
+  } as unknown as Song;
+}
+
+function makeCard(over: Partial<Card> = {}): Card {
+  return {
+    ID: 1, cardID: 9001, cardname: 'テスト衣装', name: '九条天', rarity: 'UR', attribute: 'Melody',
+    shout_max: 1000, beat_max: 1000, melody_max: 4000,
+    ap_skill_type: 'スコアアップ（コンボ）',
+    ap_skill_5_count: 25, ap_skill_5_per: 40, ap_skill_5_value: 5200, ap_skill_5_rate: 0,
+    sp_time: 0,
+    ...over,
+  } as unknown as Card;
+}
+
+function makeBroach(over: Partial<FixedBroach> = {}): FixedBroach {
+  return {
+    id: 501, card_id: 9001, broach_type: 1,
+    shout: 0, beat: 0, melody: 0, score: 0,
+    group: null, idol: null, attribute: null, song: null, limit: null,
+    ...over,
+  } as unknown as FixedBroach;
+}
+
+describe('calcBaseScore: グループキーが欠落した曲はスキップする (line 76 !group continue)', () => {
+  it('一部グループ (light_3 等) が undefined の曲でも例外なく計算できる', () => {
+    // notes_20 と chorus_light_6 のみ存在、その他グループは未定義
+    const sparse = {
+      id: 1, song_name: 'sparse', duration: 100, notes_count: 100,
+      notes_20: { ...EMPTY_GROUP, shout_white: 4 },
+      chorus_light_6: { ...EMPTY_GROUP, melody_white: 2 },
+    } as unknown as Song;
+    const appeal = { Shout: 1000, Beat: 1000, Melody: 4000 };
+    // shout_white: floor(1000*0.025)=25 ×1.0 ×4 = 100
+    // melody_white: floor(4000*0.025)=100 ×3.0 ×2 = 600
+    expect(calcBaseScore(appeal, sparse)).toBe(100 + 600);
+  });
+});
+
+describe('calcCardStrengthAppeal: id が null のブローチはスキップ (line 115 br.id == null continue)', () => {
+  it('id=null ブローチは無視され素ステータスのまま', () => {
+    const broach = makeBroach({ id: null, melody: 9999 });
+    const { appeal } = calcCardStrengthAppeal(makeCard(), [broach], makeSong());
+    expect(appeal.Melody).toBe(4000);
+  });
+});
+
+describe('calcCardStrengthAppeal: 非 UR カード + ブローチで resolved.get(0) が空 (line 119 ?? [])', () => {
+  it('SR カードのブローチは resolveDeckBroachs で UR 限定のため発動せず素ステータスのまま', () => {
+    const sr = makeCard({ rarity: 'SR' });
+    const broach = makeBroach({ melody: 5000 });
+    const { appeal, broachScoreBonus } = calcCardStrengthAppeal(sr, [broach], makeSong());
+    expect(appeal.Melody).toBe(4000);
+    expect(broachScoreBonus).toBe(0);
+  });
+});
+
+describe('calcCardStrengthAppeal: 非アクティブ / 種類9 ブローチは属性加算しない (line 121)', () => {
+  it('発動条件を満たさない種類7 ブローチは属性に加算されない (rb.active=false)', () => {
+    // 単独デッキでは 3 属性そろわず type7 は非アクティブ
+    const broach = makeBroach({ broach_type: 7, melody: 9000, limit: 2 });
+    const { appeal } = calcCardStrengthAppeal(makeCard(), [broach], makeSong());
+    expect(appeal.Melody).toBe(4000);
+  });
+
+  it('種類9 (スコアUP) ブローチは属性に加算せず broachScoreBonus にのみ反映 (rb.broach_type===9)', () => {
+    const broach = makeBroach({ broach_type: 9, song: 'テスト曲', score: 1500, melody: 0 });
+    const { appeal, broachScoreBonus } = calcCardStrengthAppeal(makeCard(), [broach], makeSong());
+    expect(appeal.Melody).toBe(4000);
+    expect(broachScoreBonus).toBe(1500);
+  });
+});
+
+describe('buildCardStrengthEntry: 分母が 0 のときスキル値は算出されない (line 153 ?? 0)', () => {
+  it('コンボ型でも notes_count=0 なら maxActivations=0', () => {
+    const entry = buildCardStrengthEntry(makeCard(), [], makeSong({ notes_count: 0 }));
+    expect(entry.maxActivations).toBe(0);
+    expect(entry.skillExpected).toBe(0);
+    expect(entry.skillMax).toBe(0);
+  });
+
+  it('タイマー型でも duration=0 なら maxActivations=0', () => {
+    const timer = makeCard({
+      ap_skill_type: 'スコアアップ（タイマー）',
+      ap_skill_5_count: 15, ap_skill_5_per: 50, ap_skill_5_value: 4800,
+    });
+    const entry = buildCardStrengthEntry(timer, [], makeSong({ duration: 0 }));
+    expect(entry.maxActivations).toBe(0);
+    expect(entry.skillExpected).toBe(0);
+  });
+});

--- a/tests/unit/score/deckShareUrlBranches.test.ts
+++ b/tests/unit/score/deckShareUrlBranches.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  encodeDeckToParams,
+  decodeParamsToDeck,
+  buildShareUrl,
+  isDeckEmpty,
+  type DeckShareState,
+} from '../../../src/lib/score/deckShareUrl';
+
+function baseState(overrides: Partial<DeckShareState> = {}): DeckShareState {
+  return {
+    songId: 2,
+    deckIds: [101, 102, null, null, null, null],
+    bonusTiers: ['gold', 'silver', 'bronze', 'none', 'none', 'none'],
+    trained: [true, true, true, true, true, true],
+    sharedBroachs: [[1, 2], [], [], [], [], []],
+    skillLevels: [5, 5, 5, 5, 5, 5],
+    ...overrides,
+  };
+}
+
+describe('encodeDeckToParams: 欠損要素のフォールバック分岐', () => {
+  it('bonusTiers が不足するスロットは none (n) に補完される (line 59 ?? none)', () => {
+    const state = baseState({ bonusTiers: ['gold'] });
+    const params = encodeDeckToParams(state);
+    expect(params.get('tiers')).toBe('g.n.n.n.n.n');
+  });
+
+  it('skillLevels が範囲外 (0 や 6) の場合 5 に補正される (line 71 cond-expr false 分岐)', () => {
+    const state = baseState({ skillLevels: [0, 6, 3, 5, 5, 5] });
+    const params = encodeDeckToParams(state);
+    expect(params.get('lv')).toBe('553555');
+  });
+
+  it('sharedBroachs が不足するスロットは空文字に補完される (line 77 ?? [])', () => {
+    const state = baseState({ sharedBroachs: [[1, 2]] });
+    const params = encodeDeckToParams(state);
+    expect(params.get('sb')).toBe('1,2_____');
+  });
+
+  it('songId が null のとき song パラメータは出力されない', () => {
+    const params = encodeDeckToParams(baseState({ songId: null }));
+    expect(params.has('song')).toBe(false);
+  });
+});
+
+describe('decodeParamsToDeck: バージョン/各フィールドの分岐', () => {
+  it('dv が一致しないとき null を返す', () => {
+    const p = new URLSearchParams('dv=2');
+    expect(decodeParamsToDeck(p)).toBeNull();
+  });
+
+  it('dv が無いとき null を返す', () => {
+    const p = new URLSearchParams('cards=1.2.3.4.5.6');
+    expect(decodeParamsToDeck(p)).toBeNull();
+  });
+
+  it('song パラメータが空文字のとき songId=null になる (line 92-94 else if 分岐)', () => {
+    const p = new URLSearchParams('dv=1&song=');
+    const result = decodeParamsToDeck(p);
+    expect(result).not.toBeNull();
+    expect(result!.songId).toBeNull();
+  });
+
+  it('song が 0 以下の無効値のとき songId は未設定 (n>0 を満たさず set されない)', () => {
+    const p = new URLSearchParams('dv=1&song=0');
+    const result = decodeParamsToDeck(p)!;
+    expect(result.songId).toBeUndefined();
+  });
+
+  it('song が有効な正の数のとき songId に設定される', () => {
+    const p = new URLSearchParams('dv=1&song=36');
+    expect(decodeParamsToDeck(p)!.songId).toBe(36);
+  });
+
+  it('cards の要素数が SLOTS(6) と異なるとき deckIds はセットされない', () => {
+    const p = new URLSearchParams('dv=1&cards=1.2.3');
+    expect(decodeParamsToDeck(p)!.deckIds).toBeUndefined();
+  });
+
+  it('cards の 0 や非数値は null スロットに変換される', () => {
+    const p = new URLSearchParams('dv=1&cards=101.0.x.103.0.0');
+    expect(decodeParamsToDeck(p)!.deckIds).toEqual([101, null, null, 103, null, null]);
+  });
+
+  it('tiers の要素数が 6 でないとき bonusTiers はセットされない', () => {
+    const p = new URLSearchParams('dv=1&tiers=g.s.b');
+    expect(decodeParamsToDeck(p)!.bonusTiers).toBeUndefined();
+  });
+
+  it('tiers の未知文字は none に変換される (line 111 ?? none)', () => {
+    const p = new URLSearchParams('dv=1&tiers=g.s.b.n.z.q');
+    expect(decodeParamsToDeck(p)!.bonusTiers).toEqual(['gold', 'silver', 'bronze', 'none', 'none', 'none']);
+  });
+
+  it('tr が長さ 6 でない/不正文字を含むとき trained はセットされない', () => {
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&tr=11111'))!.trained).toBeUndefined();
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&tr=11112x'))!.trained).toBeUndefined();
+  });
+
+  it('tr が有効なとき boolean 配列に変換される', () => {
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&tr=101010'))!.trained)
+      .toEqual([true, false, true, false, true, false]);
+  });
+
+  it('lv が長さ 6 でない/範囲外文字を含むとき skillLevels はセットされない', () => {
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&lv=555'))!.skillLevels).toBeUndefined();
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&lv=555560'))!.skillLevels).toBeUndefined();
+  });
+
+  it('lv が有効なとき number 配列に変換される', () => {
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&lv=543215'))!.skillLevels)
+      .toEqual([5, 4, 3, 2, 1, 5]);
+  });
+
+  it('sb のスロット数が 6 でないとき sharedBroachs はセットされない', () => {
+    expect(decodeParamsToDeck(new URLSearchParams('dv=1&sb=1,2_3'))!.sharedBroachs).toBeUndefined();
+  });
+
+  it('sb の空スロットは空配列、無効値はフィルタされる', () => {
+    const p = new URLSearchParams('dv=1&sb=1,2_3___0,4_x');
+    expect(decodeParamsToDeck(p)!.sharedBroachs).toEqual([[1, 2], [3], [], [], [4], []]);
+  });
+});
+
+describe('encode → decode ラウンドトリップ', () => {
+  it('encode した state を decode で復元できる', () => {
+    const state = baseState();
+    const decoded = decodeParamsToDeck(encodeDeckToParams(state))!;
+    expect(decoded.songId).toBe(2);
+    expect(decoded.deckIds).toEqual([101, 102, null, null, null, null]);
+    expect(decoded.bonusTiers).toEqual(['gold', 'silver', 'bronze', 'none', 'none', 'none']);
+    expect(decoded.trained).toEqual([true, true, true, true, true, true]);
+    expect(decoded.skillLevels).toEqual([5, 5, 5, 5, 5, 5]);
+    expect(decoded.sharedBroachs).toEqual([[1, 2], [], [], [], [], []]);
+  });
+});
+
+describe('buildShareUrl / isDeckEmpty', () => {
+  it('buildShareUrl はベース URL にクエリを付与する', () => {
+    const url = buildShareUrl(baseState({ songId: 2, deckIds: [1, null, null, null, null, null] }), 'https://example.com/score-calc/');
+    expect(url.startsWith('https://example.com/score-calc/?')).toBe(true);
+    expect(url).toContain('dv=1');
+    expect(url).toContain('song=2');
+  });
+
+  it('isDeckEmpty: songId があれば false', () => {
+    expect(isDeckEmpty(baseState({ songId: 2 }))).toBe(false);
+  });
+
+  it('isDeckEmpty: songId null かつ全 deckIds が null なら true', () => {
+    expect(isDeckEmpty(baseState({ songId: null, deckIds: [null, null, null, null, null, null] }))).toBe(true);
+  });
+
+  it('isDeckEmpty: songId null だが deckIds に非 null があれば false', () => {
+    expect(isDeckEmpty(baseState({ songId: null, deckIds: [101, null, null, null, null, null] }))).toBe(false);
+  });
+});

--- a/tests/unit/score/deckSkillDistributionBranches.test.ts
+++ b/tests/unit/score/deckSkillDistributionBranches.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { buildDeckSkillDistribution } from '../../../src/lib/score/deckSkillDistribution';
+import type { ComputedTeam, DeckCard, CardSkill } from '../../../src/lib/score/types';
+
+function skill(partial: Partial<CardSkill>): CardSkill {
+  return {
+    cardIndex: 0,
+    skillType: 'scoreUp',
+    originalType: '',
+    count: 10,
+    per: 50,
+    value: 1000,
+    rate: 0,
+    isTimer: false,
+    isShrink: false,
+    spTime: 0,
+    ...partial,
+  };
+}
+
+function card(partial: Partial<DeckCard>): DeckCard {
+  return {
+    cardId: 1,
+    cardID: 1,
+    cardname: 'テスト衣装',
+    name: 'キャラ',
+    rarity: 'UR',
+    attribute: 'Shout',
+    shout_max: 0,
+    beat_max: 0,
+    melody_max: 0,
+    skill: null,
+    broachShout: 0,
+    broachBeat: 0,
+    broachMelody: 0,
+    slotIndex: 1,
+    bonusMultiplier: 1,
+    ...partial,
+  } as DeckCard;
+}
+
+/** センター(0)・フレンド(5)・メンバー(1-4) をすべて含むフルチームを組む */
+function fullTeam(cards: DeckCard[]): ComputedTeam {
+  const sum = (f: (c: DeckCard) => number) => cards.reduce((s, c) => s + f(c), 0);
+  const rawShout = sum((c) => c.shout_max);
+  const rawBeat = sum((c) => c.beat_max);
+  const rawMelody = sum((c) => c.melody_max);
+  const broachShout = sum((c) => c.broachShout);
+  const broachBeat = sum((c) => c.broachBeat);
+  const broachMelody = sum((c) => c.broachMelody);
+  return {
+    Shout: rawShout + broachShout,
+    Beat: rawBeat + broachBeat,
+    Melody: rawMelody + broachMelody,
+    cards,
+    songDuration: 120,
+    rawShout, rawBeat, rawMelody,
+    broachShout, broachBeat, broachMelody,
+    broachScoreBonus: 0,
+  } as ComputedTeam;
+}
+
+const NO_OPT = { scoreUpAssist: false, scoreUpBadgeRate: 0 };
+
+describe('buildDeckSkillDistribution: 属性別 baseByAttr とセンター/フレンドボーナス', () => {
+  it('Beat/Melody センター/フレンドのセンタースキル分を計上する (L46-49, L52, L55, L65, L66)', () => {
+    // センターを Beat、フレンドを Melody にして baseByAttr の Beat/Melody 分岐を通す
+    const center = card({ slotIndex: 0, attribute: 'Beat', beat_max: 2000 });
+    const member = card({ slotIndex: 1, attribute: 'Melody', melody_max: 1000 });
+    const friend = card({ slotIndex: 5, attribute: 'Melody', melody_max: 1500 });
+    const team = fullTeam([center, member, friend]);
+    const entries = buildDeckSkillDistribution(team, 100, NO_OPT);
+
+    const e0 = entries.find((e) => e.slotIndex === 0)!;
+    const e5 = entries.find((e) => e.slotIndex === 5)!;
+    // センター/フレンドの effectiveAppeal は自カード属性値 + センタースキルボーナス分だけ
+    // メンバー (ボーナスなし) より底上げされている
+    const eMember = entries.find((e) => e.slotIndex === 1)!;
+    expect(e0.effectiveAppeal).toBeGreaterThan(center.beat_max);
+    expect(e5.effectiveAppeal).toBeGreaterThan(friend.melody_max);
+    expect(eMember.effectiveAppeal).toBe(member.melody_max); // ボーナス対象外
+    // 貢献比率の総和は 1
+    const sum = entries.reduce((s, e) => s + e.contribRatio, 0);
+    expect(sum).toBeCloseTo(1, 6);
+  });
+
+  it('Shout センターでも baseByAttr の Shout 分岐とボーナス加算が効く', () => {
+    const center = card({ slotIndex: 0, attribute: 'Shout', shout_max: 3000 });
+    const friend = card({ slotIndex: 5, attribute: 'Shout', shout_max: 3000 });
+    const team = fullTeam([center, friend]);
+    const entries = buildDeckSkillDistribution(team, 100, NO_OPT);
+    const e0 = entries.find((e) => e.slotIndex === 0)!;
+    expect(e0.effectiveAppeal).toBeGreaterThan(3000);
+  });
+});
+
+describe('buildDeckSkillDistribution: totalBase=0 のゼロ除算回避 (L80)', () => {
+  it('全カードの属性値が 0 なら contribRatio はすべて 0', () => {
+    const team = fullTeam([
+      card({ slotIndex: 0, attribute: 'Shout', shout_max: 0 }),
+      card({ slotIndex: 1, attribute: 'Shout', shout_max: 0 }),
+    ]);
+    const entries = buildDeckSkillDistribution(team, 100, NO_OPT);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const e of entries) expect(e.contribRatio).toBe(0);
+  });
+});
+
+describe('buildDeckSkillDistribution: n=0 / value=0 で単一スパイク (#15)', () => {
+  it('notesCount=0 (n=0) のスキル持ちは 0 起点の単一スパイク', () => {
+    const team = fullTeam([
+      card({ slotIndex: 1, attribute: 'Shout', shout_max: 1000, skill: skill({ count: 10, value: 1000 }) }),
+    ]);
+    // notesCount=0 → calcCardSkillMaxActivations は 0 → points は初期 [{x:0,prob:1}] のまま
+    const entries = buildDeckSkillDistribution(team, 0, NO_OPT);
+    const e = entries.find((e) => e.slotIndex === 1)!;
+    expect(e.skillGroup).toBe('scoreUp');
+    expect(e.points).toEqual([{ x: 0, prob: 1 }]);
+  });
+
+  it('value=0 のスキル持ちも単一スパイク', () => {
+    const team = fullTeam([
+      card({ slotIndex: 1, attribute: 'Shout', shout_max: 1000, skill: skill({ count: 10, value: 0 }) }),
+    ]);
+    const entries = buildDeckSkillDistribution(team, 100, NO_OPT);
+    const e = entries.find((e) => e.slotIndex === 1)!;
+    expect(e.points).toEqual([{ x: 0, prob: 1 }]);
+  });
+});

--- a/tests/unit/score/histogramBranches.test.ts
+++ b/tests/unit/score/histogramBranches.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { renderHistogramSvg } from '../../../src/lib/score/histogram';
+
+describe('renderHistogramSvg: ビン境界クランプ', () => {
+  it('minScore を下回るスコアは最初のビンにクランプされる (L33)', () => {
+    // 範囲 [100, 200] に対し 50 (下限割れ) と 250 (上限超え) を混ぜる。
+    // idx<0 / idx>=BIN_COUNT のクランプ両方を通す。
+    const scores = [50, 120, 180, 250];
+    const svg = renderHistogramSvg(scores, 100, 200, 150);
+    expect(svg).toContain('<svg');
+    // 全 4 件がいずれかのビンに入る (合計 4 回ぶんの度数が描かれる)
+    const totalCounts = [...svg.matchAll(/: (\d+)回/g)].reduce((s, m) => s + Number(m[1]), 0);
+    expect(totalCounts).toBe(scores.length);
+  });
+});

--- a/tests/unit/score/histogramEmpty.test.ts
+++ b/tests/unit/score/histogramEmpty.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { renderHistogramSvg } from '../../../src/lib/score/histogram';
+
+describe('renderHistogramSvg (空・退化ケース)', () => {
+  it('scores が空配列なら「データなし」を返す', () => {
+    expect(renderHistogramSvg([], 0, 100, 50)).toContain('データなし');
+  });
+
+  it('maxScore <= minScore なら「データなし」を返す', () => {
+    expect(renderHistogramSvg([10, 20], 100, 100, 50)).toContain('データなし');
+  });
+
+  it('有効なスコア分布なら SVG を生成する', () => {
+    const scores = Array.from({ length: 50 }, (_, i) => i * 2);
+    const svg = renderHistogramSvg(scores, 0, 100, 50);
+    expect(svg).toContain('<svg');
+  });
+});

--- a/tests/unit/score/maxScoreFinderBranches.test.ts
+++ b/tests/unit/score/maxScoreFinderBranches.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  countMultisetsWithLimits,
+  createSearchContext,
+  countCombos,
+  evaluateDeck,
+  evaluateChunk,
+  evaluateFriendSwap,
+  enumerateChunkDecks,
+  generateChunks,
+  isShrinkCard,
+  type SearchInput,
+} from '../../../src/lib/score/maxScoreFinder';
+import type { Song } from '../../../src/lib/data/fetchSongsJson';
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import type { EventBonusTier } from '../../../src/lib/data/eventBonusTiers';
+import { allCards, allBroachs, findSongById } from '../../fixtures';
+
+const urPool = allCards.filter((c) => c.rarity === 'UR' && c.ID != null && c.ap_skill_type);
+const shrinkUr = urPool.filter((c) => isShrinkCard(c)).slice(0, 3);
+const nonShrinkUr = urPool.filter((c) => !isShrinkCard(c)).slice(0, 4);
+const testCandidates = [...shrinkUr, ...nonShrinkUr];
+const testSong = findSongById(2);
+const testTiers: Record<string, EventBonusTier> = Object.fromEntries(
+  testCandidates.map((c) => [String(c.ID), 'gold' as EventBonusTier]),
+);
+
+function buildInput(overrides: Partial<SearchInput> = {}): SearchInput {
+  return {
+    evalMode: 'expected',
+    ownedOnly: false,
+    shrinkPairOnly: false,
+    scoreOptions: { scoreUpAssist: false, scoreUpBadgeRate: 0 },
+    candidates: testCandidates,
+    ownedCounts: {},
+    song: testSong,
+    broachs: allBroachs,
+    tierByCardId: testTiers,
+    rabbitNotes: {},
+    useOwnedBroachs: false,
+    sharedBroachCounts: {},
+    ...overrides,
+  };
+}
+
+describe('countMultisetsWithLimits: 内部 0 係数のスキップ (L54)', () => {
+  it('途中の次数で係数 0 が出る上限構成でも正しく数える', () => {
+    // limits=[0, 2] : 最初のカードは 0 枚 (poly に 0 係数が残る) → 2 枚目で d をスキップ
+    // x^0(=1) × (1 + x + x^2) → k=2 の係数 = 1 ({2nd, 2nd})
+    expect(countMultisetsWithLimits([0, 2], 2)).toBe(1);
+    // limits=[0,0,3] : 先頭2つが 0 → poly=[1] のまま, 3枚目で 3 枚 → k=3 で 1 通り
+    expect(countMultisetsWithLimits([0, 0, 3], 3)).toBe(1);
+    // 先頭 0 のあと不足 → 0
+    expect(countMultisetsWithLimits([0, 1], 3)).toBe(0);
+  });
+});
+
+describe('createSearchContext: notes_count フォールバック (L145)', () => {
+  it('song.notes_count が falsy なら展開ノーツ数を使う', () => {
+    const songNoNotes = { ...testSong, notes_count: 0 } as unknown as Song;
+    const ctx = createSearchContext(buildInput({ song: songNoNotes }));
+    // notes_count=0 なので flattenNotes の length に等しい正の値が入る
+    expect(ctx.notesCount).toBeGreaterThan(0);
+  });
+});
+
+describe('countCombos: 縮小フレンドプール枯渇・ペア0 のスキップ', () => {
+  it('縮小カードが存在しない候補で shrinkPairOnly なら friendPool=0 を skip し総数 0 (L189, L208)', () => {
+    // 非縮小のみの候補 → S=0。shrinkPairOnly では SHRINK_MIN を満たせず friendPool=shrink(0)
+    const ctx = createSearchContext(buildInput({ candidates: nonShrinkUr, shrinkPairOnly: true }));
+    expect(ctx.shrink.length).toBe(0);
+    expect(countCombos(ctx)).toBe(0);
+  });
+
+  it('所持×縮小2枚以上で縮小候補ゼロ: friendPool=shrink(0) を skip し総数 0 (L189)', () => {
+    // 候補が非縮小 UR のみ → shrink=0。所持してもスロット0-4 で SHRINK_MIN を満たせず
+    // friendPool=ctx.shrink.length(0) になり L189 の `continue` で skip される。
+    const ownedCounts = { [String(nonShrinkUr[0].ID)]: 5 };
+    const ctx = createSearchContext(
+      buildInput({ candidates: nonShrinkUr, ownedOnly: true, shrinkPairOnly: true, ownedCounts }),
+    );
+    expect(ctx.shrink.length).toBe(0);
+    expect(countCombos(ctx)).toBe(0);
+  });
+
+  it('非縮小0枚の候補: s2=0/s2=1 の pairs が 0 になり continue で skip される (L208)', () => {
+    // 縮小のみ T=0 → s2=0 の multichoose(T,2)=H(0,2)=0、s2=1 の S*T=0 が 0 になり L208 で skip。
+    // s2=2 も members の multichoose(0,0)=0 のため最終的に総数は 0 になる。
+    const ctx = createSearchContext(buildInput({ candidates: shrinkUr, shrinkPairOnly: true }));
+    expect(ctx.nonShrink.length).toBe(0);
+    expect(ctx.shrink.length).toBe(3);
+    expect(countCombos(ctx)).toBe(0);
+  });
+});
+
+describe('countCombos / enumerate: 所持モードの上限フォールバック (L164, L182, L317)', () => {
+  it('所持モード非縮小: ownedLimit に無い ID を含む構成でも数える', () => {
+    // 1 種 5 枚所持 (非縮小) → 上限付き多重集合
+    const fiveOwned = { [String(nonShrinkUr[0].ID)]: 5 };
+    const ctx = createSearchContext(buildInput({ ownedOnly: true, ownedCounts: fiveOwned }));
+    expect(countCombos(ctx)).toBe(testCandidates.length); // 1 編成 × フレンド全候補
+  });
+
+  it('所持×縮小2枚以上: センター縮小 + 縮小所持で総数 > 0 (L182)', () => {
+    const ownedCounts = {
+      [String(shrinkUr[0].ID)]: 3, // 縮小
+      [String(shrinkUr[1].ID)]: 2, // 縮小
+      [String(nonShrinkUr[0].ID)]: 1, // 非縮小
+    };
+    const ctx = createSearchContext(buildInput({ ownedOnly: true, shrinkPairOnly: true, ownedCounts }));
+    expect(countCombos(ctx)).toBeGreaterThan(0);
+    // 列挙の所持上限違反スキップ (L317) も通る: 各デッキの 5 枠が上限内
+    let enumerated = 0;
+    for (const chunk of generateChunks(ctx)) {
+      for (const deck of enumerateChunkDecks(ctx, chunk)) {
+        const usage = new Map<number, number>();
+        for (let i = 0; i < 5; i++) usage.set(deck[i].ID!, (usage.get(deck[i].ID!) ?? 0) + 1);
+        for (const [id, n] of usage) expect(n).toBeLessThanOrEqual(ownedCounts[String(id)] ?? 0);
+        enumerated++;
+      }
+    }
+    expect(enumerated).toBe(countCombos(ctx));
+  });
+});
+
+describe('evaluateChunk: callbacks 無し経路 (L458, L468)', () => {
+  it('onTick を渡さないチャンクは tick 分岐をスキップして完走する', async () => {
+    const smallInput = buildInput({ candidates: [...shrinkUr.slice(0, 2), ...nonShrinkUr.slice(0, 2)] });
+    const ctx = createSearchContext(smallInput);
+    const chunk = [...generateChunks(ctx)][0];
+    // yieldEvery を 1 にしても callbacks 自体が無いので onTick は呼ばれない (L458/L468 の callbacks?.onTick 偽側)
+    const r = await evaluateChunk(ctx, chunk, undefined, 1);
+    expect(r.aborted).toBe(false);
+    expect(r.evaluated).toBeGreaterThan(0);
+    expect(r.topK.length).toBeGreaterThan(0);
+  });
+
+  it('callbacks はあるが onTick 未定義でも完走する', async () => {
+    const smallInput = buildInput({ candidates: [...shrinkUr.slice(0, 2), ...nonShrinkUr.slice(0, 2)] });
+    const ctx = createSearchContext(smallInput);
+    const chunk = [...generateChunks(ctx)][0];
+    const r = await evaluateChunk(ctx, chunk, {}, 1);
+    expect(r.aborted).toBe(false);
+    expect(r.evaluated).toBeGreaterThan(0);
+  });
+});
+
+describe('evaluateFriendSwap: 候補に無い ID のフォールバック (L484)', () => {
+  it('bestCardIds の 5 枠目に候補外 ID を含めても null フォールバックで評価できる', () => {
+    const ctx = createSearchContext(buildInput());
+    const c = ctx.candidates;
+    // フレンド枠 (index 5) に存在しない ID (-999) を入れる → byId.get → null フォールバック (L484)。
+    // フレンド枠は evaluateFriendSwap 内で各候補に差し替えられるため null でも安全に評価できる。
+    const fixedIds = [c[0].ID!, c[1].ID!, c[2].ID!, c[3].ID!, c[4].ID!, -999];
+    const friends = evaluateFriendSwap(ctx, fixedIds);
+    expect(friends.length).toBe(Math.min(5, c.length));
+    for (let i = 1; i < friends.length; i++) {
+      expect(friends[i].score).toBeLessThanOrEqual(friends[i - 1].score);
+    }
+  });
+});

--- a/tests/unit/score/normalizeAttribute.test.ts
+++ b/tests/unit/score/normalizeAttribute.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAttribute } from '../../../src/lib/score/types';
+
+describe('normalizeAttribute', () => {
+  it('数値はATTRIBUTE_MAPで変換（1=Shout,2=Beat,3=Melody）', () => {
+    expect(normalizeAttribute(1)).toBe('Shout');
+    expect(normalizeAttribute(2)).toBe('Beat');
+    expect(normalizeAttribute(3)).toBe('Melody');
+  });
+
+  it('未知の数値は Shout フォールバック', () => {
+    expect(normalizeAttribute(99)).toBe('Shout');
+  });
+
+  it('属性名文字列はそのまま', () => {
+    expect(normalizeAttribute('Beat')).toBe('Beat');
+  });
+
+  it('数字文字列は数値として変換', () => {
+    expect(normalizeAttribute('3')).toBe('Melody');
+  });
+
+  it('null・非数値文字列は Shout フォールバック', () => {
+    expect(normalizeAttribute(null)).toBe('Shout');
+    expect(normalizeAttribute('xyz')).toBe('Shout');
+  });
+});

--- a/tests/unit/score/scoreSmallBranches.test.ts
+++ b/tests/unit/score/scoreSmallBranches.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import type { Song } from '../../../src/lib/data/fetchSongsJson';
+import type { CardSkill, ComputedTeam, DeckCard } from '../../../src/lib/score/types';
+import type { CardStrengthEntry } from '../../../src/lib/score/cardStrength';
+import { SKILL_TYPE } from '../../../src/lib/data/fetchCardsJson';
+
+import {
+  createEmptyDeckState,
+  swapSlots,
+  clampSharedBroachs,
+  setCard,
+} from '../../../src/lib/score/deckState';
+import { computeGroupSizes, computeShrinkExclusion } from '../../../src/lib/score/shrinkExclusion';
+import { flattenNotes } from '../../../src/lib/score/noteFlattener';
+import { buildBroachRanking } from '../../../src/lib/score/songBroachRanking';
+import { reachProbability, cardScorePmf, valueToThreshold } from '../../../src/lib/score/cardDistribution';
+
+import { allBroachs, findCardById, findBroachsByCardId } from '../../fixtures';
+
+// ===========================================================================
+// deckState.ts: swapSlots ガード分岐 / clampSharedBroachs の hasFixed=false 分岐
+// ===========================================================================
+describe('deckState: swapSlots ガード分岐', () => {
+  /** 10th Anniversary 四葉環 (UR、固有ブローチあり) */
+  const urWithBroach = findCardById(2484);
+  /** 和泉一織 (UR、固有ブローチなし) */
+  const urNoBroach = findCardById(406);
+
+  it('a === b のとき何もしない (L32 path)', () => {
+    const s = createEmptyDeckState();
+    setCard(s, 1, urWithBroach, 'gold', allBroachs);
+    const before = s.cards[1];
+    swapSlots(s, 1, 1);
+    expect(s.cards[1]).toBe(before);
+  });
+
+  it('範囲外 index (a>4 / b<0) のとき何もしない (L33 path)', () => {
+    const s = createEmptyDeckState();
+    setCard(s, 0, urWithBroach, 'gold', allBroachs);
+    // フレンド枠 (5) は swap 対象外
+    swapSlots(s, 0, 5);
+    expect(s.cards[0]).toBe(urWithBroach);
+    expect(s.cards[5]).toBeNull();
+    // 負値
+    swapSlots(s, -1, 0);
+    expect(s.cards[0]).toBe(urWithBroach);
+  });
+
+  it('clampSharedBroachs: 固有ブローチなし UR は共有ブローチ 2 個まで (L49 hasFixed=false path)', () => {
+    expect(findBroachsByCardId(406).length).toBe(0); // 前提: 固有ブローチなし
+    const s = createEmptyDeckState();
+    setCard(s, 0, urNoBroach, 'none', allBroachs);
+    s.sharedBroachs[0] = [1, 2, 3];
+    clampSharedBroachs(s, 0, allBroachs);
+    expect(s.sharedBroachs[0]).toEqual([1, 2]);
+  });
+});
+
+// ===========================================================================
+// shrinkExclusion.ts & noteFlattener.ts: グループ欠落 / 非数値 / サイズ 0 分岐
+// ===========================================================================
+
+/** 全 8 グループを持つ song。groups で各サブキーを上書きできる */
+function fullSong(groups: Partial<Record<string, Record<string, number | null>>>): Song {
+  const empty = {
+    shout_white: 0, shout_color: 0,
+    beat_white: 0, beat_color: 0,
+    melody_white: 0, melody_color: 0,
+  };
+  const keys = ['notes_20', 'light_2', 'light_3', 'light_4', 'light_5', 'light_6', 'chorus_light_5', 'chorus_light_6'];
+  const song: Record<string, unknown> = { id: 1, song_name: 'TEST', notes_count: null };
+  for (const k of keys) song[k] = { ...empty, ...(groups[k] ?? {}) };
+  return song as unknown as Song;
+}
+
+describe('computeGroupSizes: グループ欠落・非数値分岐', () => {
+  it('グループキーが欠落している楽曲では size=0 (L33 path)', () => {
+    const song = fullSong({ light_6: { shout_white: 30 } });
+    delete (song as unknown as Record<string, unknown>).chorus_light_6;
+    const sizes = computeGroupSizes(song);
+    expect(sizes.chorus_light_6).toBe(0);
+    expect(sizes.light_6).toBe(30);
+  });
+
+  it('サブキー値が数値でない場合は加算しない (L41 typeof !== number path)', () => {
+    // beat_white を null にして数値ガードの else 経路を通す
+    const song = fullSong({ light_3: { shout_white: 10, beat_white: null } });
+    const sizes = computeGroupSizes(song);
+    // shout_white(10) のみ加算、beat_white(null) は無視
+    expect(sizes.light_3).toBe(10);
+  });
+});
+
+describe('computeShrinkExclusion: groupSizes 欠落キー / サイズ0グループ / 縮小タイマー songDuration<=0', () => {
+  function shrinkSkill(count: number, originalType: string = SKILL_TYPE.SHRINK): CardSkill {
+    return {
+      cardIndex: 0, skillType: 'shrink', originalType,
+      count, per: 40, value: 4, rate: 1.4,
+      isTimer: false, isShrink: true, spTime: 0,
+    };
+  }
+  function makeCard(skill: CardSkill | null, slotIndex: number): DeckCard {
+    return {
+      cardId: 0, cardID: 0, cardname: '', name: '',
+      rarity: 'UR', attribute: 'Shout',
+      shout_max: 0, beat_max: 0, melody_max: 0,
+      broachShout: 0, broachBeat: 0, broachMelody: 0,
+      slotIndex, bonusMultiplier: 1, skill,
+    };
+  }
+  function makeTeam(skills: (CardSkill | null)[], songDuration = 104): ComputedTeam {
+    return {
+      Shout: 0, Beat: 0, Melody: 0,
+      cards: skills.map((s, i) => makeCard(s, i)),
+      songDuration,
+      rawShout: 0, rawBeat: 0, rawMelody: 0,
+      broachShout: 0, broachBeat: 0, broachMelody: 0, broachScoreBonus: 0,
+    };
+  }
+
+  it('groupSizes に notes_20 が無いとき ?? 0 で扱う (L84 path)', () => {
+    // notes_20 キーを持たない groupSizes。minCount(=30) が target になる
+    const groupSizes: Record<string, number> = { light_2: 100 };
+    const team = makeTeam([shrinkSkill(30), null, null, null, null, null]);
+    const exc = computeShrinkExclusion(team, groupSizes);
+    // target = max(notes_20=0, 30) = 30。light_2(100) で部分除外 30
+    expect(exc.partialGroup).toBe('light_2');
+    expect(exc.partialCount).toBe(30);
+    expect(exc.totalExcluded).toBe(30);
+  });
+
+  it('groupSizes に欠落キーがあると ?? 0 で skip し size<=0 continue する (L93/L94 path)', () => {
+    // LIGHT_MULTIPLIER の途中グループを欠落 & 0 にして size<=0 の continue を通す。
+    // notes_20 を 0、light_2 を欠落、light_3 を大きくして target に届かせる。
+    const groupSizes: Record<string, number> = {
+      notes_20: 0,          // size<=0 → continue (L94)
+      // light_2 欠落 → ?? 0 → continue (L93/L94)
+      light_3: 200,
+    };
+    const team = makeTeam([shrinkSkill(50), null, null, null, null, null]);
+    const exc = computeShrinkExclusion(team, groupSizes);
+    // target = max(0, 50)=50。notes_20=0 skip、light_2 欠落 skip、light_3(200) で部分除外 50
+    expect(exc.partialGroup).toBe('light_3');
+    expect(exc.partialCount).toBe(50);
+    expect(exc.totalExcluded).toBe(50);
+  });
+
+  it('縮小タイマースキル × songDuration>0 で first-trigger ノート換算経路を通る', () => {
+    const groupSizes: Record<string, number> = { notes_20: 21, light_2: 100 };
+    const team = makeTeam(
+      [shrinkSkill(5, SKILL_TYPE.SHRINK_TIMER), null, null, null, null, null],
+      104,
+    );
+    const exc = computeShrinkExclusion(team, groupSizes);
+    // notesCount=121, first trigger note = floor((5/104)*121)=5 → max(notes_20=21,5)=21
+    expect(exc.totalExcluded).toBe(21);
+    expect(exc.fullGroups.has('notes_20')).toBe(true);
+  });
+
+  it('縮小タイマースキル × songDuration<=0 では first-trigger を加えない (L74 false path)', () => {
+    const groupSizes: Record<string, number> = { notes_20: 21, light_2: 100 };
+    // songDuration=0 の SHRINK_TIMER のみ → shrinkFirstTriggerNotes が空のまま → empty 返却
+    const team = makeTeam(
+      [shrinkSkill(5, SKILL_TYPE.SHRINK_TIMER), null, null, null, null, null],
+      0,
+    );
+    const exc = computeShrinkExclusion(team, groupSizes);
+    expect(exc.totalExcluded).toBe(0);
+    expect(exc.fullGroups.size).toBe(0);
+  });
+});
+
+describe('flattenNotes: グループ欠落 / seed 省略分岐', () => {
+  it('グループキーが欠落している楽曲ではそのグループを skip する (L35 path)', () => {
+    const song = fullSong({ light_2: { shout_white: 5 }, light_6: { beat_white: 7 } });
+    delete (song as unknown as Record<string, unknown>).chorus_light_6;
+    const notes = flattenNotes(song, 42);
+    expect(notes.some(n => n.group === 'chorus_light_6')).toBe(false);
+    expect(notes.filter(n => n.group === 'light_2')).toHaveLength(5);
+    expect(notes.filter(n => n.group === 'light_6')).toHaveLength(7);
+  });
+
+  it('seed 省略時も生成できる (L31 seed ?? Date.now() path)', () => {
+    const song = fullSong({ light_2: { shout_white: 3 } });
+    const notes = flattenNotes(song);
+    expect(notes).toHaveLength(3);
+  });
+});
+
+// ===========================================================================
+// songBroachRanking.ts: グループ欠落 / count 欠落フォールバック
+// ===========================================================================
+describe('buildBroachRanking: グループ欠落・count 欠落分岐', () => {
+  it('グループキー欠落楽曲では当該グループを skip (L45 path)', () => {
+    const song = fullSong({ light_6: { shout_white: 100 } });
+    delete (song as unknown as Record<string, unknown>).chorus_light_6;
+    const ranking = buildBroachRanking(song);
+    expect(ranking.length).toBeGreaterThan(0);
+    // Shout 偏重なので Shout 系が含まれる
+    expect(ranking.some(e => e.name === 'Shout1100')).toBe(true);
+  });
+
+  it('サブキー count が欠落していると ?? 0 で 0 扱い (L50 path)', () => {
+    // light_6 から shout_color を削除（undefined）。shout_white のみ加算される。
+    const song = fullSong({ light_6: { shout_white: 10 } });
+    delete (song as unknown as Record<string, Record<string, unknown>>).light_6.shout_color;
+    const ranking = buildBroachRanking(song);
+    const all700 = ranking.find(e => e.name === 'ALL700');
+    // perNote = floor(700*0.025)=17 → floor(17*1.5)=25。10 ノーツ → 250（color は 0 扱い）
+    expect(all700?.score).toBe(250);
+  });
+});
+
+// ===========================================================================
+// cardDistribution.ts: kMin>n / 縮小スパイク / 縮小 base 分岐
+// ===========================================================================
+describe('cardDistribution: 縮小・範囲外分岐', () => {
+  function skill(partial: Partial<CardSkill>): CardSkill {
+    return {
+      cardIndex: 0, skillType: 'scoreUp', originalType: 'スコアアップ',
+      count: 10, per: 50, value: 1000, rate: 0,
+      isTimer: false, isShrink: false, spTime: 0,
+      ...partial,
+    };
+  }
+  function entry(partial: Partial<CardStrengthEntry>): CardStrengthEntry {
+    return {
+      card: findCardById(2484),
+      attribute: 'Shout',
+      appeal: { Shout: 0, Beat: 0, Melody: 0 },
+      appealTotal: 0,
+      baseScore: 100000,
+      skillExpected: 0, skillMax: 0,
+      totalScore: 100000, maxTotalScore: 100000,
+      maxActivations: 0, maxCoverSec: 0, expectedCoverSec: 0,
+      skill: null, broachScoreBonus: 0,
+      ...partial,
+    };
+  }
+
+  it('reachProbability: t>1 で kMin>n のとき 0 (L35 path)', () => {
+    const e = entry({ maxActivations: 4, skill: skill({ per: 50 }) });
+    expect(reachProbability(e, 1.5)).toBe(0);
+  });
+
+  it('cardScorePmf: 縮小スキルだが n=0 のとき cover の 0 スパイク (L52 isShrink?0 path)', () => {
+    const e = entry({
+      baseScore: 99999,
+      maxActivations: 0,
+      skill: skill({ isShrink: true, skillType: 'shrink', value: 4, per: 40 }),
+    });
+    const r = cardScorePmf(e);
+    expect(r.metric).toBe('cover');
+    // n<=0 のスパイクは isShrink なので x=0
+    expect(r.points).toEqual([{ x: 0, prob: 1 }]);
+  });
+
+  it('valueToThreshold: 縮小スキル(span>0) は base=0 で割合計算 (L67 isShrink?0 path)', () => {
+    const e = entry({
+      baseScore: 100000,
+      maxActivations: 4,
+      skill: skill({ isShrink: true, skillType: 'shrink', value: 2, per: 40 }),
+    });
+    // span = 4*2 = 8, base=0（縮小）→ x=4 → t=0.5
+    expect(valueToThreshold(e, 4)).toBeCloseTo(0.5, 10);
+    expect(valueToThreshold(e, 0)).toBe(0);
+    expect(valueToThreshold(e, 8)).toBe(1);
+  });
+});

--- a/tests/unit/score/searchWorkerPool.test.ts
+++ b/tests/unit/score/searchWorkerPool.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startWorkerSearch } from '../../../src/lib/score/searchWorkerPool';
+
+/** 設定可能なモック Worker。init→ready、chunk→progress+result を駆動する。 */
+class MockWorker {
+  static instances: MockWorker[] = [];
+  static mode: 'ok' | 'error' | 'silent' = 'ok';
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onerror: ((e: { message: string }) => void) | null = null;
+  posted: { type: string; [k: string]: unknown }[] = [];
+  terminated = false;
+
+  constructor() {
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(msg: { type: string; descriptor?: unknown }): void {
+    this.posted.push(msg);
+    if (MockWorker.mode === 'silent') return;
+    queueMicrotask(() => {
+      if (this.terminated) return;
+      if (msg.type === 'init') {
+        this.onmessage?.({ data: { type: 'ready' } });
+      } else if (msg.type === 'chunk') {
+        if (MockWorker.mode === 'error') {
+          this.onmessage?.({ data: { type: 'error', message: 'worker boom' } });
+          return;
+        }
+        this.onmessage?.({ data: { type: 'progress', evaluatedDelta: 10, localBestScore: 50 } });
+        this.onmessage?.({
+          data: { type: 'result', topK: [{ d: msg.descriptor }], evaluated: 10, aborted: false },
+        });
+      }
+    });
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+}
+
+const input = { foo: 1 } as never;
+const chunks = [{ i: 0 }, { i: 1 }, { i: 2 }] as never[];
+
+beforeEach(() => {
+  MockWorker.instances = [];
+  MockWorker.mode = 'ok';
+  vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('startWorkerSearch', () => {
+  it('chunk を分散処理し localTops と evaluated を集約する', async () => {
+    const onProgress = vi.fn();
+    const run = startWorkerSearch(input, chunks, 2, onProgress);
+    const outcome = await run.promise;
+    expect(outcome.localTops).toHaveLength(3);
+    expect(outcome.evaluated).toBe(30);
+    expect(outcome.aborted).toBe(false);
+    expect(onProgress).toHaveBeenCalledWith(expect.any(Number), 50);
+    // 各 Worker は最後に terminate される
+    expect(MockWorker.instances.every((w) => w.terminated)).toBe(true);
+  });
+
+  it('chunks 空なら即解決し localTops 空', async () => {
+    const outcome = await startWorkerSearch(input, [], 2, vi.fn()).promise;
+    expect(outcome.localTops).toEqual([]);
+    expect(outcome.evaluated).toBe(0);
+  });
+
+  it('Worker が error を返したら reject する', async () => {
+    MockWorker.mode = 'error';
+    const run = startWorkerSearch(input, chunks, 1, vi.fn());
+    await expect(run.promise).rejects.toThrow(/エラー/);
+  });
+
+  it('onerror でも reject する', async () => {
+    MockWorker.mode = 'silent'; // 自動応答させない
+    const run = startWorkerSearch(input, chunks, 1, vi.fn());
+    // 生成された Worker の onerror を発火
+    MockWorker.instances[0].onerror?.({ message: 'crash' });
+    await expect(run.promise).rejects.toThrow(/エラー/);
+  });
+
+  it('abort() は全 Worker に abort を送る', async () => {
+    MockWorker.mode = 'silent';
+    const run = startWorkerSearch(input, chunks, 2, vi.fn());
+    run.abort();
+    expect(MockWorker.instances).toHaveLength(2);
+    expect(MockWorker.instances.every((w) => w.posted.some((m) => m.type === 'abort'))).toBe(true);
+    run.terminate(); // ハングしている promise の後始末
+  });
+
+  it('terminate() は全 Worker を terminate する', async () => {
+    MockWorker.mode = 'silent';
+    const run = startWorkerSearch(input, chunks, 2, vi.fn());
+    run.terminate();
+    expect(MockWorker.instances.every((w) => w.terminated)).toBe(true);
+  });
+});

--- a/tests/unit/score/simulationBranches.test.ts
+++ b/tests/unit/score/simulationBranches.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import type { CardSkill, ComputedTeam, DeckCard, FlatNote } from '../../../src/lib/score/types';
+import { SKILL_TYPE } from '../../../src/lib/data/fetchCardsJson';
+import {
+  calcExpectedScore,
+  calcCardSkillExpected,
+  calcCardSkillMax,
+  calcCardSkillMaxActivations,
+  calcMaxScore,
+  calcMinScore,
+  runSimulation,
+} from '../../../src/lib/score/engine';
+
+/**
+ * simulation.ts のガード分岐・エッジ分岐を直接 ComputedTeam / FlatNote を組み立てて網羅する。
+ * 値の正しさは小さな手計算ケースで検証する（範囲チェックではなく決定値）。
+ */
+
+function skill(partial: Partial<CardSkill>): CardSkill {
+  return {
+    cardIndex: 0,
+    skillType: 'scoreUp',
+    originalType: 'スコアアップ',
+    count: 10,
+    per: 50,
+    value: 100,
+    rate: 0,
+    isTimer: false,
+    isShrink: false,
+    spTime: 0,
+    ...partial,
+  };
+}
+
+function shrinkSkill(partial: Partial<CardSkill> = {}): CardSkill {
+  return skill({
+    skillType: 'shrink',
+    originalType: SKILL_TYPE.SHRINK,
+    isShrink: true,
+    rate: 1.4,
+    value: 4,
+    per: 40,
+    count: 10,
+    ...partial,
+  });
+}
+
+function makeCard(s: CardSkill | null, slotIndex: number): DeckCard {
+  return {
+    cardId: 0, cardID: 0, cardname: `c${slotIndex}`, name: '',
+    rarity: 'UR', attribute: 'Shout',
+    shout_max: 0, beat_max: 0, melody_max: 0,
+    broachShout: 0, broachBeat: 0, broachMelody: 0,
+    slotIndex, bonusMultiplier: 1,
+    skill: s,
+  };
+}
+
+function makeTeam(skills: (CardSkill | null)[], songDuration = 104): ComputedTeam {
+  return {
+    Shout: 1000, Beat: 0, Melody: 0,
+    cards: skills.map((s, i) => makeCard(s, i)),
+    songDuration,
+    rawShout: 1000, rawBeat: 0, rawMelody: 0,
+    broachShout: 0, broachBeat: 0, broachMelody: 0,
+    broachScoreBonus: 0,
+  };
+}
+
+/** すべて Shout / white の単純ノート列 */
+function plainNotes(count: number, group = 'light_2'): FlatNote[] {
+  return Array.from({ length: count }, (): FlatNote => ({
+    attribute: 'Shout', type: 'white', group, excluded: false,
+  }));
+}
+
+describe('simulation: ガード分岐（count<=0 / denom<=0 / 空ノート）', () => {
+  it('calcCardSkillMaxActivations: count<=0 のスキルは 0', () => {
+    // L429-430 経由ではなく count>0 必須。count=0 → dc.skill.count<=0 で 0 を返す
+    const team = makeTeam([skill({ count: 0 }), null, null, null, null, null]);
+    expect(calcCardSkillMaxActivations(team, 100, 0)).toBe(0);
+  });
+
+  it('calcCardSkillMaxActivations: 通常スキルで denom(notesCount)<=0 のとき 0 (L433 path)', () => {
+    const team = makeTeam([skill({ count: 5, isTimer: false }), null, null, null, null, null]);
+    expect(calcCardSkillMaxActivations(team, 0, 0)).toBe(0);
+  });
+
+  it('calcCardSkillMaxActivations: 通常スキルは floor(notesCount/count)', () => {
+    const team = makeTeam([skill({ count: 10 }), null, null, null, null, null]);
+    expect(calcCardSkillMaxActivations(team, 95, 0)).toBe(9);
+  });
+
+  it('calcCardSkillExpected: 縮小スキルで effectiveSeconds<=0 のとき 0 (L398 path)', () => {
+    // songDuration=0 → effectiveSeconds = 0 - 0 = 0 → <=0
+    const team = makeTeam([shrinkSkill({ count: 5 }), null, null, null, null, null], 0);
+    const notes = plainNotes(20);
+    expect(calcCardSkillExpected(team, notes, 20, 0)).toBe(0);
+  });
+
+  it('calcCardSkillExpected: 縮小スキルで numActivations<=0 のとき 0 (L400 path)', () => {
+    // eligible(notes 20 - excluded 0)=20, count=50 → floor(20/50)=0
+    const team = makeTeam([shrinkSkill({ count: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(20);
+    expect(calcCardSkillExpected(team, notes, 20, 0)).toBe(0);
+  });
+
+  it('calcCardSkillMax: 縮小スキルで effectiveSeconds<=0 のとき 0 (L459 path)', () => {
+    const team = makeTeam([shrinkSkill({ count: 5 }), null, null, null, null, null], 0);
+    const notes = plainNotes(20);
+    expect(calcCardSkillMax(team, notes, 20, 0)).toBe(0);
+  });
+
+  it('calcCardSkillMax: 縮小スキルで numActivations<=0 のとき 0 (L461 path)', () => {
+    const team = makeTeam([shrinkSkill({ count: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(20);
+    expect(calcCardSkillMax(team, notes, 20, 0)).toBe(0);
+  });
+});
+
+describe('simulation: calcExpectedScore のスキップ分岐', () => {
+  it('縮小スキルは scoreUpExpected の加算対象外 (L332 path: skill.isShrink で continue)', () => {
+    // 縮小スキルのみのデッキ: scoreUpExpected は 0 になる
+    const team = makeTeam([shrinkSkill({ count: 10, per: 40, value: 4 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = calcExpectedScore(team, notes, 40);
+    expect(r.scoreUpExpected).toBe(0);
+  });
+
+  it('count<=0 のスコアアップスキルは scoreUpExpected に寄与しない (L334 path)', () => {
+    const team = makeTeam([skill({ count: 0, value: 100, per: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = calcExpectedScore(team, notes, 40);
+    expect(r.scoreUpExpected).toBe(0);
+  });
+
+  it('count>0 のスコアアップスキルは floor(notesCount/count)*per/100*value', () => {
+    const team = makeTeam([skill({ count: 10, value: 100, per: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = calcExpectedScore(team, notes, 40);
+    // floor(40/10)=4 回 × 0.5 × 100 = 200
+    expect(r.scoreUpExpected).toBe(200);
+  });
+
+  it('denom(notesCount)<=0 のスコアアップスキルは寄与しない (L334 path)', () => {
+    // count>0 だが notesCount=0 (非タイマー) → denom<=0 で continue
+    const team = makeTeam([skill({ count: 10, value: 100, per: 50, isTimer: false }), null, null, null, null, null]);
+    const r = calcExpectedScore(team, [], 0);
+    expect(r.scoreUpExpected).toBe(0);
+  });
+});
+
+describe('simulation: calcMaxScore / calcMinScore の空・縮小分岐', () => {
+  it('空ノート列では minScore = broachScoreBonus 加算済みの基礎のみ', () => {
+    const team = makeTeam([null, null, null, null, null, null]);
+    expect(calcMinScore(team, [])).toBe(0);
+    expect(calcMaxScore(team, [])).toBe(0);
+  });
+
+  it('calcMaxScore: 通常スコアアップ skill.count<=0 はスキップされる (L276 path)', () => {
+    // count=0 のスキルを混ぜても score は count>0 のスキルのみ反映
+    const teamZero = makeTeam([skill({ count: 0, value: 9999 }), null, null, null, null, null]);
+    const teamNone = makeTeam([null, null, null, null, null, null]);
+    const notes = plainNotes(40);
+    expect(calcMaxScore(teamZero, notes)).toBe(calcMaxScore(teamNone, notes));
+  });
+});
+
+describe('runSimulation: 統計・cardStats 分岐', () => {
+  it('seed 省略時も実行できる (L639 path: seed ?? Date.now())', async () => {
+    const team = makeTeam([skill({ count: 10, value: 100, per: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, undefined);
+    expect(r.scores.length).toBe(4);
+  });
+
+  it('偶数試行回数では median が中央 2 値の平均 (L667 偶数 path)', async () => {
+    const team = makeTeam([skill({ count: 10, value: 100, per: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, 42);
+    const sorted = [...r.scores].sort((a, b) => a - b);
+    const expectedMedian = Math.round((sorted[1] + sorted[2]) / 2);
+    expect(r.median).toBe(expectedMedian);
+  });
+
+  it('奇数試行回数では median が中央 1 値 (L667 奇数 path)', async () => {
+    const team = makeTeam([skill({ count: 10, value: 100, per: 50 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 3, undefined, 42);
+    expect(r.scores.length).toBe(3);
+    const sorted = [...r.scores].sort((a, b) => a - b);
+    expect(r.median).toBe(Math.round(sorted[1]));
+  });
+
+  it('cardStats skillType: タイマー型スコアアップ (originalType=null → timerScoreUp 分岐)', async () => {
+    // originalType を null にして fallback ternary に入らせ、skillType='timerScoreUp' を選択
+    const timerScoreUp = skill({
+      skillType: 'timerScoreUp', originalType: null,
+      isTimer: true, count: 16, value: 7200, per: 47,
+    });
+    const team = makeTeam([timerScoreUp, null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, 42);
+    const stat = r.cardStats.find(s => s.cardIndex === 0);
+    expect(stat).toBeDefined();
+    expect(stat!.skillType).toBe(SKILL_TYPE.SCOREUP_TIMER);
+  });
+
+  it('cardStats skillType: 縮小型 (originalType=null → isShrink 分岐 → SHRINK)', async () => {
+    const sh = shrinkSkill({ originalType: null, count: 10, value: 4, per: 40 });
+    const team = makeTeam([sh, null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, 42);
+    const stat = r.cardStats.find(s => s.cardIndex === 0);
+    expect(stat!.skillType).toBe(SKILL_TYPE.SHRINK);
+  });
+
+  it('cardStats skillType: 通常スコアアップ (originalType=null → 末尾 スコアアップ 分岐)', async () => {
+    const su = skill({ skillType: 'scoreUp', originalType: null, isShrink: false, isTimer: false, count: 10, value: 100, per: 50 });
+    const team = makeTeam([su, null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, 42);
+    const stat = r.cardStats.find(s => s.cardIndex === 0);
+    expect(stat!.skillType).toBe('スコアアップ');
+  });
+
+  it('runOnce: 通常スコアアップ count<=0 はスキップ (Phase B L578 path)', async () => {
+    const teamZero = makeTeam([skill({ count: 0, value: 9999, per: 100 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    const r = await runSimulation(teamZero, notes, 4, undefined, 42);
+    // count<=0 のスキルは発動せず scoreUpScores は全て 0
+    expect(r.scoreUpScores.every(s => s === 0)).toBe(true);
+  });
+});
+
+describe('simulation: タイマースキルの noteIndex<0 分岐 (songDuration<=0)', () => {
+  it('calcMaxScore: タイマー型でも songDuration=0 のとき maxAct=0 で寄与なし', () => {
+    // songDuration=0 → floor(0/count)=0 → ループに入らない
+    const team = makeTeam([skill({ isTimer: true, count: 5, value: 9999 }), null, null, null, null, null], 0);
+    const notes = plainNotes(40);
+    const none = makeTeam([null, null, null, null, null, null], 0);
+    expect(calcMaxScore(team, notes)).toBe(calcMaxScore(none, notes));
+  });
+
+  it('calcMaxScore: 非縮小タイマー × 空ノート列で calcNoteIndexAtTime が -1 (L172 / L231 else-if false)', () => {
+    // songDuration>0 で maxAct>=1 だが N=0 → noteIndex=-1 → どちらの分岐も成立せず
+    const team = makeTeam([skill({ isTimer: true, count: 5, value: 9999, per: 100 }), null, null, null, null, null], 104);
+    expect(calcMaxScore(team, [])).toBe(0);
+  });
+
+  it('runSimulation: 非縮小タイマー × 空ノート列で noteIndex=-1 (runOnce L530 else-if false)', async () => {
+    const team = makeTeam([skill({ isTimer: true, count: 5, value: 9999, per: 100 }), null, null, null, null, null], 104);
+    const r = await runSimulation(team, [], 4, undefined, 42);
+    // ノートが無いので score は broachScoreBonus(0) のみ
+    expect(r.scores.every(s => s === 0)).toBe(true);
+  });
+
+  it('runSimulation: 縮小タイマー × songDuration=0 で calcShrinkActivationCount の :0 分岐 (L182/L184/L198)', async () => {
+    // SHRINK_TIMER skill + songDuration=0:
+    //  - calcShrinkActivationCount: isShrinkTimer && songDuration<=0 → :0 (L184 path1)
+    //  - shrinkDurationNotes: songDuration<=0 → 0 → enqueueShrink durationNotes<=0 (L198 path0)
+    const shrinkTimer = shrinkSkill({
+      originalType: SKILL_TYPE.SHRINK_TIMER,
+      count: 5, value: 4, per: 40, rate: 1.4,
+    });
+    const team = makeTeam([shrinkTimer, null, null, null, null, null], 0);
+    const notes = plainNotes(40);
+    const r = await runSimulation(team, notes, 4, undefined, 42);
+    // songDuration=0 のタイマーは発動しないので縮小寄与なし
+    expect(r.shrinkScores.every(s => s === 0)).toBe(true);
+  });
+
+  it('calcCardSkillMaxActivations: 縮小タイマーで denom(songDuration)<=0 のとき 0 (L433 timer path)', () => {
+    const shrinkTimer = shrinkSkill({ originalType: SKILL_TYPE.SHRINK_TIMER, count: 5 });
+    const team = makeTeam([shrinkTimer, null, null, null, null, null], 0);
+    expect(calcCardSkillMaxActivations(team, 100, 0)).toBe(0);
+  });
+
+  it('calcCardSkillMax: 縮小スキル count<=0 は早期 0 (dc.skill.count<=0 ガード)', async () => {
+    // 注: これは calcCardSkillMax 側の count<=0 ガード (L446 相当) で 0 を返す。
+    // calcShrinkActivationCount 内部 L182 の count<=0 ガードには到達しない
+    // (全呼出元が count>0 で事前フィルタするため。報告参照)。
+    const team = makeTeam([shrinkSkill({ count: 0 }), null, null, null, null, null]);
+    const notes = plainNotes(40);
+    expect(calcCardSkillMax(team, notes, 40, 0)).toBe(0);
+  });
+});
+
+describe('simulation: 縮小タイマーの enqueue durationNotes>0 経路 (正常系)', () => {
+  it('縮小タイマー × maxShrinkCoverage で縮小区間が発動しスコアが上がる', async () => {
+    const shrinkTimer = shrinkSkill({
+      originalType: SKILL_TYPE.SHRINK_TIMER,
+      count: 5, value: 6, per: 40, rate: 1.5,
+    });
+    const team = makeTeam([shrinkTimer, null, null, null, null, null], 104);
+    const notes = plainNotes(100, 'light_6');
+    const base = makeTeam([null, null, null, null, null, null], 104);
+    const baseNotes = plainNotes(100, 'light_6');
+    const r = await runSimulation(team, notes, 6, undefined, 42, {
+      scoreUpAssist: false, maxShrinkCoverage: true,
+    });
+    const baseMin = calcMinScore(base, baseNotes);
+    // 縮小タイマーが発動 → mean は基礎を上回る
+    expect(r.mean).toBeGreaterThan(baseMin);
+  });
+});

--- a/tests/unit/score/simulationScoreUp.test.ts
+++ b/tests/unit/score/simulationScoreUp.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import { computeTeam, flattenNotes, calcMinScore, calcMaxScore, runSimulation } from '../../../src/lib/score/engine';
+import { findCardById, findSongById } from '../../fixtures';
+
+const monsterGeneration = findSongById(2);
+const MC_SEED = 42;
+
+/** JokerFlag2 四葉環 (スコアアップ タイマー / Lv5 count=16秒 per=47 value=7200) */
+const timerScoreUpCard = findCardById(1172);
+/** 屋外フェス2 逢坂壮五 (スコアアップ コンボ / Lv5 count=16ノート per=46 value=6403) */
+const comboScoreUpCard = findCardById(410);
+
+const deckOf = (c: Card): (Card | null)[] => [c, null, null, null, null, null];
+
+describe('runSimulation: タイマー型スコアアップ (MC 分岐)', () => {
+  const team = computeTeam(deckOf(timerScoreUpCard), [], monsterGeneration);
+  const notes = flattenNotes(monsterGeneration, MC_SEED);
+
+  it('確率発動でスコアが minScore〜maxScore の範囲に分布する', async () => {
+    const r = await runSimulation(team, notes, 200, undefined, MC_SEED);
+    const min = calcMinScore(team, notes);
+    const max = calcMaxScore(team, notes);
+    expect(r.mcMin).toBeGreaterThanOrEqual(min);
+    expect(r.mcMax).toBeLessThanOrEqual(max);
+    expect(r.mean).toBeGreaterThan(min);
+    const stat = r.cardStats.find((s) => s.skillType.includes('スコアアップ'));
+    expect(stat).toBeDefined();
+    expect(stat!.avgActivations).toBeGreaterThan(0);
+    expect(r.scoreUpScores.length).toBe(200);
+  });
+
+  it('maxScoreUpCoverage: true で常時発動 → 平均が maxScore 近傍、発動回数=理論最大(6)', async () => {
+    const max = calcMaxScore(team, notes);
+    const r = await runSimulation(team, notes, 30, undefined, MC_SEED, {
+      scoreUpAssist: false, maxScoreUpCoverage: true,
+    });
+    expect(Math.abs(r.mean - max) / max).toBeLessThan(0.001);
+    const stat = r.cardStats.find((s) => s.skillType.includes('スコアアップ'));
+    expect(stat!.avgActivations).toBe(6);
+  });
+});
+
+describe('runSimulation: 通常型スコアアップ (コンボ, Phase B 分岐)', () => {
+  const team = computeTeam(deckOf(comboScoreUpCard), [], monsterGeneration);
+  const notes = flattenNotes(monsterGeneration, MC_SEED);
+
+  it('確率発動でスコアアップ寄与が発生する', async () => {
+    const r = await runSimulation(team, notes, 200, undefined, MC_SEED);
+    expect(r.mean).toBeGreaterThan(calcMinScore(team, notes));
+    const stat = r.cardStats.find((s) => s.skillType.includes('スコアアップ'));
+    expect(stat!.avgActivations).toBeGreaterThan(0);
+  });
+
+  it('maxScoreUpCoverage: true で発動回数=理論最大(26)、平均が maxScore 近傍', async () => {
+    const max = calcMaxScore(team, notes);
+    const r = await runSimulation(team, notes, 30, undefined, MC_SEED, {
+      scoreUpAssist: false, maxScoreUpCoverage: true,
+    });
+    const stat = r.cardStats.find((s) => s.skillType.includes('スコアアップ'));
+    expect(stat!.avgActivations).toBe(26);
+    expect(Math.abs(r.mean - max) / max).toBeLessThan(0.001);
+  });
+
+  it('onProgress コールバックが進捗(0〜1)で呼ばれる', async () => {
+    const pcts: number[] = [];
+    await runSimulation(team, notes, 50, (p) => pcts.push(p), MC_SEED);
+    expect(pcts.length).toBeGreaterThan(0);
+    expect(pcts[pcts.length - 1]).toBe(1);
+  });
+});

--- a/tests/unit/score/skillFormatterBranches.test.ts
+++ b/tests/unit/score/skillFormatterBranches.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { formatSkillEffect, getMaxApSkillLevel } from '../../../src/lib/score/skillFormatter';
+import { SKILL_TYPE, type ApSkillLevel, type Card } from '../../../src/lib/data/fetchCardsJson';
+
+const sl = (
+  count: number | null,
+  per: number | null,
+  value: number | null,
+  rate: number | null = null,
+): ApSkillLevel => ({ count, per, value, rate });
+
+describe('formatSkillEffect: req=null での空プレフィックス (L26, L32, L35)', () => {
+  it('判定縮小 (回数系) で req=null なら接頭辞なし (L26)', () => {
+    expect(formatSkillEffect(SKILL_TYPE.SHRINK, null, sl(30, 40, 8, 250)))
+      .toBe('30回毎に40％の確率で8秒間判定領域を縮小してスコアを2.5倍に');
+  });
+
+  it('BAD→Perfect (回数系) で req=null なら接頭辞なし (L32)', () => {
+    expect(formatSkillEffect(SKILL_TYPE.BAD_TO_PERFECT, null, sl(30, 45, 5)))
+      .toBe('30回毎に45％の確率で5秒間BAD以上をPerfectに');
+  });
+
+  it('スコアアップ (プレフィックス系) で req=null なら接頭辞なし (L35)', () => {
+    expect(formatSkillEffect('スコアアップ（コンボ）', null, sl(25, 35, 250)))
+      .toBe('25回毎に35％の確率でスコア250UP');
+  });
+});
+
+/** スキルレベル別フィールドを持つ最小 Card を組み立てる (一部フィールドを null にできる) */
+function makeCard(
+  level: 1 | 2 | 3 | 4 | 5,
+  fields: { count: number | null; per: number | null; value: number | null },
+): Card {
+  const card: Record<string, unknown> = { ap_skill_type: SKILL_TYPE.SCOREUP_TIMER, ap_skill_req: null };
+  for (let i = 1; i <= 5; i++) {
+    card[`ap_skill_${i}_count`] = null;
+    card[`ap_skill_${i}_per`] = null;
+    card[`ap_skill_${i}_value`] = null;
+    card[`ap_skill_${i}_rate`] = null;
+  }
+  card[`ap_skill_${level}_count`] = fields.count;
+  card[`ap_skill_${level}_per`] = fields.per;
+  card[`ap_skill_${level}_value`] = fields.value;
+  return card as unknown as Card;
+}
+
+describe('getMaxApSkillLevel: value が null のレベルは無効扱い (L49 ?? 0)', () => {
+  it('count/per > 0 でも value=null なら null (有効レベルなし)', () => {
+    const card = makeCard(5, { count: 15, per: 40, value: null });
+    expect(getMaxApSkillLevel(card)).toBeNull();
+  });
+
+  it('count>0 per>0 value>0 なら有効レベルとして返る (対照)', () => {
+    const card = makeCard(5, { count: 15, per: 40, value: 300 });
+    expect(getMaxApSkillLevel(card)).toBe(5);
+  });
+});

--- a/tests/unit/score/skillTypeShortLabel.test.ts
+++ b/tests/unit/score/skillTypeShortLabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { skillTypeShortLabel } from '../../../src/lib/score/skillFormatter';
+import { SKILL_TYPE } from '../../../src/lib/data/fetchCardsJson';
+
+describe('skillTypeShortLabel', () => {
+  it('null / undefined / 空文字は「スキルなし」', () => {
+    expect(skillTypeShortLabel(null)).toBe('スキルなし');
+    expect(skillTypeShortLabel(undefined)).toBe('スキルなし');
+    expect(skillTypeShortLabel('')).toBe('スキルなし');
+  });
+
+  it('BAD→Perfect は「判定強化」に短縮', () => {
+    expect(skillTypeShortLabel(SKILL_TYPE.BAD_TO_PERFECT)).toBe('判定強化');
+  });
+
+  it('MISS→Perfect は「判定ガード」に短縮', () => {
+    expect(skillTypeShortLabel(SKILL_TYPE.MISS_TO_PERFECT)).toBe('判定ガード');
+  });
+
+  it('その他の種別はそのまま返す', () => {
+    expect(skillTypeShortLabel('スコアアップ（タイマー）')).toBe('スコアアップ（タイマー）');
+  });
+});

--- a/tests/unit/score/specDiagramsBranches.test.ts
+++ b/tests/unit/score/specDiagramsBranches.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shrinkTimelineSvg,
+  coverageDiagramSvg,
+  type Activation,
+} from '../../../src/lib/score/specDiagrams';
+
+function isValidSvg(s: string): boolean {
+  return /^<svg[\s\S]*<\/svg>\s*$/.test(s.trim());
+}
+
+describe('shrinkTimelineSvg: 省略可能フィールドの既定値 (L259, L260, L278, L306)', () => {
+  it('excludeHead / activations を省略しても描画できる (L259 ?? 0, L260 ?? [])', () => {
+    const svg = shrinkTimelineSvg({
+      count: 20, per: 40, value: 4,
+      notesCount: 400, songDuration: 100,
+      // excludeHead 未指定 → ?? 0、activations 未指定 → ?? []
+    });
+    expect(isValidSvg(svg)).toBe(true);
+    expect(svg).not.toContain('先頭除外'); // excludeHead=0 なので除外矩形なし
+  });
+
+  it('activation の cardIndex を省略するとレーン 0 として扱う (L278, L306)', () => {
+    // cardIndex を持たない発動 1 件 + 不発 1 件を渡す
+    const acts: Activation[] = [
+      { start: 40, end: 60, fired: true },   // cardIndex 省略 → ?? 0
+      { start: 80, end: 80, fired: false },  // cardIndex 省略 + 不発
+    ];
+    const svg = shrinkTimelineSvg({
+      count: 20, per: 40, value: 4,
+      notesCount: 400, songDuration: 100, excludeHead: 0,
+      activations: acts,
+    });
+    expect(isValidSvg(svg)).toBe(true);
+    // 発動コイン (緑) と不発コイン (mute) の両方が出る
+    expect(svg).toContain('#22c55e');                 // 発動
+    expect(svg).toContain('var(--chart-mute-fill)');  // 不発 (L281 の !a.fired 側)
+    expect(svg).toContain('衣装1: 発動');
+    expect(svg).toContain('衣装1: 不発');
+  });
+});
+
+describe('coverageDiagramSvg: songDuration を完全に超えたセグメント (L454)', () => {
+  it('開始時点で 100% を超えるセグメントは実効塗りが空になる (x2Cap <= x1)', () => {
+    // 1 本目で既に songDuration を使い切り、2 本目はキャップ後 (cursor >= songDuration) から始まる。
+    const svg = coverageDiagramSvg({
+      songDuration: 50,
+      segments: [
+        { label: 'A', seconds: 60, color: '#f59e0b' }, // 既に songDuration 超過
+        { label: 'B', seconds: 30, color: '#f97316' }, // x1(cursor=60) > x2Cap(=50) → 実効塗り空 (L454 else)
+      ],
+    });
+    expect(isValidSvg(svg)).toBe(true);
+    // 2 本目は超過部 (opacity 0.3 の破線) のみが出る
+    expect(svg).toContain('opacity="0.3"');
+    expect(svg).toContain('100.0%'); // キャップ後カバー率
+  });
+});

--- a/tests/unit/score/teamBuilderBranches.test.ts
+++ b/tests/unit/score/teamBuilderBranches.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Card } from '../../../src/lib/data/fetchCardsJson';
+import type { FixedBroach } from '../../../src/lib/data/fetchFixedBroachsJson';
+import { computeTeam, getCenterSkillRate } from '../../../src/lib/score/engine';
+import { parseSkill } from '../../../src/lib/score/teamBuilder';
+import type { RabbitNoteMap } from '../../../src/lib/data/rabbitNote';
+import { findCardById, findSongById } from '../../fixtures';
+
+/** MONSTER GENERATiON */
+const song = findSongById(2);
+
+/** 10th Anniversary 四葉環 (UR / Beat) */
+const tenthTamaki = findCardById(2484);
+/** UR / Shout (和泉一織) — center 倍率を Shout 方向に効かせる */
+const urShout = findCardById(406);
+/** UR / Melody (和泉三月) — center 倍率を Melody 方向に効かせる */
+const urMelody = findCardById(408);
+/** SR / Melody (百) — CENTER_SKILL_RATES 非掲載レアリティ */
+const srCard = findCardById(1622);
+/** type9 ブローチ (MEMORiES MELODiES, score 1000) を持つ UR/Beat カード IDOLiSH7 */
+const type9Card = findCardById(959);
+
+const empty: (Card | null)[] = [null, null, null, null, null, null];
+
+describe('getCenterSkillRate のフォールバック分岐', () => {
+  it('CENTER_SKILL_RATES に無いレアリティ (SR) は DEFAULT_CENTER_SKILL_RATE(6) を返す', () => {
+    expect(getCenterSkillRate('SR')).toBe(6);
+  });
+});
+
+describe('parseSkill: 使用可能なスキルレベルが一つも無い場合 null を返す (line 31)', () => {
+  it('全レベル count=0 の判定ガード(MISS→Perfect) カードは skill=null', () => {
+    // ID180 (cardID 368): ap_skill_type=判定ガード(MISS→Perfect) かつ全レベル count=0
+    const guardCard = findCardById(368);
+    expect(guardCard.ap_skill_type).toBe('判定ガード(MISS→Perfect)');
+    expect(parseSkill(guardCard, 0)).toBeNull();
+  });
+});
+
+describe('parseSkill: 縮小スキルで rate(縮小倍率) が無いレベルは使用不可 (L64 isShrink && !rate)', () => {
+  it('全レベル rate=0 の判定縮小カードは usable level 無しで skill=null', () => {
+    // count/per/value はそろっているが rate が 0 → 縮小として使用不可
+    const shrinkNoRate = {
+      ID: 0, cardID: 0, cardname: '', name: '', rarity: 'UR', attribute: 'Shout',
+      shout_max: 1000, beat_max: 0, melody_max: 0,
+      ap_skill_type: '判定縮小（Perfect）',
+      ap_skill_1_count: 20, ap_skill_1_per: 40, ap_skill_1_value: 4, ap_skill_1_rate: 0,
+      ap_skill_2_count: 20, ap_skill_2_per: 40, ap_skill_2_value: 4, ap_skill_2_rate: 0,
+      ap_skill_3_count: 20, ap_skill_3_per: 40, ap_skill_3_value: 4, ap_skill_3_rate: 0,
+      ap_skill_4_count: 20, ap_skill_4_per: 40, ap_skill_4_value: 4, ap_skill_4_rate: 0,
+      ap_skill_5_count: 20, ap_skill_5_per: 40, ap_skill_5_value: 4, ap_skill_5_rate: 0,
+      sp_time: 0,
+    } as unknown as Card;
+    expect(parseSkill(shrinkNoRate, 0)).toBeNull();
+  });
+
+  it('rate が有効な判定縮小カードは shrink スキルとして採用される (L64 false 側)', () => {
+    const memorialTamaki = findCardById(2268); // 記念日2024 環 / 縮小 rate=1.6
+    const skill = parseSkill(memorialTamaki, 5);
+    expect(skill).not.toBeNull();
+    expect(skill!.isShrink).toBe(true);
+    expect(skill!.rate).toBeGreaterThan(0);
+  });
+});
+
+describe('computeTeam: 未特訓 (trained=false) 時の自属性 TRAIN_BONUS 減算分岐 (line 135/137)', () => {
+  it('Shout 属性 UR を未特訓にすると Shout のみ TRAIN_BONUS(1800) 減算される', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const trained = [false, false, false, false, false, false];
+    const team = computeTeam(deck, [], song, undefined, trained);
+    expect(team.rawShout).toBe((urShout.shout_max ?? 0) - 1800);
+    // 他属性は減算なし
+    expect(team.rawBeat).toBe(urShout.beat_max);
+    expect(team.rawMelody).toBe(urShout.melody_max);
+  });
+
+  it('Melody 属性 UR を未特訓にすると Melody のみ TRAIN_BONUS(1800) 減算される', () => {
+    const deck: (Card | null)[] = [urMelody, null, null, null, null, null];
+    const trained = [false, false, false, false, false, false];
+    const team = computeTeam(deck, [], song, undefined, trained);
+    expect(team.rawMelody).toBe((urMelody.melody_max ?? 0) - 1800);
+    expect(team.rawShout).toBe(urMelody.shout_max);
+    expect(team.rawBeat).toBe(urMelody.beat_max);
+  });
+});
+
+describe('computeTeam: ラビットノート加算 (line 140 / rn truthy 分岐)', () => {
+  it('カード名に一致するラビットノートが各属性へ加算される (イベント倍率前)', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const notes: RabbitNoteMap = {
+      [urShout.name ?? '']: { shout: 100, beat: 200, melody: 300 },
+    };
+    const team = computeTeam(
+      deck, [], song,
+      undefined, undefined, undefined, undefined, undefined,
+      notes,
+    );
+    expect(team.rawShout).toBe((urShout.shout_max ?? 0) + 100);
+    expect(team.rawBeat).toBe((urShout.beat_max ?? 0) + 200);
+    expect(team.rawMelody).toBe((urShout.melody_max ?? 0) + 300);
+  });
+});
+
+describe('computeTeam: 種類9(スコアUP)ブローチはステータス加算せずスキップ (line 154)', () => {
+  it('type9 ブローチは broachShout/Beat/Melody に影響せず broachScoreBonus にのみ反映される', () => {
+    const deck: (Card | null)[] = [type9Card, null, null, null, null, null];
+    const broachs = [findBroach9()];
+    const team = computeTeam(deck, broachs, song);
+    expect(team.broachShout).toBe(0);
+    expect(team.broachBeat).toBe(0);
+    expect(team.broachMelody).toBe(0);
+    expect(team.broachScoreBonus).toBe(1000);
+  });
+
+  it('曲名が一致しない場合 type9 ブローチは発動しない (broachScoreBonus=0)', () => {
+    const deck: (Card | null)[] = [type9Card, null, null, null, null, null];
+    const otherSong = findSongById(60); // Binary Vampire
+    const team = computeTeam(deck, [findBroach9()], otherSong);
+    expect(team.broachScoreBonus).toBe(0);
+  });
+});
+
+describe('computeTeam: 共有ブローチ選択の各分岐 (line 161-176)', () => {
+  it('無条件共有ブローチ (ALL750) が装着カードへ加算される', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const sel: number[][] = [[1], [], [], [], [], []]; // id=1 ALL750
+    const team = computeTeam(deck, [], song, undefined, undefined, undefined, sel);
+    expect(team.broachShout).toBe(750);
+    expect(team.broachBeat).toBe(750);
+    expect(team.broachMelody).toBe(750);
+  });
+
+  it('条件付き共有ブローチ (S属性枚数分Shout+300, id=24) はデッキ内 Shout 枚数倍で加算される', () => {
+    // Shout カード 2 枚 (slot0, slot1) → 倍率 2
+    const deck: (Card | null)[] = [urShout, urShout, null, null, null, null];
+    const sel: number[][] = [[24], [], [], [], [], []];
+    const team = computeTeam(deck, [], song, undefined, undefined, undefined, sel);
+    expect(team.broachShout).toBe(300 * 2);
+    expect(team.broachBeat).toBe(0);
+    expect(team.broachMelody).toBe(0);
+  });
+
+  it('falsy な共有ブローチ ID (0) は無視される (line 163 continue)', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const sel: number[][] = [[0], [], [], [], [], []];
+    const team = computeTeam(deck, [], song, undefined, undefined, undefined, sel);
+    expect(team.broachShout).toBe(0);
+    expect(team.broachBeat).toBe(0);
+    expect(team.broachMelody).toBe(0);
+  });
+
+  it('存在しない共有ブローチ ID (9999) は無視される (line 165 continue)', () => {
+    const deck: (Card | null)[] = [urShout, null, null, null, null, null];
+    const sel: number[][] = [[9999], [], [], [], [], []];
+    const team = computeTeam(deck, [], song, undefined, undefined, undefined, sel);
+    expect(team.broachShout).toBe(0);
+  });
+});
+
+describe('computeTeam: song.duration が falsy のとき 0 を返す (line 229)', () => {
+  it('duration を 0 にした楽曲では songDuration=0', () => {
+    const noDurationSong = { ...song, duration: 0 };
+    const team = computeTeam([urShout, null, null, null, null, null], [], noDurationSong);
+    expect(team.songDuration).toBe(0);
+  });
+});
+
+describe('computeTeam: falsy なカードフィールドのフォールバック (L131-134 / L140 / L185-189)', () => {
+  // ID/cardID/name/cardname/rarity/*_max がすべて falsy な合成カード
+  const blankCard = {
+    ID: 0, cardID: 0, cardname: '', name: '', rarity: null,
+    attribute: 'Shout',
+    shout_max: 0, beat_max: 0, melody_max: 0,
+    ap_skill_type: null, sp_time: 0,
+  } as unknown as Card;
+
+  it('全フィールド falsy のカードでも例外なく 0/空文字へフォールバックする', () => {
+    const team = computeTeam([blankCard, null, null, null, null, null], [], song);
+    expect(team.rawShout).toBe(0);
+    expect(team.rawBeat).toBe(0);
+    expect(team.rawMelody).toBe(0);
+    expect(team.cards).toHaveLength(1);
+    const dc = team.cards[0];
+    expect(dc.cardId).toBe(0);
+    expect(dc.cardID).toBe(0);
+    expect(dc.cardname).toBe('');
+    expect(dc.name).toBe('');
+    expect(dc.rarity).toBe('');
+  });
+
+  it('rarity が null (TRAIN_BONUS 非掲載) かつ未特訓でも自属性の減算は 0 (TRAIN_BONUS ?? 0)', () => {
+    const trained = [false, false, false, false, false, false];
+    const team = computeTeam([blankCard, null, null, null, null, null], [], song, undefined, trained);
+    expect(team.rawShout).toBe(0); // shoutMax 0 - 0 = 0
+  });
+
+  it('card.name が空文字でもラビットノート参照は安全 (L140 || \'\')', () => {
+    const notes: RabbitNoteMap = { '': { shout: 50, beat: 0, melody: 0 } };
+    const team = computeTeam(
+      [blankCard, null, null, null, null, null], [], song,
+      undefined, undefined, undefined, undefined, undefined, notes,
+    );
+    // name='' をキーにしたエントリが拾われる
+    expect(team.rawShout).toBe(50);
+  });
+});
+
+describe('computeTeam: 条件付き共有ブローチの対象属性枚数が 0 のとき加算 0 (L168 || 0)', () => {
+  it('S属性枚数分Shout+300 を Beat 単独デッキに付けると Shout 枚数 0 で加算 0', () => {
+    // tenthTamaki は Beat。Shout カードは 0 枚 → attrCounts.Shout=0
+    const deck: (Card | null)[] = [tenthTamaki, null, null, null, null, null];
+    const sel: number[][] = [[24], [], [], [], [], []]; // id24 targetAttribute=Shout
+    const team = computeTeam(deck, [], song, undefined, undefined, undefined, sel);
+    expect(team.broachShout).toBe(0);
+  });
+});
+
+describe('isUsableSkillLevel 経由: shrink でない通常スキルは全レベル走査でも採用される (L64 両アーム)', () => {
+  it('スコアアップ（コンボ）カードは Lv5 が有効ならそのまま採用 (L64 false 側)', () => {
+    const comboCard = findCardById(410); // 屋外フェス2 壮五 / スコアアップコンボ Lv5 有効
+    const team = computeTeam([comboCard, null, null, null, null, null], [], song);
+    expect(team.cards[0].skill).not.toBeNull();
+    expect(team.cards[0].skill!.skillType).toBe('scoreUp');
+  });
+});
+
+describe('computeTeam: 空デッキは加算ループを通らない (空スロット continue 分岐)', () => {
+  it('全 null デッキは全属性 0', () => {
+    const team = computeTeam(empty, [], song);
+    expect(team.Shout).toBe(0);
+    expect(team.Beat).toBe(0);
+    expect(team.Melody).toBe(0);
+    expect(team.cards).toHaveLength(0);
+  });
+});
+
+/** type9 ブローチ (id=646 相当, MEMORiES MELODiES / score 1000) をフィクスチャから手で組む */
+function findBroach9(): FixedBroach {
+  return {
+    id: 646,
+    card_id: type9Card.cardID,
+    card_name: type9Card.cardname,
+    name: 'type9-test',
+    name_other: null,
+    shout: null, beat: null, melody: null,
+    attribute: null, idol: null, group: null,
+    auto: null,
+    song: 'MONSTER GENERATiON',
+    score: 1000,
+    limit: null,
+    broach_type: 9,
+    condition: null,
+  };
+}

--- a/tests/unit/score/workerHandler.test.ts
+++ b/tests/unit/score/workerHandler.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// maxScoreFinder の重い探索ロジックはモックし、ハンドラの制御フローのみ検証する
+vi.mock('../../../src/lib/score/maxScoreFinder', () => ({
+  createSearchContext: vi.fn((input) => ({ ctx: true, input })),
+  evaluateChunk: vi.fn(),
+}));
+
+import { createWorkerHandler } from '../../../src/lib/score/maxScoreFinder.worker';
+import { createSearchContext, evaluateChunk } from '../../../src/lib/score/maxScoreFinder';
+
+type AnyMsg = Parameters<ReturnType<typeof createWorkerHandler>>[0];
+const initMsg = { type: 'init', input: { foo: 1 } } as unknown as AnyMsg;
+const chunkMsg = { type: 'chunk', descriptor: { start: 0, end: 10 } } as unknown as AnyMsg;
+const abortMsg = { type: 'abort' } as unknown as AnyMsg;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('createWorkerHandler', () => {
+  it('init で SearchContext を作り ready を返す', async () => {
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(initMsg);
+    expect(createSearchContext).toHaveBeenCalledWith({ foo: 1 });
+    expect(post).toHaveBeenCalledWith({ type: 'ready' });
+  });
+
+  it('init 前の chunk は無視（ctx null）', async () => {
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(chunkMsg);
+    expect(evaluateChunk).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('chunk で progress と result を返す', async () => {
+    vi.mocked(evaluateChunk).mockImplementation(async (_ctx, _desc, opts) => {
+      await opts!.onTick!(5, { score: 100 } as never);
+      await opts!.onTick!(3, null as never); // localBest null の分岐
+      return { topK: [{ id: 1 }], evaluated: 8, aborted: false } as never;
+    });
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(initMsg);
+    await handle(chunkMsg);
+
+    expect(post).toHaveBeenCalledWith({ type: 'progress', evaluatedDelta: 5, localBestScore: 100 });
+    expect(post).toHaveBeenCalledWith({ type: 'progress', evaluatedDelta: 3, localBestScore: null });
+    expect(post).toHaveBeenCalledWith({ type: 'result', topK: [{ id: 1 }], evaluated: 8, aborted: false });
+  });
+
+  it('abort 後の chunk では onTick が中断シグナル(true)を返す', async () => {
+    let tickResult: boolean | undefined;
+    vi.mocked(evaluateChunk).mockImplementation(async (_ctx, _desc, opts) => {
+      tickResult = await opts!.onTick!(1, null as never);
+      return { topK: [], evaluated: 1, aborted: tickResult } as never;
+    });
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(initMsg);
+    await handle(abortMsg); // aborted = true
+    await handle(chunkMsg);
+    expect(tickResult).toBe(true);
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'result', aborted: true }));
+  });
+
+  it('evaluateChunk が Error を throw したら message を構造化して返す', async () => {
+    vi.mocked(evaluateChunk).mockRejectedValue(new Error('boom'));
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(initMsg);
+    await handle(chunkMsg);
+    expect(post).toHaveBeenCalledWith({ type: 'error', message: 'boom' });
+  });
+
+  it('evaluateChunk が非 Error を throw したら String(err) を返す', async () => {
+    vi.mocked(evaluateChunk).mockRejectedValue('plain string error');
+    const post = vi.fn();
+    const handle = createWorkerHandler(post);
+    await handle(initMsg);
+    await handle(chunkMsg);
+    expect(post).toHaveBeenCalledWith({ type: 'error', message: 'plain string error' });
+  });
+});

--- a/tests/unit/songNoteBreakdownBranches.test.ts
+++ b/tests/unit/songNoteBreakdownBranches.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildNoteBreakdown } from '../../src/lib/songNoteBreakdown';
+import type { Song } from '../../src/lib/data/fetchSongsJson';
+
+/** ステージグループを部分的にしか持たない (一部キー欠落 / フィールド欠落) Song を作る */
+function makeSparseSong(groups: Record<string, Record<string, number | undefined> | undefined>): Song {
+  const song: Record<string, unknown> = {
+    id: 1, category: 'IDOLiSH7', artist: 'IDOLiSH7', song_name: 'TEST',
+    song_type: null, difficulty: null, stars: null,
+    shout_ratio: null, beat_ratio: null, melody_ratio: null,
+    notes_count: null, duration: null,
+    total_shout_white: null, total_shout_color: null,
+    total_beat_white: null, total_beat_color: null,
+    total_melody_white: null, total_melody_color: null,
+    updated_at: null,
+  };
+  for (const [k, v] of Object.entries(groups)) song[k] = v;
+  return song as unknown as Song;
+}
+
+describe('buildNoteBreakdown: 欠落グループ・欠落フィールドの処理', () => {
+  it('存在しないステージグループ (undefined) は continue でスキップする (L59)', () => {
+    // light_3 のみ存在し、他のステージキーは Song に存在しない
+    const song = makeSparseSong({ light_3: { shout_white: 10 } });
+    const bd = buildNoteBreakdown(song);
+    expect(bd.rows.map((r) => r.key)).toEqual(['light_3']);
+    expect(bd.totals.shoutWhite).toBe(10);
+  });
+
+  it('グループ内のフィールドが欠落していれば 0 として扱う (L61)', () => {
+    // shout_white のみ定義、他フィールドは undefined → ?? 0 で 0 になる
+    const song = makeSparseSong({
+      light_4: { shout_white: 7, shout_color: undefined, beat_white: undefined },
+    });
+    const bd = buildNoteBreakdown(song);
+    const row = bd.rows.find((r) => r.key === 'light_4')!;
+    expect(row.shoutWhite).toBe(7);
+    expect(row.shoutColor).toBe(0);
+    expect(row.beatWhite).toBe(0);
+    expect(row.beatColor).toBe(0);
+    expect(row.melodyWhite).toBe(0);
+    expect(row.melodyColor).toBe(0);
+  });
+});

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { STORAGE_KEYS, loadJson, saveJson } from '../../src/lib/storage';
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe('STORAGE_KEYS', () => {
+  it('全キーが i7_ プレフィックスの一意な文字列', () => {
+    const keys = Object.values(STORAGE_KEYS);
+    expect(keys.every((k) => k.startsWith('i7_'))).toBe(true);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('loadJson', () => {
+  it('保存済み JSON をパースして返す', () => {
+    localStorage.setItem('k', JSON.stringify({ a: 1 }));
+    expect(loadJson('k', { a: 0 })).toEqual({ a: 1 });
+  });
+
+  it('キー未存在なら fallback', () => {
+    const fb = { x: 1 };
+    expect(loadJson('missing', fb)).toBe(fb);
+  });
+
+  it('不正な JSON なら fallback（例外を握りつぶす）', () => {
+    localStorage.setItem('bad', '{not json');
+    const fb = { ok: true };
+    expect(loadJson('bad', fb)).toBe(fb);
+  });
+});
+
+describe('saveJson', () => {
+  it('値を JSON 文字列化して保存', () => {
+    saveJson('k', { a: 1 });
+    expect(JSON.parse(localStorage.getItem('k')!)).toEqual({ a: 1 });
+  });
+
+  it('setItem が例外を投げても握りつぶす（quota 超過想定）', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveJson('k', { a: 1 })).not.toThrow();
+  });
+});

--- a/tests/unit/stores/broachCounts.test.ts
+++ b/tests/unit/stores/broachCounts.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  MAX_BROACH_COUNT, getBroachCount, setBroachCount, deltaBroachCount,
+  allBroachCounts, totalOwnedBroachs, reloadBroachCountsFromStorage,
+} from '../../../src/lib/stores/broachCounts.svelte';
+import { STORAGE_KEYS } from '../../../src/lib/storage';
+
+beforeEach(() => {
+  localStorage.clear();
+  reloadBroachCountsFromStorage();
+});
+
+describe('setBroachCount', () => {
+  it('未設定は 0、設定後は値を返す', () => {
+    expect(getBroachCount(1)).toBe(0);
+    setBroachCount(1, 5);
+    expect(getBroachCount(1)).toBe(5);
+  });
+
+  it('MAX_BROACH_COUNT(=10) でクランプ、負数は 0、小数は floor', () => {
+    expect(MAX_BROACH_COUNT).toBe(10);
+    setBroachCount(2, 15);
+    expect(getBroachCount(2)).toBe(10);
+    setBroachCount(2, -3);
+    expect(getBroachCount(2)).toBe(0);
+    setBroachCount(2, 4.8);
+    expect(getBroachCount(2)).toBe(4);
+  });
+
+  it('0 で削除し、localStorage に永続化', () => {
+    setBroachCount(3, 5);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.SHARED_BROACH_COUNTS)!)['3']).toBe(5);
+    setBroachCount(3, 0);
+    expect(allBroachCounts()).not.toHaveProperty('3');
+  });
+});
+
+describe('deltaBroachCount / 集計 / reload', () => {
+  it('加算は上限でクランプ', () => {
+    setBroachCount(1, 8);
+    deltaBroachCount(1, 5);
+    expect(getBroachCount(1)).toBe(10);
+  });
+
+  it('totalOwnedBroachs は合計', () => {
+    setBroachCount(1, 3);
+    setBroachCount(2, 4);
+    expect(totalOwnedBroachs()).toBe(7);
+  });
+
+  it('reload で最新に同期し消えたキーを削除', () => {
+    setBroachCount(1, 5);
+    setBroachCount(2, 5);
+    localStorage.setItem(STORAGE_KEYS.SHARED_BROACH_COUNTS, JSON.stringify({ '1': 9 }));
+    reloadBroachCountsFromStorage();
+    expect(getBroachCount(1)).toBe(9);
+    expect(getBroachCount(2)).toBe(0);
+  });
+});

--- a/tests/unit/stores/cardCounts.test.ts
+++ b/tests/unit/stores/cardCounts.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getCount, setCount, deltaCount, allCounts, totalOwned, ownedIdSet, reloadFromStorage,
+} from '../../../src/lib/stores/cardCounts.svelte';
+import { STORAGE_KEYS } from '../../../src/lib/storage';
+
+beforeEach(() => {
+  localStorage.clear();
+  reloadFromStorage(); // モジュール内 state を初期化
+});
+
+describe('getCount / setCount', () => {
+  it('未設定は 0、設定後は値を返す（数値/文字列キー両対応）', () => {
+    expect(getCount(1)).toBe(0);
+    setCount(1, 3);
+    expect(getCount(1)).toBe(3);
+    expect(getCount('1')).toBe(3);
+  });
+
+  it('負数は 0 にクランプ、小数は floor', () => {
+    setCount(2, -5);
+    expect(getCount(2)).toBe(0);
+    setCount(2, 3.9);
+    expect(getCount(2)).toBe(3);
+  });
+
+  it('0 を設定するとマップから削除される', () => {
+    setCount(3, 5);
+    expect(allCounts()).toHaveProperty('3');
+    setCount(3, 0);
+    expect(allCounts()).not.toHaveProperty('3');
+  });
+
+  it('localStorage に永続化される', () => {
+    setCount(4, 7);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.CARD_COUNTS)!)['4']).toBe(7);
+  });
+});
+
+describe('deltaCount', () => {
+  it('加減算し、0以下で削除', () => {
+    deltaCount(10, 3);
+    expect(getCount(10)).toBe(3);
+    deltaCount(10, -1);
+    expect(getCount(10)).toBe(2);
+    deltaCount(10, -5);
+    expect(getCount(10)).toBe(0);
+    expect(allCounts()).not.toHaveProperty('10');
+  });
+});
+
+describe('集計系', () => {
+  it('totalOwned は値の合計', () => {
+    setCount(1, 5);
+    setCount(2, 3);
+    expect(totalOwned()).toBe(8);
+  });
+
+  it('ownedIdSet は所持数>0 のキー集合（文字列）', () => {
+    setCount(1, 2);
+    setCount(2, 1);
+    expect(ownedIdSet()).toEqual(new Set(['1', '2']));
+  });
+});
+
+describe('reloadFromStorage', () => {
+  it('localStorage の最新内容に同期し、消えたキーは削除', () => {
+    setCount(1, 5);
+    setCount(2, 5);
+    localStorage.setItem(STORAGE_KEYS.CARD_COUNTS, JSON.stringify({ '1': 10 }));
+    reloadFromStorage();
+    expect(getCount(1)).toBe(10);
+    expect(getCount(2)).toBe(0);
+    expect(allCounts()).toEqual({ '1': 10 });
+  });
+});

--- a/tests/unit/ui.test.ts
+++ b/tests/unit/ui.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ATTR_TEXT_CLASS,
+  cardImageUrl,
+  cardThumbUrl,
+  songImageUrl,
+  formatElapsed,
+  starsText,
+} from '../../src/lib/ui';
+import {
+  CARD_IMAGE_BASE_URL,
+  CARD_THUMB_BASE_URL,
+  SONG_IMAGE_BASE_URL,
+} from '../../src/lib/constants';
+
+describe('ATTR_TEXT_CLASS', () => {
+  it('Shout/Beat/Melody が Tailwind テキスト色クラスにマッピングされる', () => {
+    expect(ATTR_TEXT_CLASS).toEqual({
+      Shout: 'text-red-500',
+      Beat: 'text-green-500',
+      Melody: 'text-blue-500',
+    });
+  });
+});
+
+describe('cardImageUrl / cardThumbUrl / songImageUrl', () => {
+  it('数値 ID からフルサイズ画像 URL を生成', () => {
+    expect(cardImageUrl(123)).toBe(`${CARD_IMAGE_BASE_URL}/123.png`);
+  });
+
+  it('文字列 ID も受け付ける', () => {
+    expect(cardImageUrl('999')).toBe(`${CARD_IMAGE_BASE_URL}/999.png`);
+  });
+
+  it('サムネイル URL を生成', () => {
+    expect(cardThumbUrl(42)).toBe(`${CARD_THUMB_BASE_URL}/42.png`);
+  });
+
+  it('楽曲画像 URL を生成', () => {
+    expect(songImageUrl(7)).toBe(`${SONG_IMAGE_BASE_URL}/7.png`);
+  });
+});
+
+describe('formatElapsed', () => {
+  it('1000ms 未満は "ms" 単位', () => {
+    expect(formatElapsed(0)).toBe('0 ms');
+    expect(formatElapsed(999)).toBe('999 ms');
+  });
+
+  it('1秒以上60秒未満は小数2桁の "秒" 単位', () => {
+    expect(formatElapsed(1000)).toBe('1.00 秒');
+    expect(formatElapsed(1234)).toBe('1.23 秒');
+  });
+
+  it('60秒以上は "分 秒" 形式', () => {
+    expect(formatElapsed(60000)).toBe('1分 0.0秒');
+    expect(formatElapsed(125000)).toBe('2分 5.0秒');
+  });
+});
+
+describe('starsText', () => {
+  it('n 個の★ + (5-n) 個の☆', () => {
+    expect(starsText(1)).toBe('★☆☆☆☆');
+    expect(starsText(3)).toBe('★★★☆☆');
+    expect(starsText(5)).toBe('★★★★★');
+  });
+
+  it('5を超える値は5にクランプ', () => {
+    expect(starsText(6)).toBe('★★★★★');
+  });
+
+  it('falsy (0 / null / undefined) は空文字', () => {
+    expect(starsText(0)).toBe('');
+    expect(starsText(null)).toBe('');
+    expect(starsText(undefined)).toBe('');
+  });
+
+  it('負数はクランプされ★なし', () => {
+    expect(starsText(-3)).toBe('☆☆☆☆☆');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,25 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
+  // Svelte 5 runes ストア（src/lib/stores/*.svelte.ts）をテストするためにコンパイルする
+  plugins: [svelte({ compilerOptions: { dev: false } })],
   test: {
     environment: 'node',
     include: ['tests/unit/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**'],
+      exclude: ['**/*.d.ts'],
+      reporter: ['text-summary', 'text', 'html', 'json-summary'],
+      // src/lib 全体に対するグローバルしきい値。下回ると vitest が exit≠0 で CI を落とす。
+      // 到達不能な防御的分岐は各所の /* v8 ignore */ で個別除外している。
+      thresholds: {
+        statements: 95,
+        branches: 95,
+        functions: 95,
+        lines: 95,
+      },
+    },
   },
 });


### PR DESCRIPTION
## 概要

CI の `quality` ジョブに **単体テストカバレッジ 95% ゲート**（`src/lib/**` 全体・Statements/Branches/Functions/Lines の4指標すべて）を追加する。下回ると PR が fail する。ADR [0032](docs/adr/0032-unit-test-coverage-gate.md) 参照。

## 背景

CI は typecheck と Vitest を実行していたがカバレッジ未計測で、テスト追加忘れによる回帰を素通りさせるリスクがあった。導入前ベースライン（`src/lib/**`）: Statements 76.5% / Branches 67.2% / Functions 68.2% / Lines 77.3%。

## 変更点

- **基盤**: `@vitest/coverage-v8` / `jsdom` を追加。`vitest.config.ts` に `@sveltejs/vite-plugin-svelte` 統合 + `coverage`（include `src/lib/**`、reporters、thresholds 95×4）。`package.json` に `coverage` script、`.gitignore` に `coverage/`。
- **CI**: `quality` ジョブを `npm run coverage` に変更し、`$GITHUB_STEP_SUMMARY` にカバレッジ表を出力。
- **テスト追加**: フェッチャ（fetch/fs モック）・Svelte ストア・DOM（jsdom）・Worker（純粋関数化 + Worker モック）・スコアエンジンのエッジ/分岐を網羅（620 tests）。
- **最小リファクタ**: `maxScoreFinder.worker.ts` の `onmessage` を純粋関数 `createWorkerHandler` に分離。`clientRefresh.ts` の未使用 `hideIndicator` を削除。
- **v8 ignore**: 到達不能な防御的分岐（SSR 専用・固定キーのフォールバック・Worker ブートストラップ等）に理由コメント付きで個別付与。

## 結果

導入後（`src/lib/**`）: **Statements 99.9% / Branches 98.6% / Functions 100% / Lines 100%、620 tests pass**。

## 検証

- `npm run coverage` が 4指標 ≥95% で exit 0。
- 閾値超過時に `vitest run --coverage` が exit≠0 + `ERROR: Coverage ... does not meet global threshold` で fail（ゲート実効性を確認）。
- `npm run typecheck` pass。全体テストを3回連続実行し 620/620 安定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)