### PR TITLE
fix: 衣装詳細の APスキルレベル表示をテーブル化

### DIFF
--- a/src/pages/cards/[id].astro
+++ b/src/pages/cards/[id].astro
@@ -217,14 +217,16 @@ const otherSkills = [
         {card.ap_skill_req && <p><strong>発動条件:</strong> {card.ap_skill_req}</p>}
       </div>
       {apSkillLevels.length > 0 && (
-        <div class="text-sm space-y-1">
-          {apSkillLevels.map(lv => (
-            <div>
-              <span class="font-medium text-gray-600">【Lv{lv.lv}】</span>
-              {formatSkillEffect(card.ap_skill_type, card.ap_skill_req, { count: lv.count, per: lv.per, value: lv.value, rate: lv.rate })}
-            </div>
-          ))}
-        </div>
+        <table class="w-full text-sm">
+          <tbody class="divide-y divide-gray-100">
+            {apSkillLevels.map(lv => (
+              <tr>
+                <td class="py-2 pr-4 font-medium text-gray-500 whitespace-nowrap align-top w-16">Lv{lv.lv}</td>
+                <td class="py-2">{formatSkillEffect(card.ap_skill_type, card.ap_skill_req, { count: lv.count, per: lv.per, value: lv.value, rate: lv.rate })}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </section>
   )}


### PR DESCRIPTION
## 概要

衣装詳細ページの APスキルレベル表示を、インラインの「【Lv1】効果文…」羅列から
**Lv 列＋効果列の 2 カラムテーブル**に変更し、ページ内の他テーブル（基本情報・その他スキル）と見た目を統一する。

## 変更

- `src/pages/cards/[id].astro`: スキルレベルのリストを `<table>` 化（`w-full text-sm` / `divide-y divide-gray-100`、Lv 列は `w-16` 固定）
- Lv ラベルが左揃えで整列し、行区切り線が入って読みやすくなる
- 0埋め（データ欠損）レベルの非表示は維持（前リリース v1.46.1）

## 検証

- `astro check` 0 errors
- dev サーバーで衣装詳細 (ID 2) を実画面確認：Lv1〜4 がテーブルで整列表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)