### PR TITLE
fix: 衣装詳細でデータ欠損（0埋め）のスキルレベル行を非表示にする

### DIFF
--- a/src/lib/score/skillFormatter.ts
+++ b/src/lib/score/skillFormatter.ts
@@ -10,7 +10,7 @@ export function formatSkillEffect(
   req: string | null,
   sl: ApSkillLevel,
 ): string {
-  if (!skillType || sl.count == null || sl.per == null || sl.value == null) return '-';
+  if (!skillType || !isValidApSkillLevel(sl)) return '-';
   const c = sl.count;
   const p = sl.per;
   const v = sl.value;
@@ -38,15 +38,22 @@ export function formatSkillEffect(
 }
 
 /**
+ * スキルレベルが有効データ（登録済み）かどうかを判定する。
+ * 「有効」= count/per/value がいずれも 0 より大きい。null・0 は未登録扱い。
+ * 新規衣装で値が 0 埋めになっているレベルや、欠損レベルを除外する用途で使う。
+ */
+export function isValidApSkillLevel(sl: ApSkillLevel): boolean {
+  return (sl.count ?? 0) > 0 && (sl.per ?? 0) > 0 && (sl.value ?? 0) > 0;
+}
+
+/**
  * 数値（count/per/value）が有効な最上位スキルレベルを返す。
  * Lv5 が無い衣装（SSR）や Lv5 未登録の新規衣装（値が 0 で埋まっている）は Lv4 以下に
  * フォールバックする。いずれのレベルも有効でなければ null。
- * 「有効」= count/per/value がいずれも 0 より大きい（null・0 は未登録扱い）。
  */
 export function getMaxApSkillLevel(card: Card): 1 | 2 | 3 | 4 | 5 | null {
   for (const level of [5, 4, 3, 2, 1] as const) {
-    const sl = getApSkillLevel(card, level);
-    if ((sl.count ?? 0) > 0 && (sl.per ?? 0) > 0 && (sl.value ?? 0) > 0) return level;
+    if (isValidApSkillLevel(getApSkillLevel(card, level))) return level;
   }
   return null;
 }

--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -8,7 +8,7 @@ import { ATTR_HEX, RARITY_BADGE_CLASSES, ATTR_BADGE_BG } from '../../lib/constan
 import { ATTR_TEXT_CLASS, cardImageUrl } from '../../lib/ui';
 import { cardCreativeWorkLd } from '../../lib/seo';
 import { attrDonutSvg } from '../../lib/donutChart';
-import { formatSkillEffect } from '../../lib/score/skillFormatter';
+import { formatSkillEffect, isValidApSkillLevel } from '../../lib/score/skillFormatter';
 
 export async function getStaticPaths() {
   const [cards, broachs, events] = await Promise.all([
@@ -88,7 +88,8 @@ if (card.ap_skill_name) {
     const per = card[`ap_skill_${i}_per`];
     const value = card[`ap_skill_${i}_value`];
     const rate = card[`ap_skill_${i}_rate`];
-    if (count != null || per != null || value != null || rate != null) {
+    // count/per/value がいずれも未登録（null・0）のレベルはデータ欠損なので除外する
+    if (isValidApSkillLevel({ count, per, value, rate })) {
       apSkillLevels.push({ lv: i, count, per, value, rate });
     }
   }

--- a/tests/unit/score/skillFormatter.test.ts
+++ b/tests/unit/score/skillFormatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatSkillEffect, formatSkillBadge, getMaxApSkillLevel, formatSkillEffectMax } from '../../../src/lib/score/skillFormatter';
+import { formatSkillEffect, formatSkillBadge, getMaxApSkillLevel, formatSkillEffectMax, isValidApSkillLevel } from '../../../src/lib/score/skillFormatter';
 import { SKILL_TYPE, type ApSkillLevel, type Card } from '../../../src/lib/data/fetchCardsJson';
 
 const sl = (
@@ -51,6 +51,12 @@ describe('formatSkillEffect (スキル効果の自然文生成)', () => {
 
   it('レベル値 (count/per/value) が欠けていたら "-"', () => {
     expect(formatSkillEffect(SKILL_TYPE.SCOREUP_TIMER, null, sl(null, 40, 300))).toBe('-');
+  });
+
+  it('レベル値 (count/per/value) のいずれかが 0（未登録）なら "-"', () => {
+    expect(formatSkillEffect(SKILL_TYPE.SCOREUP_TIMER, null, sl(0, 0, 0))).toBe('-');
+    expect(formatSkillEffect(SKILL_TYPE.SCOREUP_TIMER, null, sl(15, 0, 300))).toBe('-');
+    expect(formatSkillEffect('スコアアップ（Perfectのみ）', 'Perfect', sl(25, 35, 0))).toBe('-');
   });
 
   it('縮小系で rate が null なら "-"', () => {
@@ -108,6 +114,26 @@ function makeCardWithLevels(
   }
   return card as unknown as Card;
 }
+
+describe('isValidApSkillLevel (レベルが有効データか)', () => {
+  it('count/per/value がすべて 0 より大きければ true', () => {
+    expect(isValidApSkillLevel(sl(15, 40, 300))).toBe(true);
+    expect(isValidApSkillLevel(sl(15, 40, 300, 250))).toBe(true);
+  });
+
+  it('count/per/value のいずれかが 0 なら false（未登録扱い）', () => {
+    expect(isValidApSkillLevel(sl(0, 0, 0))).toBe(false);
+    expect(isValidApSkillLevel(sl(0, 40, 300))).toBe(false);
+    expect(isValidApSkillLevel(sl(15, 0, 300))).toBe(false);
+    expect(isValidApSkillLevel(sl(15, 40, 0))).toBe(false);
+  });
+
+  it('count/per/value のいずれかが null なら false', () => {
+    expect(isValidApSkillLevel(sl(null, 40, 300))).toBe(false);
+    expect(isValidApSkillLevel(sl(15, null, 300))).toBe(false);
+    expect(isValidApSkillLevel(sl(15, 40, null))).toBe(false);
+  });
+});
 
 describe('getMaxApSkillLevel (最上位スキルレベルの判定)', () => {
   it('Lv5 まで揃っていれば 5', () => {


### PR DESCRIPTION
## 概要

衣装詳細ページの APスキル表示で、データ未登録（`count/per/value` がすべて `0`）のレベル行が
「**【Lv5】コンボ0回毎に0％の確率でスコア0UP**」のように表示されていた不具合を修正する。

## 原因

- `src/pages/cards/[id].astro` のレベル行フィルタが「いずれかのフィールドが `null` でなければ表示」で、`0` を弾いていなかった
- `formatSkillEffect` の欠損ガードも `== null` のみで `0` を弾いていなかった

## 修正

- `skillFormatter.ts` に `isValidApSkillLevel(sl)`（`count/per/value` がいずれも `>0`）を新設
  - 一覧表示用 `getMaxApSkillLevel` が既に採用していた「0=未登録」規約を共通ヘルパーに切り出し（DRY）
- 衣装詳細のレベル行フィルタを `isValidApSkillLevel` に差し替え
- `formatSkillEffect` のガードも `0` を弾くよう拡張（防御）

ライブデータ上、0埋めレベルを持つ衣装は約 1,983 件。すべて該当レベル行が非表示になる。

## 検証

- 単体テスト 33 passed（`isValidApSkillLevel` と 0 ガードのテストを追加）
- `astro check` 0 errors
- dev サーバーで衣装詳細 (ID 2) を実画面確認：Lv1〜4 のみ表示、Lv5 の 0埋め行が消えた

🤖 Generated with [Claude Code](https://claude.com/claude-code)